### PR TITLE
Add missing revision info implementations

### DIFF
--- a/libsvncpp/include/svncpp/info.hpp
+++ b/libsvncpp/include/svncpp/info.hpp
@@ -108,7 +108,7 @@ namespace svn
     lastChangedDate() const;
 
     const char *
-    lastChangedAuthoer() const;
+    lastChangedAuthor() const;
 
     /** @todo MORE ENTRIES FROM @ref svn_info_to IF NEEDED */
 

--- a/libsvncpp/src/info.cpp
+++ b/libsvncpp/src/info.cpp
@@ -95,6 +95,14 @@ namespace svn
     return m->info != 0;
   }
 
+  svn_revnum_t
+  Info::revision() const
+  {
+    if (0 == m->info)
+      return 0;
+    else
+      return m->info->rev;
+  }
 
   const char *
   Info::url() const
@@ -121,6 +129,33 @@ namespace svn
       return 0;
     else
       return m->info->repos_UUID;
+  }
+
+  svn_revnum_t
+  Info::lastChangedRev() const
+  {
+    if (0 == m->info)
+      return 0;
+    else
+      return m->info->last_changed_rev;
+  }
+
+  apr_time_t
+  Info::lastChangedDate() const
+  {
+    if (0 == m->info)
+      return 0;
+    else
+      return m->info->last_changed_date;
+  }
+
+  const char *
+  Info::lastChangedAuthor() const
+  {
+    if (0 == m->info)
+      return 0;
+    else
+      return m->info->last_changed_author;
   }
 
 }


### PR DESCRIPTION
Also fixes the spelling of "author" in the previously-unimplemented lastChangedAuthor function.  These functions are not currently used by RapidSVN, but may be useful to other users of libsvncpp.
