### PR TITLE
folder browser item unescape and export/checkout dialog url unescape

### DIFF
--- a/librapidsvn/src/checkout_dlg.cpp
+++ b/librapidsvn/src/checkout_dlg.cpp
@@ -43,7 +43,7 @@ public:
 
   Data(const svn::Path selectedUrl)
   {
-    data.RepUrl = Utf8ToLocal(selectedUrl.c_str());
+    data.RepUrl = Utf8ToLocal(selectedUrl.native().c_str());
   }
 
 };

--- a/librapidsvn/src/export_dlg.cpp
+++ b/librapidsvn/src/export_dlg.cpp
@@ -45,7 +45,7 @@ public:
 
   Data(const svn::Path selectedUrl)
   {
-    data.SrcPath = Utf8ToLocal(selectedUrl.c_str());
+    data.SrcPath = Utf8ToLocal(selectedUrl.native().c_str());
   }
 
 };

--- a/librapidsvn/src/folder_browser.cpp
+++ b/librapidsvn/src/folder_browser.cpp
@@ -670,7 +670,7 @@ public:
           open_image = FOLDER_IMAGE_OPEN_FOLDER;
         }
 
-        wxString basename(Utf8ToLocal(filename.basename()));
+        wxString basename = wxFileName::FileName(path).GetName();
         FolderItemData * data = new FolderItemData(
           FOLDER_TYPE_NORMAL, path,
           basename,


### PR DESCRIPTION
when export/checkout dialog show, convert the path to human read

the selectedUrl pass to the constructor is urlencode fomat(come from svn
list), if I just click OK, this url will urlencode again, and
checkout/export fail.

human read in folder browser …

when ExpandItem, the new item is labled by basename, but the basename is
urlencode format(from svn list). if the basename is chinese, it will
show like '%E4%B8...'.
Just use wxFileName::FileName().GetName() to get basename from path
which is unescape fromat