### PR TITLE
Issue 0016 : Log History is slow to return for large SVN repositories

### DIFF
--- a/librapidsvn/include/ids.hpp
+++ b/librapidsvn/include/ids.hpp
@@ -90,6 +90,7 @@ enum
   ID_Import,
   ID_Lock,
   ID_Log,
+  ID_LogNext,
   ID_Merge,
   ID_Mkdir,
   ID_Move,
@@ -192,6 +193,8 @@ enum
   TOKEN_UPDATE_ASCENDING,
   TOKEN_ANNOTATE,
   TOKEN_LOG,
+  TOKEN_LOG_NEXT,
+  TOKEN_LOG_NEXT_CALLBACK,
   TOKEN_DRAG_N_DROP,
 
   LISTENER_MIN,

--- a/librapidsvn/include/log_action.hpp
+++ b/librapidsvn/include/log_action.hpp
@@ -35,10 +35,69 @@ namespace svn
   class Client;
   class Path;
   class RepositoryPath;
+  class LogEntry;
+  typedef std::vector<LogEntry> LogEntries;
 }
+class LogDlg;
+
+struct LogNextData
+{
+public:
+  wxString path;
+  svn::Revision startRevision;
+  svn::Revision endRevision;
+  LogDlg* logdlg;
+  svn::LogEntries* logEntries;
+
+  /** Constructor */
+  LogNextData()
+      : startRevision(svn::Revision::START),
+      endRevision(svn::Revision::HEAD),
+      logdlg(NULL),
+      logEntries(NULL)
+  {
+  }
+  /** Constructor */
+  LogNextData(wxString path_, svn::Revision startRevision_ = svn::Revision::START,
+              svn::Revision endRevision_ = svn::Revision::HEAD,
+              LogDlg* logdlg_ = NULL, svn::LogEntries* logEntries_ = NULL)
+      : path(path_),
+      startRevision(startRevision_),
+      endRevision(endRevision_),
+      logdlg(logdlg_),
+      logEntries(logEntries_)
+  {
+  }
+};
+
+class LogNextAction : public Action
+{
+public:
+  /** Constructor */
+  LogNextAction(wxWindow * parent, LogNextData & data);
+
+  /** Desctructor */
+  virtual ~LogNextAction();
+
+  /**
+   * @see Action
+   */
+  virtual bool
+  Perform();
+
+  static bool
+  CheckStatusSel(const svn::StatusSel & statusSel);
+
+private:
+  struct Data;
+  Data * m;
+};
 
 class LogAction : public Action
 {
+public:
+  static int LogLimit;
+
 public:
   LogAction(wxWindow * parent);
 

--- a/librapidsvn/include/log_dlg.hpp
+++ b/librapidsvn/include/log_dlg.hpp
@@ -98,8 +98,9 @@ private:
   /** hide implementation details */
   struct Data;
   std::auto_ptr<Data> m;
-  
+    
   std::list<svn::LogChangePathEntry> affectedFiles;
+  svn_revnum_t m_NextRevision;
 
   void OnAffectedFileOrDirCommand(wxCommandEvent & event);
 

--- a/librapidsvn/include/log_dlg.hpp
+++ b/librapidsvn/include/log_dlg.hpp
@@ -52,12 +52,19 @@ public:
    */
   LogDlg(wxWindow * parent,
          const svn::RepositoryPath & path, 
-         const svn::LogEntries * entries);
+         svn::LogEntries * entries);
 
   /**
    * destructor
    */
   virtual ~LogDlg();
+
+  void
+  NextLogEntriesCallback(svn::LogEntries* nextLogEntries);
+
+  void
+  AddLogEntries(svn::LogEntries* logEntries);
+
 
 protected:  // events inherited from LogDlgBase
   void 
@@ -74,6 +81,9 @@ protected:  // events inherited from LogDlgBase
 
   void 
   OnAnnotate(wxCommandEvent & event);
+
+  void
+  OnMore(wxCommandEvent & event);
 
   void
   OnRevSelected(wxListEvent & event);
@@ -96,6 +106,7 @@ private:
   void OnView(wxString & path);
   void OnDiff(wxString & path, bool singleItemDiff = false);
   void OnAnnotate(wxString & path);
+  void OnMore(wxString & path);
   void OnLog(wxString & path);
 
   void CheckControls();

--- a/librapidsvn/include/log_rev_list.hpp
+++ b/librapidsvn/include/log_rev_list.hpp
@@ -44,9 +44,9 @@ public:
 
   virtual ~LogRevList();
 
-  void SetEntries(svn::LogEntries * entries);
+  void SetEntries(const svn::LogEntries * entries);
   void
-  AddEntriesToList(svn::LogEntries * entries);
+  AddEntriesToList(const svn::LogEntries * entries);
 
   /**
    * Returns the revision for the given @a item

--- a/librapidsvn/include/log_rev_list.hpp
+++ b/librapidsvn/include/log_rev_list.hpp
@@ -44,9 +44,9 @@ public:
 
   virtual ~LogRevList();
 
-  void SetEntries(const svn::LogEntries * entries);
+  void SetEntries(svn::LogEntries * entries);
   void
-  AddEntriesToList(const svn::LogEntries * entries);
+  AddEntriesToList(svn::LogEntries * entries);
 
   /**
    * Returns the revision for the given @a item

--- a/librapidsvn/include/rapidsvn_generated.h
+++ b/librapidsvn/include/rapidsvn_generated.h
@@ -578,6 +578,7 @@ class LogDlgBase : public wxDialog
 		wxPanel* m_upperPanel;
 		wxStaticText* m_staticRevisions;
 		LogRevList* m_listRevisions;
+		wxButton* m_buttonMore;
 		wxButton* m_buttonClose;
 		wxButton* m_buttonView;
 		wxButton* m_buttonGet;
@@ -594,6 +595,7 @@ class LogDlgBase : public wxDialog
 		// Virtual event handlers, overide them in your derived class
 		virtual void OnRevDeselected( wxListEvent& event ) { event.Skip(); }
 		virtual void OnRevSelected( wxListEvent& event ) { event.Skip(); }
+		virtual void OnMore( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnView( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnGet( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnDiff( wxCommandEvent& event ) { event.Skip(); }

--- a/librapidsvn/src/action_factory.cpp
+++ b/librapidsvn/src/action_factory.cpp
@@ -259,6 +259,13 @@ ActionFactory::CreateAction(wxWindow * parent, int id)
       action = new LogAction(parent);
       break;
 
+    case ID_LogNext:
+    {
+      LogNextData data;
+      action = new LogNextAction(parent, data);
+      break;
+    }
+
     case ID_Revert:
       action = new RevertAction(parent);
       break;

--- a/librapidsvn/src/locale/de/rapidsvn.po
+++ b/librapidsvn/src/locale/de/rapidsvn.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RapidSVN 0.1.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-02 17:09+0100\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: 2009-11-02 17:10+0100\n"
 "Last-Translator: Alexander Mueller <XelaRellum@web.de>\n"
 "Language-Team: RapidSVN Developers <dev@rapidsvn.tigris.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -20,22 +21,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr "%s  code: %ld"
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, c-format
 msgid "%s Version %s"
 msgstr "%s Version %s"
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, c-format
 msgid "%s Version %s Revision %d"
 msgstr "%s Version %s Revision %d"
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr "%x %X"
 
-#: ../main_frame.cpp:323
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr "&Über..."
 
@@ -43,35 +44,31 @@ msgstr "&Über..."
 msgid "&Add\tINS"
 msgstr "&Hinzufügen\tINS"
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr "Existierende Arbeitskopie hin&zufügen..."
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr "&Anmerken"
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 msgid "&Annotate..."
 msgstr "&Anmerken..."
 
-#: ../main_frame.cpp:344
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr "&Lesezeichen"
 
-#: ../rapidsvn_generated.cpp:676
+#: ../rapidsvn_generated.cpp:549
 msgid "&Browse"
 msgstr "Durch&suchen"
 
-#: ../log_dlg.cpp:359
-msgid "&Close"
-msgstr "&Schliessen"
-
-#: ../rapidsvn_generated.cpp:655
+#: ../rapidsvn_generated.cpp:528
 msgid "&Compatible with:"
 msgstr "&Kompatibel mit:"
 
-#: ../main_frame.cpp:316
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr "&Inhalt\tF1"
 
@@ -79,7 +76,7 @@ msgstr "&Inhalt\tF1"
 msgid "&Copy...\tF5"
 msgstr "&Kopieren...\tF5"
 
-#: ../main_frame.cpp:290
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr "&Erzeugen..."
 
@@ -87,12 +84,11 @@ msgstr "&Erzeugen..."
 msgid "&Delete\tDEL"
 msgstr "&Löschen\tDEL"
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr "&Löschen..."
 
-#: ../log_dlg.cpp:362
-#: ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 msgid "&Diff"
 msgstr "&Vergleichen"
 
@@ -104,44 +100,48 @@ msgstr "Vergleiche mit Basis...\tCTRL-B"
 msgid "&Diff to Head...\tCTRL+H"
 msgstr "Vergleiche mit Aktuellster...\tCTRL-H"
 
+#: ../utils.cpp:220
+#, fuzzy
+msgid "&Diff..."
+msgstr "&Vergleichen"
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr "&Vergleiche...\tCTRL-D"
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr "B&earbeite Lesezeichen..."
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr "&Bearbeiten..."
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr "&Bearbeiten...\tF3"
 
-#: ../main_frame.cpp:288
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr "&Exportieren..."
 
-#: ../main_frame.cpp:345
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr "&Extras"
 
-#: ../main_frame.cpp:339
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr "&Datei"
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 msgid "&Files to commit"
 msgstr "Dateien für Commit"
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 msgid "&Get"
 msgstr "&Holen"
 
-#: ../main_frame.cpp:223
-#: ../main_frame.cpp:346
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr "&Hilfe"
 
@@ -149,11 +149,11 @@ msgstr "&Hilfe"
 msgid "&Ignore\tCTRL-DEL"
 msgstr "&Ignorieren\tCTRL-DEL"
 
-#: ../main_frame.cpp:287
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr "&Importieren...\tCTRL-I"
 
-#: ../main_frame.cpp:317
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr "Inde&x\tShift+F1"
 
@@ -161,7 +161,7 @@ msgstr "Inde&x\tShift+F1"
 msgid "&Info..."
 msgstr "&Info..."
 
-#: ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:540
 msgid "&Load configuration from directory (optional):"
 msgstr "&Lade Konfiguration aus Verzeichnis (optional):"
 
@@ -169,27 +169,42 @@ msgstr "&Lade Konfiguration aus Verzeichnis (optional):"
 msgid "&Lock..."
 msgstr "&Sperren..."
 
+#: ../utils.cpp:222
+#, fuzzy
+msgid "&Log..."
+msgstr "&Log...\tCTRL-L"
+
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr "&Log...\tCTRL-L"
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 msgid "&Merge"
 msgstr "&Zusammenführen"
 
-#: ../main_frame.cpp:342
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr "&Bearbeiten"
 
-#: ../rapidsvn_generated.cpp:625
+#: ../rapidsvn_generated.cpp:897
+#, fuzzy
+msgid "&Name"
+msgstr "Name"
+
+#: ../rapidsvn_generated.cpp:499
 msgid "&Name of the new repository:"
 msgstr "&Name des neuen &Repositories:"
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr "&Neu..."
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+#, fuzzy
+msgid "&Password"
+msgstr "Kennwort"
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr "&Immer"
 
@@ -197,43 +212,47 @@ msgstr "&Immer"
 msgid "&Properties...\tCTRL-P"
 msgstr "&Eigenschaften...\tCTRL-P"
 
-#: ../main_frame.cpp:343
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr "Ab&frage"
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 msgid "&Recent entries:"
 msgstr "Letzte Einträge:"
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 msgid "&Remove Bookmark"
 msgstr "Lesezeichen entfernen..."
 
-#: ../main_frame.cpp:341
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr "Repository"
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+msgid "&Revision"
+msgstr "&Revision"
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr "&Stop"
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr "Repository URL Umstellen..."
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr "&Vorläufig"
 
-#: ../main_frame.cpp:348
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr "&Tests"
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr "Umschalten"
 
-#: ../rapidsvn_generated.cpp:599
+#: ../rapidsvn_generated.cpp:473
 msgid "&Type:"
 msgstr "&Typ:"
 
@@ -241,32 +260,41 @@ msgstr "&Typ:"
 msgid "&Unlock"
 msgstr "&Entsperren"
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr "&Update...\tCTRL-U"
 
-#: ../log_dlg.cpp:360
-#: ../main_frame.cpp:340
+#: ../rapidsvn_generated.cpp:89
+#, fuzzy
+msgid "&Username"
+msgstr "Umbenennen"
+
+#: ../rapidsvn_generated.cpp:904
+#, fuzzy
+msgid "&Value"
+msgstr "Wert"
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr "&Ansicht"
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr "An&sehen..."
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr "- Für das Zertifikat liegt ein unbekannter Fehler vor."
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr "- Das Zertifikat ist abgelaufen."
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr "- Der Zertifikat Hostname stimmt nicht überein."
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
@@ -274,13 +302,17 @@ msgstr ""
 "- Das Zertifikat wurde von keiner anerkannten Autorität erstellt.\n"
 " Benutzen Sie den Fingerprint um das Zertifikat manuell zu validieren!"
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
 msgstr "- Das Zertifikat ist noch nicht gültig."
 
-#: ../file_info.cpp:102
-#: ../file_info.cpp:110
-#: ../file_info.cpp:195
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+#, fuzzy
+msgid "..."
+msgstr "&Neu..."
+
+#: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
 msgid "<None>"
 msgstr "<kein>"
 
@@ -292,31 +324,25 @@ msgstr "Ein Verzeichnis mit diesem Namen existiert bereits"
 msgid "A file of this name exists already"
 msgstr "Eine Datei mit diesem Namen existiert bereits"
 
-#: ../about_dlg.cpp:68
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr "ANSI"
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr "Über %s"
 
-#: ../log_dlg.cpp:242
-msgid "Action"
-msgstr "Aktion"
-
-#: ../add_action.cpp:37
-#: ../add_recursive_action.cpp:37
-#: ../listener.cpp:353
-#: ../main_frame.cpp:1398
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr "Existierendes &Repository hinzufügen..."
 
-#: ../rapidsvn_generated.cpp:642
+#: ../rapidsvn_generated.cpp:516
 msgid "Add a bookmark for the new repository"
 msgstr "Füge ein Lesezeichen für das neue Repository hinzu"
 
@@ -324,42 +350,40 @@ msgstr "Füge ein Lesezeichen für das neue Repository hinzu"
 msgid "Add r&ecursive"
 msgstr "Rekursiv hinzufügen"
 
-#: ../main_frame_helper.cpp:64
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr "Ausgewählte hinzufügen"
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr "Zu Lesezeichen hinzufügen"
 
-#: ../listener.cpp:362
-#: ../listener.cpp:369
-#: ../main_frame.cpp:1407
-#: ../main_frame.cpp:1414
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr "Hinzugefügt"
 
-#: ../main_frame.cpp:1904
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr "Repository '%s' zu Lesezeichen hinzugefügt"
 
-#: ../main_frame.cpp:1875
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr "Repository '%s' zu Lesezeichen hinzugefügt"
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr "Füge Verzeichnis zum Repository hinzu: %s"
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, c-format
 msgid "Adding file to repository: %s"
 msgstr "Füge Datei zum Repository hinzu: %s"
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr "Betroffene Dateien/Verz."
 
@@ -367,21 +391,19 @@ msgstr "Betroffene Dateien/Verz."
 msgid "All files|*"
 msgstr "Alle Dateien|*"
 
-#: ../main_frame.cpp:1271
-#: ../main_frame.cpp:1290
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr "Beim Starten des Browsers trat ein Fehler auf"
 
-#: ../main_frame.cpp:1258
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr "Beim Prüfen der gültigen Aktionen trat ein Fehler auf"
 
-#: ../annotate_action.cpp:80
-#: ../annotate_action.cpp:81
+#: ../annotate_action.cpp:80 ../annotate_action.cpp:81
 msgid "Annotate"
 msgstr "Anmerken"
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -393,13 +415,11 @@ msgid ""
 "  %s?"
 msgstr "Sind Sie sicher, dass Sie   %snach  %simportieren wollen?"
 
-#: ../auth_dlg.cpp:117
-#: ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr "Anmeldung"
 
-#: ../annotate_dlg.cpp:48
-#: ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr "Autor"
 
@@ -407,11 +427,11 @@ msgstr "Autor"
 msgid "BASE"
 msgstr "BASIS"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../rapidsvn_generated.cpp:477
 msgid "BerkeleyDB"
 msgstr "BerkeleyDB"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr "Lesezeichen"
 
@@ -419,19 +439,17 @@ msgstr "Lesezeichen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: ../main_frame_helper.cpp:85
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr "Übertrage Änderungen aus dem Repository in die Arbeitskopie"
 
-#: ../rapidsvn_generated.cpp:57
-#: ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119
-#: ../rapidsvn_generated.cpp:146
-#: ../rapidsvn_generated.cpp:620
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -442,58 +460,44 @@ msgstr ""
 "wxWidgets %d.%d.%d (%s)\n"
 "Subversion %d.%d.%d\n"
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr "CR (MacOS)"
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr "CRLF (Windows)"
 
-#: ../auth_dlg.cpp:73
-#: ../cert_dlg.cpp:138
-#: ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57
-#: ../destination_dlg.cpp:90
-#: ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146
-#: ../import_dlg.cpp:130
-#: ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342
-#: ../lock_dlg.cpp:61
-#: ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195
-#: ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409
-#: ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564
-#: ../rapidsvn_generated.cpp:708
-#: ../switch_dlg.cpp:139
-#: ../unlock_dlg.cpp:58
-#: ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+#, fuzzy
+msgid "Certificate information:"
 msgstr "Zertifikat Information:"
 
-#: ../main_frame.cpp:289
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr "Auschecken...\tCTRL-O"
 
 #: ../checkout_action.cpp:40
-#: ../checkout_dlg.cpp:250
 msgid "Checkout"
 msgstr "Auschecken"
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
 msgstr "Neue Arbeits&kopie auschecken..."
-
-#: ../main_frame.cpp:331
-msgid "Checkout Test"
-msgstr "Checkout Test"
 
 #: ../columns.cpp:58
 msgid "Checksum"
@@ -504,26 +508,28 @@ msgstr "Prüfsumme"
 msgid "Checksum: %s"
 msgstr "Prüfsumme: %s"
 
-#: ../cleanup_action.cpp:39
-#: ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr "Bereinigen"
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+#, fuzzy
+msgid "Close"
+msgstr "&Schliessen"
+
+#: ../utils.cpp:297
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr "Co&mmiten...\tCTRL-ENTER"
 
-#: ../main_frame.cpp:265
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr "Spalten"
 
-#: ../rapidsvn_generated.cpp:275
-#: ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr "Combo!"
 
-#: ../commit_action.cpp:42
-#: ../commit_dlg.cpp:45
+#: ../commit_action.cpp:42 ../commit_dlg.cpp:45
 msgid "Commit"
 msgstr "Commiten"
 
@@ -531,11 +537,11 @@ msgstr "Commiten"
 msgid "Commit Log Message"
 msgstr "Log Meldung"
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr "Log Meldung: die zuletzt eingegebene verwenden"
 
-#: ../main_frame_helper.cpp:94
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr "Ausgewählte committen"
 
@@ -543,9 +549,19 @@ msgstr "Ausgewählte committen"
 msgid "Committed revision"
 msgstr "Committete Revision"
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
 msgstr "Vergleiche:"
+
+#: ../listener.cpp:496
+#, fuzzy, c-format
+msgid "Completed %s at revision %d"
+msgstr "Committete Revision"
+
+#: ../listener.cpp:486
+#, fuzzy, c-format
+msgid "Completed at revision %d"
+msgstr "Committete Revision"
 
 #: ../columns.cpp:64
 msgid "Conflict BASE"
@@ -579,6 +595,11 @@ msgstr "Konflikt Arbeitskopie"
 msgid "Conflict Working File: %s"
 msgstr "Konflikt Arbeitsdatei: %s"
 
+#: ../listener.cpp:307
+#, fuzzy
+msgid "Conflicted"
+msgstr "Konflikt"
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr "Kopiert"
@@ -593,31 +614,21 @@ msgstr "Kopiert von Revision: %ld"
 msgid "Copied From URL: %s"
 msgstr "Kopiert von URL: %s"
 
-#: ../log_dlg.cpp:244
-msgid "Copied from Path"
-msgstr "Kopiert von Pfad"
-
-#: ../log_dlg.cpp:245
-msgid "Copied from Rev"
-msgstr "Kopiert von Revision"
-
-#: ../dnd_dlg.cpp:108
-#: ../listener.cpp:354
-#: ../main_frame.cpp:1399
-#: ../move_action.cpp:44
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr "Kopieren"
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 msgid "Copy/Move"
 msgstr "Kopieren/Verschieben"
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, c-format
 msgid "Copying file into working directory: %s"
 msgstr "Kopiere ins Arbeitsverzeichnis: %s"
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, c-format
 msgid "Copying file: %s"
 msgstr "Kopiere Datei: %s"
@@ -627,7 +638,7 @@ msgstr "Kopiere Datei: %s"
 msgid "Could not set working directory to %s"
 msgstr "Konnte das Arbeitsverzeichnis %s nicht setzen"
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr "Neues &Repository erzeugen..."
 
@@ -635,66 +646,49 @@ msgstr "Neues &Repository erzeugen..."
 msgid "Create Repository"
 msgstr "Repository Erzeugen"
 
-#: ../rapidsvn_generated.cpp:611
+#: ../rapidsvn_generated.cpp:485
 msgid "Create repository in &directory:"
 msgstr "Erzeuge Repository in &Verzeichnis:"
 
-#: ../columns.cpp:54
-#: ../log_dlg.cpp:165
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr "Datum"
 
-#: ../rapidsvn_generated.cpp:265
-#: ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr "Datum:"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "Default"
 msgstr "Voreinstellung"
 
-#: ../delete_action.cpp:40
-#: ../delete_dlg.cpp:79
-#: ../listener.cpp:355
-#: ../main_frame.cpp:1400
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../main_frame_helper.cpp:75
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr "Lösche Dateien und Verzeichnis aus Versionskontrolle"
 
-#: ../main_frame_helper.cpp:74
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr "Lösche ausgewählte"
 
-#: ../listener.cpp:361
-#: ../listener.cpp:370
-#: ../main_frame.cpp:1406
-#: ../main_frame.cpp:1415
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr "Gelöscht"
 
-#: ../checkout_dlg.cpp:72
-#: ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
 msgstr "Zielverzeichnis"
 
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr "Zieldatei"
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
-msgstr "Zielverzeichnis"
-
-#: ../diff_action.cpp:191
-#: ../diff_action.cpp:197
-#: ../diff_dlg.cpp:179
+#: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr "Vergleichen"
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 msgid "Diff Tool"
 msgstr "Diff-Werkzeug"
 
@@ -714,79 +708,94 @@ msgstr "Vergleichen mit anderer Revision/Datum"
 msgid "Diff two revisions/dates"
 msgstr "Vergleiche zwei Revisionen/Daten"
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
 msgstr "Separate Anmeldung für jedes Lesezeichen"
+
+#: ../rapidsvn_generated.cpp:1296
+#, fuzzy
+msgid "Directory"
+msgstr "Verzeichnis:"
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr "Verzeichnis:"
 
-#: ../rapidsvn_generated.cpp:681
+#: ../rapidsvn_generated.cpp:554
 msgid "Disable automatic Log removal"
 msgstr "Deaktiviere das automatische Entfernen von Log"
 
-#: ../rapidsvn_generated.cpp:685
+#: ../rapidsvn_generated.cpp:557
 msgid "Disable fsync when committing database transactions"
 msgstr "Deaktiviere fsync beim Festschreiben von Datenbank Transaktionen"
 
-#: ../main_frame_helper.cpp:195
+#: ../main_frame_helper.cpp:179
 msgid "Display conflicted files/directories"
 msgstr "Zeige Dateien/Verzeichnisse mit Konflikten"
 
-#: ../main_frame_helper.cpp:132
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr "Zeige Informationen über die ausgewählten Einträge an"
 
-#: ../main_frame_helper.cpp:189
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr "Zeige geänderte Dateien/Verzeichnisse"
 
-#: ../main_frame_helper.cpp:183
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr "Zeige unveränderte Dateien/Verzeichnisse"
 
-#: ../main_frame_helper.cpp:177
+#: ../main_frame_helper.cpp:161
 msgid "Display unversioned files/directories"
 msgstr "Zeige unversionierte Dateien/Verzeichnisse"
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr "Wollen Sie die gewählten Dateien/Verzeichnisse löschen?"
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr "Wollen Sie die lokalen Änderungen rückgängig machen?"
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr "Wollen Sie die gewählten Dateien/Verzeichnisse entsperren?"
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr "&Beenden\tCTRL-Q"
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr "Zeilenende:"
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr "Bearbeite Lesezeichen"
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr "Eigenschaft Bearbeiten"
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "Edit..."
+msgstr "&Bearbeiten..."
+
+#: ../rapidsvn_generated.cpp:1306
+#, fuzzy
+msgid "End &log message"
+msgstr "Geben Sie eine &Log Meldung ein"
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 msgid "Enter &log message"
 msgstr "Geben Sie eine &Log Meldung ein"
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr "Geben Sie einen Kommentar für diese Sperre ein"
 
@@ -794,41 +803,20 @@ msgstr "Geben Sie einen Kommentar für diese Sperre ein"
 msgid "Enter a name for the repository"
 msgstr "Geben Sie den Namen für das Repository ein"
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr "Geben Sie eine &Log Meldung ein"
-
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr "Neuer Name:"
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr "Geben Sie den lokalen Pfad ein, wohin der Code exportiert werden soll."
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
-msgstr "Geben Sie den lokalen Pfad ein, wohin der Code ausgecheckt werden soll."
+msgstr ""
+"Geben Sie den lokalen Pfad ein, wohin der Code ausgecheckt werden soll."
 
-#: ../checkout_dlg.cpp:70
-#: ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr "Geben Sie die Repository URL (nicht den lokalen Pfad) ein."
 
-#: ../export_dlg.cpp:143
-msgid "Enter what kind of symbol(s) do you want as EOL (end of line) in exported files."
-msgstr "Geben Sie an, welche Art von Zeilenumbrüchen wollen Sie in exportierten Dateien wollen."
-
-#: ../import_dlg.cpp:178
-#: ../import_dlg.cpp:191
-#: ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494
-#: ../log_dlg.cpp:530
-#: ../main_frame.cpp:1865
-#: ../merge_dlg.cpp:52
-#: ../merge_dlg.cpp:91
-#: ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr "Fehler"
 
@@ -840,59 +828,63 @@ msgstr "Fehler beim holen des Status:"
 msgid "Error running svnadmin"
 msgstr "Fehler beim Ausführen von svnadmin"
 
-#: ../property_dlg.cpp:120
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr "Fehler beim Setzen der Werte für Eigenschaften"
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, fuzzy, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr "Fehler beim Setzen der Werte für Eigenschaften"
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr "Fehler beim Validieren des Server-Zertifikates für '%s':"
 
-#: ../simple_worker.cpp:216
-#: ../threaded_worker.cpp:178
+#: ../simple_worker.cpp:216 ../threaded_worker.cpp:178
 msgid "Error while performing action."
 msgstr "Fehler beim Ausführen der Aktion"
 
-#: ../simple_worker.cpp:206
-#: ../threaded_worker.cpp:165
+#: ../simple_worker.cpp:206 ../threaded_worker.cpp:165
 #, c-format
 msgid "Error while performing action: %s"
 msgstr "Fehler beim Ausführen der Aktion: %s"
 
-#: ../simple_worker.cpp:167
-#: ../threaded_worker.cpp:286
+#: ../simple_worker.cpp:167 ../threaded_worker.cpp:286
 msgid "Error while preparing action."
 msgstr "Fehler beim Vorbereiten der Aktion."
 
-#: ../simple_worker.cpp:161
-#: ../threaded_worker.cpp:276
+#: ../simple_worker.cpp:161 ../threaded_worker.cpp:276
 #, c-format
 msgid "Error while preparing action: %s"
 msgstr "Fehler beim Vorbereiten der Aktion: %s"
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr "Fehler beim Aktualisieren der Dateiliste (%s)"
 
-#: ../main_frame.cpp:907
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr "Fehler beim Aktualisieren der Dateiliste"
 
-#: ../main_frame.cpp:894
+#: ../main_frame.cpp:917
 #, c-format
 msgid "Error while updating filelist (%s)"
 msgstr "Fehler beim Aktualisieren der Dateiliste (%s)"
 
-#: ../main_frame.cpp:542
+#: ../main_frame.cpp:561
 #, c-format
 msgid "Error: %s\n"
 msgstr "Fehler: %s\n"
 
-#: ../main_frame.cpp:1799
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
-msgstr "Eine Ausnahme ist aufgetreten während die Dateiliste aktualisiert wurde"
+msgstr ""
+"Eine Ausnahme ist aufgetreten während die Dateiliste aktualisiert wurde"
 
 #: ../preferences_dlg.cpp:38
 msgid "Executable Files|*.exe;*.com;*.bat|All files (*.*)|*.*"
@@ -907,8 +899,7 @@ msgstr "Ausführen"
 msgid "Execute diff tool: %s"
 msgstr "Diff-Tool ausführen: %s"
 
-#: ../external_program_action.cpp:140
-#: ../view_action.cpp:121
+#: ../external_program_action.cpp:140 ../view_action.cpp:121
 #, c-format
 msgid "Execute editor: %s"
 msgstr "Editor ausführen: %s"
@@ -923,18 +914,16 @@ msgstr "Execute file explorer: %s"
 msgid "Execute merge tool: %s"
 msgstr "Diff-Werkzeug ausführen: %s"
 
-#: ../simple_worker.cpp:175
-#: ../threaded_worker.cpp:143
+#: ../simple_worker.cpp:175 ../threaded_worker.cpp:143
 #, c-format
 msgid "Execute: %s"
 msgstr "Ausführen: %s"
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr "Explorer...\tF2"
 
-#: ../export_action.cpp:40
-#: ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr "Exportieren"
 
@@ -942,66 +931,60 @@ msgstr "Exportieren"
 msgid "Extension"
 msgstr "Erweiterung"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../listener.cpp:405
+#, fuzzy
+msgid "External"
+msgstr "Extern"
+
+#: ../rapidsvn_generated.cpp:477
 msgid "FSFS"
 msgstr "FSFS"
 
-#: ../listener.cpp:376
-#: ../main_frame.cpp:1421
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr "Sperren fehlgeschlagen"
 
-#: ../listener.cpp:377
-#: ../main_frame.cpp:1422
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr "Entsperren fehlgeschlagen"
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr "Datei"
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr "Dateipfad erwartet beim Importieren einer Datei!"
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr "Fingerabdruck:"
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr "Erster Pfad oder URL wird benötigt für Zusammenführen"
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr "Erste Arbeitskopie oder URL"
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr "Für mehr Informationen siehe:"
 
-#: ../destination_dlg.cpp:80
-#: ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr "Erzwingen"
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr "Löschen erzwingen"
 
-#: ../export_dlg.cpp:123
-msgid "Force to execute even if destination directory not empty, causes overwriting of files with the same names."
+#: ../export_dlg.cpp:75
+msgid ""
+"Force to execute even if destination directory not empty, causes overwriting "
+"of files with the same names."
 msgstr ""
 "Ausführung erzwingen, auch wenn das Zielverzeichnis nicht leer ist.\n"
 "Dadurch werden Dateien mit demselben Namen überschrieben."
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
 msgstr "Entsperren erzwingen auch wenn Sie nicht der Besitzer der Sperre sind"
 
-#: ../rapidsvn_generated.cpp:41
-#: ../rapidsvn_generated.cpp:649
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr "Allgemein"
 
@@ -1014,48 +997,61 @@ msgstr "Hole Datei %s rev. %s"
 msgid "HEAD"
 msgstr "AKTUELLSTE"
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+msgid "Help"
+msgstr "&Hilfe"
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr "Historie: %d Revisionen"
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr "Hostname:"
 
-#: ../checkout_dlg.cpp:88
-#: ../export_dlg.cpp:91
-msgid "If not using the latest version of the files, specify which revision to use here."
-msgstr "Wenn nicht die neueste Version der Dateien verwendet werden soll, dann geben Sie hier die zu verwendende Revision an."
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
+msgid ""
+"If not using the latest version of the files, specify which revision to use "
+"here."
+msgstr ""
+"Wenn nicht die neueste Version der Dateien verwendet werden soll, dann geben "
+"Sie hier die zu verwendende Revision an."
 
-#: ../checkout_dlg.cpp:102
-#: ../export_dlg.cpp:105
-msgid "If the files were renamed or moved some time, specify which peg revision to use here."
-msgstr "Wenn die Dateien umbenannt oder verschoben wurden, dann geben Sie die hier zu verwendende \"peg\" Revision an."
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
+msgid ""
+"If the files were renamed or moved some time, specify which peg revision to "
+"use here."
+msgstr ""
+"Wenn die Dateien umbenannt oder verschoben wurden, dann geben Sie die hier "
+"zu verwendende \"peg\" Revision an."
 
 #: ../ignore_action.cpp:40
 msgid "Ignore"
 msgstr "Ignoriere"
 
-#: ../main_frame.cpp:275
-#: ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr "Ignoriere Externe Links"
 
-#: ../checkout_dlg.cpp:122
-#: ../export_dlg.cpp:126
-#: ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr "Ignore Externe Links"
 
-#: ../dnd_dlg.cpp:37
-#: ../dnd_dlg.cpp:97
-#: ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr "Importieren"
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+#, fuzzy
+msgid "Import &Path"
+msgstr "Importieren"
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr "Importiere die Datei ins Repository: %s"
@@ -1064,15 +1060,15 @@ msgstr "Importiere die Datei ins Repository: %s"
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr "Konflikt Interaktiv auflösen...\tCTRL-T"
 
-#: ../main_frame.cpp:270
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr "Zeige modifizierte Einträge"
 
-#: ../main_frame.cpp:1984
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr "Info"
 
-#: ../main_frame_helper.cpp:131
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr "Info über ausgewählte"
 
@@ -1080,7 +1076,7 @@ msgstr "Info über ausgewählte"
 msgid "Internal Error: There is another action running"
 msgstr "Interner Fehler: eine andere Aktion wird ausgeführt"
 
-#: ../main_frame.cpp:1542
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr "Internal Error: no client data for action event!"
 
@@ -1092,27 +1088,16 @@ msgstr "Interner Fehler: kein Kontext verfügbar"
 msgid "Invalid revision number detected"
 msgstr "Ungültige Revisionsnummer entdeckt"
 
-#: ../log_dlg.cpp:478
-msgid "Invalid selection. At least one revisions is needed for diff and no more than two."
-msgstr "Ungültige Auswahl. Es werden eine oder zwei Revisionen für einen Vergleich benötigt."
-
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr "Ungültige Auswahl. Es werden genau zwei Revisionen für einen Vergleich benötigt."
-
-#: ../log_dlg.cpp:529
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr "Ungültige Auswahl. Es wird genau eine Revision für das  Anmerken benötigt."
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
+#: ../rapidsvn_generated.cpp:159
+#, fuzzy
+msgid "Issuer:"
 msgstr "Aussteller:"
 
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 msgid "Keep Locks"
 msgstr "Sperren behalten"
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr "LF (Unix)"
 
@@ -1134,20 +1119,16 @@ msgstr "Zuletzt Geändert"
 msgid "Last Changed Rev: %ld"
 msgstr "Zuletzt geändert Rev: %ld"
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr "Zeile"
 
-#: ../main_frame.cpp:330
-msgid "Listener Test"
-msgstr "Listener Test"
-
-#: ../filelist_ctrl.cpp:1058
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr "Einträge auflisten in '%s'"
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1160,21 +1141,7 @@ msgstr ""
 "System Name: %s\n"
 "Kanonischer Name: %s\n"
 
-#: ../rapidsvn_app.cpp:198
-#: ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr "Hilfedatei lokalisieren"
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr "Lokalisiere Tipps-Datei"
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr "Lokalisiere Tipps-Datei"
-
 #: ../lock_action.cpp:40
-#: ../lock_dlg.cpp:100
 msgid "Lock"
 msgstr "Sperre"
 
@@ -1209,32 +1176,27 @@ msgstr "Besitzer der Sperre: %s"
 msgid "Lock Token: %s"
 msgstr "Token der Sperre: %s"
 
-#: ../listener.cpp:374
-#: ../main_frame.cpp:1419
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr "Gesperrt"
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr "Log"
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr "Log Historie"
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr "Log Meldung"
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr "Log Meldung:"
-
-#: ../main_frame_helper.cpp:141
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr "Log für ausgewählte"
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr "Anmelden..."
 
@@ -1259,43 +1221,40 @@ msgstr "Neues Verzeichnis erstellen...\tF7"
 msgid "Make directory"
 msgstr "Neues Verzeichnis erstellen..."
 
-#: ../merge_action.cpp:38
-#: ../merge_action.cpp:44
-#: ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr "Zusammenführen"
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 msgid "Merge Tool"
 msgstr "Merge-Werkzeug"
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
-msgstr "Revisionen zusammenführen"
-
-#: ../main_frame.cpp:294
+#: ../main_frame.cpp:303
 msgid "Merge..."
 msgstr "Zusammenführen..."
+
+#: ../listener.cpp:308
+#, fuzzy
+msgid "Merged"
+msgstr "Zusammenführen"
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr "Erzeuge Verzeichnis"
 
-#: ../listener.cpp:368
-#: ../main_frame.cpp:1413
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr "Geändert"
 
-#: ../rapidsvn_generated.cpp:692
+#: ../rapidsvn_generated.cpp:563
 msgid "More options"
 msgstr "Mehr Optionen"
 
-#: ../dnd_dlg.cpp:104
-#: ../move_action.cpp:42
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr "Verschieben"
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, c-format
 msgid "Moving file: %s"
 msgstr "Verschiebe Datei: %s"
@@ -1304,10 +1263,16 @@ msgstr "Verschiebe Datei: %s"
 msgid "Multiple Files"
 msgstr "Mehrere Dateien"
 
-#: ../columns.cpp:45
-#: ../listed_dlg.cpp:75
-#: ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr "Name"
 
@@ -1316,41 +1281,24 @@ msgstr "Name"
 msgid "Name: %s"
 msgstr "Name: %s"
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
 msgstr "Neue Eigenschaft"
-
-#: ../revert_dlg.cpp:57
-msgid "No"
-msgstr "Nein"
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr "Kein Tool zum Vergleichen eingestellt"
 
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr "Es wurde keine Hilfedatei angegeben, wollten Siebeim nächsten Programmstart erneut gefragt werden"
-
 #: ../userresolve_action.cpp:62
 msgid "No merge tool set in the preferences"
 msgstr "Kein Diff-Werkzeug eingestellt"
-
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr "Sie haben keine Tipps-Datei angegeben, wollen Siebeim nächsten Programmstart erneut gefragt werden?"
 
 #: ../file_info.cpp:118
 #, c-format
 msgid "Node Kind: %s"
 msgstr "Knotentyp: %s"
 
-#: ../checkout_dlg.cpp:106
-#: ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr "Nicht spezifiziert"
 
@@ -1358,55 +1306,38 @@ msgstr "Nicht spezifiziert"
 msgid "Not versioned"
 msgstr "Unversioniert"
 
-#: ../about_dlg.cpp:114
-#: ../annotate_dlg.cpp:42
-#: ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126
-#: ../delete_dlg.cpp:54
-#: ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145
-#: ../import_dlg.cpp:128
-#: ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341
-#: ../lock_dlg.cpp:60
-#: ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191
-#: ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405
-#: ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560
-#: ../rapidsvn_generated.cpp:704
-#: ../report_dlg.cpp:57
-#: ../switch_dlg.cpp:137
-#: ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr "OK"
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr "Öffnen..."
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr "Überschreiben"
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr "Kennwort"
-
 #: ../columns.cpp:46
-#: ../import_dlg.cpp:80
-#: ../log_dlg.cpp:243
 msgid "Path"
 msgstr "Pfad"
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+#, fuzzy
+msgid "Path &type"
 msgstr "Pfad Typ:"
 
-#: ../checkout_dlg.cpp:97
-#: ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr "\"Peg\" Revision"
 
@@ -1414,27 +1345,27 @@ msgstr "\"Peg\" Revision"
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr "Einstellungen..."
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr "Kommandozeilen Argumente (%1=base, %2=theirs, %3=mine, %4=result):"
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr "Kommandozeilen Argumente (%1=Datei1, %2=Datei2):"
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr "Kommandozeilen Argumente (%1=ausgewähltes Verzeichnis):"
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr "Kommandozeilen Argumente (%1=ausgewählte Datei):"
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr "Programme"
 
@@ -1450,7 +1381,7 @@ msgstr "Eig. Status"
 msgid "Properties Last Updated"
 msgstr "Eigenschaften Geändert"
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr "Eigenschaften:"
 
@@ -1462,22 +1393,21 @@ msgstr "Eigenschaft"
 msgid "Property Editor"
 msgstr "Eigenschaften Editor"
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr "Temporäre Datein beim Programmende entfernen"
 
-#: ../main_frame_helper.cpp:65
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr "Stelle Dateien und Verzeichnisse unter Versionskontrolle"
 
-#: ../main_frame.cpp:509
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
+msgstr ""
+
+#: ../main_frame.cpp:528
 msgid "RapidSVN Error"
 msgstr "RapidSVN Fehler"
-
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
-msgstr "RapidSVN Hilfe: %s"
 
 #: ../utils.cpp:192
 msgid "Re&name...\tCTRL-N"
@@ -1491,56 +1421,51 @@ msgstr "Konflikte Auf&lösen\tCTRL-S"
 msgid "Re&vert\tCTRL-V"
 msgstr "Rückgängig\tCTRL-V"
 
-#: ../filelist_ctrl.cpp:1134
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr "Bereit"
 
-#: ../main_frame.cpp:1522
-#: ../main_frame.cpp:1566
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr "Bereit\n"
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr "Letzte Einträge:"
 
-#: ../checkout_dlg.cpp:111
-#: ../export_dlg.cpp:114
-#: ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201
-#: ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547
-#: ../revert_dlg.cpp:49
-#: ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr "Rekursiv"
 
-#: ../main_frame_helper.cpp:206
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr "Ansicht Aktualisieren\tCTRL-R"
 
-#: ../main_frame_helper.cpp:207
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr "Dateiliste aktualisieren"
 
-#: ../main_frame.cpp:268
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr "Aktualisieren mit Update"
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 msgid "Relocate"
 msgstr "Relozieren"
 
-#: ../main_frame_helper.cpp:115
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
-msgstr "Entfernt den 'Konflikt' Status der ausgewählten Dateien oder Verzeichnisse"
+msgstr ""
+"Entfernt den 'Konflikt' Status der ausgewählten Dateien oder Verzeichnisse"
 
-#: ../main_frame.cpp:1918
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr "Lesezeichen entfernt"
 
@@ -1552,8 +1477,7 @@ msgstr "Umbenennen"
 msgid "Rep. Rev."
 msgstr "Rep. Rev."
 
-#: ../listener.cpp:371
-#: ../main_frame.cpp:1416
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr "Ersetzt"
 
@@ -1561,14 +1485,14 @@ msgstr "Ersetzt"
 msgid "Repository"
 msgstr "Repository"
 
-#: ../import_dlg.cpp:67
-#: ../main_frame.cpp:1890
+#: ../rapidsvn_generated.cpp:1268
+#, fuzzy
+msgid "Repository &URL for import"
+msgstr "Repository URL wird für den Import erwartet!"
+
+#: ../main_frame.cpp:2079
 msgid "Repository URL"
 msgstr "Repository URL"
-
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
-msgstr "Repository URL wird für den Import erwartet!"
 
 #: ../file_info.cpp:112
 #, c-format
@@ -1580,79 +1504,61 @@ msgstr "Repository UUID: %s"
 msgid "Repository: %s"
 msgstr "Repository: %s"
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr "Spalten zurücksetzen"
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr "Setze den Flat Modus bei jedem Programmstart zurück"
 
-#: ../resolve_action.cpp:37
-#: ../userresolve_action.cpp:44
+#: ../resolve_action.cpp:37 ../userresolve_action.cpp:44
 msgid "Resolve"
 msgstr "Auflösen"
 
-#: ../main_frame_helper.cpp:114
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr "Konflikte auflösen"
 
-#: ../listener.cpp:359
-#: ../main_frame.cpp:1404
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr "Aufgelöst"
 
-#: ../listener.cpp:356
-#: ../main_frame.cpp:1401
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr "Wiederhergestellt..."
 
-#: ../main_frame_helper.cpp:105
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
 msgstr "Lokale Änderungen rückgängig machen"
 
-#: ../rapidsvn_generated.cpp:632
+#: ../rapidsvn_generated.cpp:506
 msgid "Resulting repository filename:"
 msgstr "Resultierender Repository Dateiname:"
 
-#: ../listener.cpp:357
-#: ../main_frame.cpp:1402
-#: ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr "Rückgängig"
 
-#: ../main_frame_helper.cpp:104
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr "Ausgewählte wiederherstellen"
 
-#: ../annotate_dlg.cpp:47
-#: ../checkout_dlg.cpp:83
-#: ../columns.cpp:47
-#: ../export_dlg.cpp:86
-#: ../log_dlg.cpp:163
-#: ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150
-#: ../rapidsvn_generated.cpp:529
-#: ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr "Revision"
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr "Die Revision muss eine vorzeichenlose Zahl sein!"
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 msgid "Revision or date #1:"
 msgstr "Revision oder Datum #&1:"
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 msgid "Revision or date #2:"
 msgstr "Revision oder Datum #&2:"
 
-#: ../rapidsvn_generated.cpp:250
-#: ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr "Revision:"
 
@@ -1666,10 +1572,6 @@ msgstr "Revision: %ld"
 msgid "Running command %s:"
 msgstr "Führe das Kommando %s aus:"
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr "SSL Zertifikat"
-
 #: ../columns.cpp:62
 msgid "Schedule"
 msgstr "Zustand"
@@ -1679,38 +1581,28 @@ msgstr "Zustand"
 msgid "Schedule: %s"
 msgstr "Zustand: %s"
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr "Zweiter Pfad oder URL wird benötigt für Zusammenführen"
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr "Zweite Arbeitskopie oder URL"
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr "Zertifikat-Datei wählen:"
 
-#: ../checkout_dlg.cpp:273
-#: ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr "Wählen Sie ein Zielverzeichnis"
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr "Wählen Sie ein Verzeichnis in das zusammengeführt werden soll"
 
-#: ../create_repos_dlg.cpp:185
-#: ../create_repos_dlg.cpp:201
-#: ../main_frame.cpp:1845
+#: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr "Wähle ein Verzeichnis"
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr "Wählen Sie ein Verzeichnis für den Import"
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr "Wählen Sie eine Datei für den Import"
 
@@ -1738,93 +1630,92 @@ msgstr "Wählen Sie den Standard Editor"
 msgid "Select standard file explorer executable"
 msgstr "Wählen Sie den Standard Explorer"
 
-#: ../main_frame_helper.cpp:95
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr "Änderngen in der Arbeitskopie and Repository übertragen"
 
-#: ../checkout_dlg.cpp:94
-#: ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
-msgstr "Setzen Sie diese Einstellung, um die aktuellste Version der Dateien im Repository zu erhalten."
+msgstr ""
+"Setzen Sie diese Einstellung, um die aktuellste Version der Dateien im "
+"Repository zu erhalten."
 
-#: ../checkout_dlg.cpp:108
-#: ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
-msgstr "Benutzen Sie dies für die BASIS/AKTUELLSTE \"peg\" Revision der Dateien."
+msgstr ""
+"Benutzen Sie dies für die BASIS/AKTUELLSTE \"peg\" Revision der Dateien."
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
-msgstr "Setzen Sie diese Einstellung um automatisch ein neues Lesezeichen für die Arbeitskopie zu erstellen."
+msgstr ""
+"Setzen Sie diese Einstellung um automatisch ein neues Lesezeichen für die "
+"Arbeitskopie zu erstellen."
 
-#: ../checkout_dlg.cpp:114
-#: ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
-msgstr "Setzen Sie diese Einstellung um alle Unterverzeichnisse von dieser URL auch zu erhalten."
+msgstr ""
+"Setzen Sie diese Einstellung um alle Unterverzeichnisse von dieser URL auch "
+"zu erhalten."
 
-#: ../checkout_dlg.cpp:125
-#: ../export_dlg.cpp:129
-msgid "Set to ignore external definitions and the external working copies managed by them."
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
+msgid ""
+"Set to ignore external definitions and the external working copies managed "
+"by them."
 msgstr "Setzen, um externe Links und externe Arbeitskopien zu ignorieren."
 
-#: ../main_frame.cpp:320
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr "Tipps beim Programmstart anzeigen"
 
-#: ../main_frame.cpp:274
-#: ../main_frame_helper.cpp:194
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 msgid "Show conflicted entries"
 msgstr "Zeige Einträge mit Konflikten"
 
-#: ../main_frame_helper.cpp:171
+#: ../main_frame_helper.cpp:155
 msgid "Show entries in subdirectories"
 msgstr "Zeige Einträge in Unterverzeichnissen"
 
-#: ../main_frame.cpp:276
+#: ../main_frame.cpp:285
 msgid "Show ignored entries"
 msgstr "Zeige ignorierte Einträge"
 
-#: ../main_frame.cpp:273
-#: ../main_frame_helper.cpp:188
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 msgid "Show modified entries"
 msgstr "Zeige geänderte Einträge"
 
-#: ../main_frame.cpp:269
-#: ../main_frame_helper.cpp:170
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 msgid "Show subdirectories"
 msgstr "Zeige Unterverzeichnisse"
 
-#: ../main_frame_helper.cpp:142
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr "Zeigt die Log Meldungen für ausgewählte Dateien oder Verzeichnisse an"
 
-#: ../main_frame.cpp:272
-#: ../main_frame_helper.cpp:182
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 msgid "Show unmodified entries"
 msgstr "Zeige unveränderte Einträge"
 
-#: ../main_frame.cpp:271
-#: ../main_frame_helper.cpp:176
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr "Zeige unversionierte Einträge"
 
-#: ../listener.cpp:360
-#: ../main_frame.cpp:1405
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr "Überspringen"
 
-#: ../main_frame.cpp:266
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr "Sortierung"
 
-#: ../main_frame.cpp:242
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr "Aufsteigend"
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 msgid "Standard Editor"
 msgstr "Standard Editor"
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 msgid "Standard Explorer"
 msgstr "Standard Explorer"
 
@@ -1832,40 +1723,39 @@ msgstr "Standard Explorer"
 msgid "Status"
 msgstr "Status"
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr "Sperre stehlen, wenn Sie einem anderen Benutzer gehört"
 
-#: ../main_frame_helper.cpp:219
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr "Stop"
 
-#: ../main_frame_helper.cpp:220
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr "Stoppt die laufende Aktion"
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr "Authenfizierungs-Nachweise auf Festplatte ablegen"
 
 #: ../switch_action.cpp:50
-#: ../switch_dlg.cpp:192
 msgid "Switch URL"
 msgstr "URL Umstellen"
 
-#: ../main_frame.cpp:295
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr "URL Umstellen...\tCTRL-S"
 
-#: ../main_frame.cpp:1352
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr "Test duration"
 
-#: ../main_frame.cpp:1348
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr "Test ended at"
 
-#: ../main_frame.cpp:1345
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr "Test started at"
 
@@ -1875,7 +1765,9 @@ msgstr "Text zuletzt geändert"
 
 #: ../view_action.cpp:96
 msgid "The Editor is not configured. Please check Edit->Preferences>Programs"
-msgstr "Der Editor ist nicht konfiguriert. Bitte überprüfen Sie Bearbeiten->Einstellungen->Programme"
+msgstr ""
+"Der Editor ist nicht konfiguriert. Bitte überprüfen Sie Bearbeiten-"
+">Einstellungen->Programme"
 
 #: ../create_repos_dlg.cpp:141
 msgid "The configuration directory does not exist"
@@ -1885,7 +1777,7 @@ msgstr "Das Konfigurationsverfzeichnis existiert nicht"
 msgid "The svnadmin command was not successful."
 msgstr "Das svnadmin Kommando war nicht erfolgreich"
 
-#: ../cert_dlg.cpp:70
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
@@ -1893,11 +1785,13 @@ msgstr ""
 "Beim Validieren des Server Zertifikates traten Fehler auf.\n"
 "Wollen Sie diesem Zertifikat vertrauen?"
 
-#: ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:418
 msgid "This action has resulted in a commit - please enter a &log message"
-msgstr "Aufgrund der Aktion wurde ein Commit ausgelöst - bitte geben Sie eine &Log Meldung ein"
+msgstr ""
+"Aufgrund der Aktion wurde ein Commit ausgelöst - bitte geben Sie eine &Log "
+"Meldung ein"
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1909,16 +1803,9 @@ msgstr ""
 "\n"
 "Verfügbar online unter:"
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr "Baum"
-
-#: ../checkout_dlg.cpp:65
-#: ../columns.cpp:59
-#: ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521
-#: ../switch_dlg.cpp:77
-#: ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr "URL"
 
@@ -1931,11 +1818,11 @@ msgstr "URL: %s"
 msgid "UUID"
 msgstr "UUID"
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../main_frame.cpp:1494
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr "Nicht implementierte Aktion!"
 
@@ -1944,75 +1831,60 @@ msgid "Unknown destination path"
 msgstr "Unbekanntes Zielverzeichnis"
 
 #: ../unlock_action.cpp:39
-#: ../unlock_dlg.cpp:80
 msgid "Unlock"
 msgstr "Entsperren"
 
-#: ../listener.cpp:375
-#: ../main_frame.cpp:1420
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr "Entsperrt"
 
-#: ../get_action.cpp:38
-#: ../update_action.cpp:39
-#: ../update_action.cpp:51
+#: ../get_action.cpp:38 ../update_action.cpp:39 ../update_action.cpp:51
 msgid "Update"
 msgstr "Update"
 
-#: ../main_frame_helper.cpp:84
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr "Ausgewählte updaten"
 
-#: ../listener.cpp:363
-#: ../main_frame.cpp:1408
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr "Aktualisiert"
 
-#: ../main_frame.cpp:1556
-#: ../main_frame.cpp:1561
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr "Aktualisieren..."
 
-#: ../main_frame.cpp:241
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr "Mit Pfad"
 
-#: ../rapidsvn_generated.cpp:271
-#: ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 msgid "Use URL/path:"
 msgstr "Benutze URL/Pfad:"
 
-#: ../rapidsvn_generated.cpp:70
-#: ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr "Immer verwenden"
 
-#: ../checkout_dlg.cpp:92
-#: ../export_dlg.cpp:95
-#: ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299
-#: ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103
-#: ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr "Aktuellste"
 
-#: ../auth_dlg.cpp:54
-#: ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr "Benutzer"
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr "Gültig ab:"
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr "Gültig bis:"
 
-#: ../listed_dlg.cpp:80
-#: ../listed_dlg.cpp:172
-#: ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr "Wert"
 
@@ -2020,11 +1892,29 @@ msgstr "Wert"
 msgid "View"
 msgstr "Ansehen"
 
-#: ../rapidsvn_generated.cpp:696
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "View..."
+msgstr "An&sehen..."
+
+#: ../rapidsvn_generated.cpp:567
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: ../dnd_dlg.cpp:69
+#: ../dnd_dlg.cpp:48
+#, fuzzy, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr "Möchten Sie   %snach  %sVerschieben oder Kopieren?"
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -2037,34 +1927,29 @@ msgid ""
 "  %s?"
 msgstr "Möchten Sie   %snach  %sVerschieben oder Kopieren?"
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr "Ja"
-
-#: ../main_frame.cpp:1863
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
-msgstr "Sie können kein administratives Verzeichnis von Subversion zu den Lesezeichen hinzufügen!"
+msgstr ""
+"Sie können kein administratives Verzeichnis von Subversion zu den "
+"Lesezeichen hinzufügen!"
 
-#: ../file_info.cpp:150
-#: ../filelist_ctrl.cpp:1261
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr "Hinzufügen"
 
-#: ../filelist_ctrl.cpp:1226
-#: ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr "hinzugefügt"
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr "Konflikt"
 
-#: ../file_info.cpp:154
-#: ../filelist_ctrl.cpp:1264
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr "Löschen"
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr "gelöscht"
 
@@ -2072,7 +1957,7 @@ msgstr "gelöscht"
 msgid "directory"
 msgstr "Verzeichnis"
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr "Extern"
 
@@ -2080,69 +1965,67 @@ msgstr "Extern"
 msgid "file"
 msgstr "Datei"
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr "ignoriert"
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr "unvollständig"
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr "zusammengeführt"
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr "fehlt"
 
-#: ../filelist_ctrl.cpp:1229
-#: ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr "geändert"
 
-#: ../export_dlg.cpp:135
-#: ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr "Nativ"
 
-#: ../file_info.cpp:132
-#: ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr "kein"
 
-#: ../file_info.cpp:146
-#: ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr "normal"
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr "versperrt"
 
-#: ../filelist_ctrl.cpp:1294
-#: ../filelist_ctrl.cpp:1308
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr "veraltet"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.4"
 msgstr "vor Subversion 1.4"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.5"
 msgstr "vor Subversion 1.5"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.6"
 msgstr "vor Subversion 1.6"
 
-#: ../file_info.cpp:158
-#: ../filelist_ctrl.cpp:1267
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr "ersetzen"
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr "ersetzt"
 
@@ -2150,25 +2033,137 @@ msgstr "ersetzt"
 msgid "svnadmin could not be found"
 msgstr "svnadmin konnte nicht gefunden werden"
 
-#: ../file_info.cpp:137
-#: ../file_info.cpp:162
+#: ../file_info.cpp:137 ../file_info.cpp:162
 msgid "unknown"
 msgstr "unbekannt"
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr "Unbekannter Wert"
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
 msgstr "unversioniert"
 
-#: ../main_frame.cpp:329
-msgid "wxString Creation&Tracing Test"
-msgstr "wxString Creation&Tracing Test"
+#~ msgid "Action"
+#~ msgstr "Aktion"
+
+#~ msgid "Checkout Test"
+#~ msgstr "Checkout Test"
+
+#~ msgid "Copied from Path"
+#~ msgstr "Kopiert von Pfad"
+
+#~ msgid "Copied from Rev"
+#~ msgstr "Kopiert von Revision"
+
+#~ msgid "Destination file"
+#~ msgstr "Zieldatei"
+
+#~ msgid "Destination path"
+#~ msgstr "Zielverzeichnis"
+
+#~ msgid "EOL:"
+#~ msgstr "Zeilenende:"
+
+#~ msgid "Enter log message"
+#~ msgstr "Geben Sie eine &Log Meldung ein"
+
+#~ msgid "Enter the local path where you want the code be exported."
+#~ msgstr ""
+#~ "Geben Sie den lokalen Pfad ein, wohin der Code exportiert werden soll."
+
+#~ msgid ""
+#~ "Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
+#~ "files."
+#~ msgstr ""
+#~ "Geben Sie an, welche Art von Zeilenumbrüchen wollen Sie in exportierten "
+#~ "Dateien wollen."
+
+#~ msgid "File path required when importing a file!"
+#~ msgstr "Dateipfad erwartet beim Importieren einer Datei!"
+
+#~ msgid "First path or URL is required for merge!"
+#~ msgstr "Erster Pfad oder URL wird benötigt für Zusammenführen"
+
+#~ msgid ""
+#~ "Invalid selection. At least one revisions is needed for diff and no more "
+#~ "than two."
+#~ msgstr ""
+#~ "Ungültige Auswahl. Es werden eine oder zwei Revisionen für einen "
+#~ "Vergleich benötigt."
+
+#~ msgid "Invalid selection. Exactly two revisions needed for merge."
+#~ msgstr ""
+#~ "Ungültige Auswahl. Es werden genau zwei Revisionen für einen Vergleich "
+#~ "benötigt."
+
+#~ msgid "Invalid selection. Only one revision may be selected for annotate"
+#~ msgstr ""
+#~ "Ungültige Auswahl. Es wird genau eine Revision für das  Anmerken benötigt."
+
+#~ msgid "Listener Test"
+#~ msgstr "Listener Test"
+
+#~ msgid "Locate help"
+#~ msgstr "Hilfedatei lokalisieren"
+
+#~ msgid "Locate tips"
+#~ msgstr "Lokalisiere Tipps-Datei"
+
+#~ msgid "Locate tips file"
+#~ msgstr "Lokalisiere Tipps-Datei"
+
+#~ msgid "Log Message:"
+#~ msgstr "Log Meldung:"
+
+#~ msgid "Merge revisions"
+#~ msgstr "Revisionen zusammenführen"
+
+#~ msgid "No"
+#~ msgstr "Nein"
+
+#~ msgid ""
+#~ "No help file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Es wurde keine Hilfedatei angegeben, wollten Siebeim nächsten "
+#~ "Programmstart erneut gefragt werden"
+
+#~ msgid ""
+#~ "No tips file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Sie haben keine Tipps-Datei angegeben, wollen Siebeim nächsten "
+#~ "Programmstart erneut gefragt werden?"
+
+#~ msgid "RapidSVN Help: %s"
+#~ msgstr "RapidSVN Hilfe: %s"
+
+#~ msgid "Revision must be an unsigned number!"
+#~ msgstr "Die Revision muss eine vorzeichenlose Zahl sein!"
+
+#~ msgid "SSL Certificate"
+#~ msgstr "SSL Zertifikat"
+
+#~ msgid "Second path or URL is required for merge!"
+#~ msgstr "Zweiter Pfad oder URL wird benötigt für Zusammenführen"
+
+#~ msgid "Second working copy or URL"
+#~ msgstr "Zweite Arbeitskopie oder URL"
+
+#~ msgid "Tree"
+#~ msgstr "Baum"
+
+#~ msgid "Yes"
+#~ msgstr "Ja"
+
+#~ msgid "wxString Creation&Tracing Test"
+#~ msgstr "wxString Creation&Tracing Test"
 
 #~ msgid "Information"
 #~ msgstr "Information"
+
 #~ msgid ""
 #~ "Please use the command line utility 'svnadmin'\n"
 #~ "to create a new repository.\n"
@@ -2184,76 +2179,105 @@ msgstr "wxString Creation&Tracing Test"
 #~ "Repository zu erzeugen.Dieses Kommandozeilen Utility ist nicht "
 #~ "Bestandteil derRapidSVN Distribution.Mehr Informationen über Subversion:"
 #~ "http://svnbook.red-bean.comhttp://subversion.tigris.org"
+
 #~ msgid "Flat Mode"
 #~ msgstr "Flat Modus"
+
 #~ msgid ".mine"
 #~ msgstr "Zeile"
+
 #~ msgid "&Add\tCTRL-A"
 #~ msgstr "Hin&zufügen\tCTRL-A"
+
 #~ msgid "Nothing selected."
 #~ msgstr "Nichts ausgewählt."
+
 #~ msgid "Please select only one file or directory."
 #~ msgstr "Wählen Sie nur eine Datei oder ein Verzeichnis"
+
 #~ msgid "Skipped: %s"
 #~ msgstr "Übersprungen: %s"
+
 #~ msgid "&Author"
 #~ msgstr "&Autor"
+
 #~ msgid "&Date"
 #~ msgstr "&Datum"
+
 #~ msgid "&Last Changed"
 #~ msgstr "&Zuletzt Geändert"
+
 #~ msgid "&Prop Status"
 #~ msgstr "Ei&genschaft Status"
-#~ msgid "&Revision"
-#~ msgstr "&Revision"
+
 #~ msgid "&Status"
 #~ msgstr "&Status"
+
 #~ msgid "CR"
 #~ msgstr "CR"
+
 #~ msgid "CRLF"
 #~ msgstr "CRLF"
+
 #~ msgid "Conflict New"
 #~ msgstr "Konflikt Neu"
+
 #~ msgid "Conflict Previous Base File: %s"
 #~ msgstr "Konflikt vorige Basisdatei: %s"
+
 #~ msgid "Deleting unversioned file: %s"
 #~ msgstr "Lösche unversionierte Datei: %s"
+
 #~ msgid "E&xtension"
 #~ msgstr "Er&weiterung"
+
 #~ msgid "Error receiving action event!"
 #~ msgstr "Fehler beim Empfangen des Aktions-Ereignisses!"
+
 #~ msgid "LF"
 #~ msgstr "LF"
+
 #~ msgid "Milestone: %s"
 #~ msgstr "Meilenstein: %s"
+
 #~ msgid "Pr&op Date"
 #~ msgstr "Eigenschaft Datum"
+
 #~ msgid "R&ep. Rev."
 #~ msgstr "R&ep. Rev."
+
 #~ msgid "Ansi"
 #~ msgstr "Ansi"
+
 #~ msgid "Url"
 #~ msgstr "Url"
+
 #~ msgid "wxWidgets %d.%d.%d"
 #~ msgstr "wxWidgets %d.%d.%d"
+
 #~ msgid "Built with:"
 #~ msgstr "Erzeugt mit:"
+
 #~ msgid "Supported URL schemas: "
 #~ msgstr "Unterstützte URL Schemas: "
+
 #~ msgid "Locale Information:"
 #~ msgstr "Sprach-Information:"
+
 #~ msgid "Language:"
 #~ msgstr "Sprache:"
+
 #~ msgid "System Name:"
 #~ msgstr "Systembezeichner:"
+
 #~ msgid "CanoncialName:"
 #~ msgstr "Kanonischer Name:"
-#~ msgid "Help"
-#~ msgstr "&Hilfe"
+
 #~ msgid "Working copy against same remote revision"
 #~ msgstr "Arbeitskopie mit derselben Remote Revision"
+
 #~ msgid "Working copy against different remote revision/date"
 #~ msgstr "Arbeitskopie mit anderer remote Revision/anderem Datum"
+
 #~ msgid "Two revisions/dates against each other"
 #~ msgstr "Zwei Versionen/Datum miteinander"
-

--- a/librapidsvn/src/locale/es/rapidsvn.po
+++ b/librapidsvn/src/locale/es/rapidsvn.po
@@ -4,10 +4,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rapidSVN\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-02 17:09+0100\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: 2007-03-11 20:33-0400\n"
 "Last-Translator: Jesus Jerez <jerezmoreno@gmail.com>\n"
 "Language-Team: español\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -19,22 +20,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr "%s  código: %ld"
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, fuzzy, c-format
 msgid "%s Version %s"
 msgstr "%s Versión %d.%d.%d"
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, fuzzy, c-format
 msgid "%s Version %s Revision %d"
 msgstr "%s Versión %d.%d.%d"
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr ""
 
-#: ../main_frame.cpp:323
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr "&Acerca de..."
 
@@ -42,36 +43,32 @@ msgstr "&Acerca de..."
 msgid "&Add\tINS"
 msgstr ""
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr "&Agregar copia del trabajo existente..."
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr "&Anotar"
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 msgid "&Annotate..."
 msgstr "&Anotar..."
 
-#: ../main_frame.cpp:344
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr "&Marcadores"
 
-#: ../rapidsvn_generated.cpp:676
+#: ../rapidsvn_generated.cpp:549
 #, fuzzy
 msgid "&Browse"
 msgstr "&Cerrar"
 
-#: ../log_dlg.cpp:359
-msgid "&Close"
-msgstr "&Cerrar"
-
-#: ../rapidsvn_generated.cpp:655
+#: ../rapidsvn_generated.cpp:528
 msgid "&Compatible with:"
 msgstr ""
 
-#: ../main_frame.cpp:316
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr "&Contenido\tF1"
 
@@ -79,7 +76,7 @@ msgstr "&Contenido\tF1"
 msgid "&Copy...\tF5"
 msgstr "&Copiar...\tF5"
 
-#: ../main_frame.cpp:290
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr "&Crear..."
 
@@ -87,11 +84,11 @@ msgstr "&Crear..."
 msgid "&Delete\tDEL"
 msgstr "&Borrar\tDEL"
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr "&Borrar..."
 
-#: ../log_dlg.cpp:362 ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 msgid "&Diff"
 msgstr "&Diff"
 
@@ -103,44 +100,49 @@ msgstr "&Diff a Base...\tCTRL+B"
 msgid "&Diff to Head...\tCTRL+H"
 msgstr "&Diff a Head...\tCTRL+H"
 
+#: ../utils.cpp:220
+#, fuzzy
+msgid "&Diff..."
+msgstr "&Diff"
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr "&Diff...\tCTRL+D"
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr "&Editar marcador..."
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr "&Editar..."
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr "&Editar...\tF3"
 
-#: ../main_frame.cpp:288
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr "&Exportar...\tCTRL-E"
 
-#: ../main_frame.cpp:345
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr "&Extras"
 
-#: ../main_frame.cpp:339
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr "&Archivo"
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 #, fuzzy
 msgid "&Files to commit"
 msgstr "Bloqueo fallido"
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 msgid "&Get"
 msgstr "&Obtener"
 
-#: ../main_frame.cpp:223 ../main_frame.cpp:346
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr "&Ayuda"
 
@@ -149,11 +151,11 @@ msgstr "&Ayuda"
 msgid "&Ignore\tCTRL-DEL"
 msgstr "&Exportar...\tCTRL-E"
 
-#: ../main_frame.cpp:287
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr "&Importar...\tCTRL-I"
 
-#: ../main_frame.cpp:317
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr "&Índice\tShift+F1"
 
@@ -161,7 +163,7 @@ msgstr "&Índice\tShift+F1"
 msgid "&Info..."
 msgstr "&Información..."
 
-#: ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:540
 msgid "&Load configuration from directory (optional):"
 msgstr ""
 
@@ -169,28 +171,43 @@ msgstr ""
 msgid "&Lock..."
 msgstr "&Bloquear..."
 
+#: ../utils.cpp:222
+#, fuzzy
+msgid "&Log..."
+msgstr "&Registro...\tCTRL-L"
+
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr "&Registro...\tCTRL-L"
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 msgid "&Merge"
 msgstr "&Fusión"
 
-#: ../main_frame.cpp:342
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr "&Modificar"
 
-#: ../rapidsvn_generated.cpp:625
+#: ../rapidsvn_generated.cpp:897
+#, fuzzy
+msgid "&Name"
+msgstr "Nombre"
+
+#: ../rapidsvn_generated.cpp:499
 #, fuzzy
 msgid "&Name of the new repository:"
 msgstr "Crear repositorio nuevo..."
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr "&Nuevo..."
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+#, fuzzy
+msgid "&Password"
+msgstr "Contraseña"
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr "&Permanentemente"
 
@@ -198,45 +215,50 @@ msgstr "&Permanentemente"
 msgid "&Properties...\tCTRL-P"
 msgstr "&Propiedades...\tCTRL-P"
 
-#: ../main_frame.cpp:343
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr "&Consulta"
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 #, fuzzy
 msgid "&Recent entries:"
 msgstr "Entradas recientes:"
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 #, fuzzy
 msgid "&Remove Bookmark"
 msgstr "&Eliminar marcador..."
 
-#: ../main_frame.cpp:341
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr "&Repositorio"
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+#, fuzzy
+msgid "&Revision"
+msgstr "Revisión"
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr "&Detener"
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr "&Cambiar la URL del repositorio..."
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr "&Temporalmente"
 
-#: ../main_frame.cpp:348
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr "&Pruebas"
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:599
+#: ../rapidsvn_generated.cpp:473
 msgid "&Type:"
 msgstr ""
 
@@ -244,31 +266,41 @@ msgstr ""
 msgid "&Unlock"
 msgstr "&Desbloquear"
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr "&Actualizar...\tCTRL-U"
 
-#: ../log_dlg.cpp:360 ../main_frame.cpp:340
+#: ../rapidsvn_generated.cpp:89
+#, fuzzy
+msgid "&Username"
+msgstr "Renombrar"
+
+#: ../rapidsvn_generated.cpp:904
+#, fuzzy
+msgid "&Value"
+msgstr "Valor"
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr "&Ver"
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr "&Ver..."
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr "- El certificado tuvo un error desconocido."
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr "- El certificado ha expirado."
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr "- El hostname del certificado no concuerda."
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
@@ -276,9 +308,15 @@ msgstr ""
 "- El certificado no proviene de una autoridad confiable.\n"
 "  ¡Utilice la huella digital para validar el certificado manualmente!"
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
 msgstr "- El certificado aún no es válido."
+
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+#, fuzzy
+msgid "..."
+msgstr "&Nuevo..."
 
 #: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
 msgid "<None>"
@@ -292,29 +330,25 @@ msgstr ""
 msgid "A file of this name exists already"
 msgstr ""
 
-#: ../about_dlg.cpp:68
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr "ANSI"
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr "Acerca de %s"
 
-#: ../log_dlg.cpp:242
-msgid "Action"
-msgstr "Acción"
-
-#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listener.cpp:353
-#: ../main_frame.cpp:1398
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr "Agregar"
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr "Agregar &repositorio existente..."
 
-#: ../rapidsvn_generated.cpp:642
+#: ../rapidsvn_generated.cpp:516
 msgid "Add a bookmark for the new repository"
 msgstr ""
 
@@ -322,40 +356,40 @@ msgstr ""
 msgid "Add r&ecursive"
 msgstr "Agregar r&ecursivo"
 
-#: ../main_frame_helper.cpp:64
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr "Agregar seleccionado"
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr "Agregar a marcadores"
 
-#: ../listener.cpp:362 ../listener.cpp:369 ../main_frame.cpp:1407
-#: ../main_frame.cpp:1414
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr "Agregado"
 
-#: ../main_frame.cpp:1904
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr "Repositorio agregado a los marcadores '%s'"
 
-#: ../main_frame.cpp:1875
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr "Copia de trabajo agregada a los marcadores '%s'"
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, fuzzy, c-format
 msgid "Adding file to repository: %s"
 msgstr "Repositorio: %s"
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr "Archivos/Directorios afectados"
 
@@ -363,11 +397,11 @@ msgstr "Archivos/Directorios afectados"
 msgid "All files|*"
 msgstr "Todos los archivos|*"
 
-#: ../main_frame.cpp:1271 ../main_frame.cpp:1290
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr ""
 
-#: ../main_frame.cpp:1258
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr ""
 
@@ -375,7 +409,7 @@ msgstr ""
 msgid "Annotate"
 msgstr "Anotar"
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -387,11 +421,11 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../auth_dlg.cpp:117 ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr "Autenticación"
 
-#: ../annotate_dlg.cpp:48 ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr "Autor"
 
@@ -399,11 +433,11 @@ msgstr "Autor"
 msgid "BASE"
 msgstr "BASE"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../rapidsvn_generated.cpp:477
 msgid "BerkeleyDB"
 msgstr ""
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr "Marcador"
 
@@ -411,17 +445,17 @@ msgstr "Marcador"
 msgid "Bookmarks"
 msgstr "Marcadores"
 
-#: ../main_frame_helper.cpp:85
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr "Traer los cambios desde el repositorio dentro de la copia de trabajo"
 
-#: ../rapidsvn_generated.cpp:57 ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119 ../rapidsvn_generated.cpp:146
-#: ../rapidsvn_generated.cpp:620
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr ""
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -432,44 +466,44 @@ msgstr ""
 "wxWidgets %d.%d.%d (%s)\n"
 "Subversion %d.%d.%d\n"
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr "CR (MacOS)"
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr "CRLF (Windows)"
 
-#: ../auth_dlg.cpp:73 ../cert_dlg.cpp:138 ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57 ../destination_dlg.cpp:90 ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146 ../import_dlg.cpp:130 ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342 ../lock_dlg.cpp:61 ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195 ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409 ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564 ../rapidsvn_generated.cpp:708
-#: ../switch_dlg.cpp:139 ../unlock_dlg.cpp:58 ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+#, fuzzy
+msgid "Certificate information:"
 msgstr "Información del certificado:"
 
-#: ../main_frame.cpp:289
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr "C&omprobación...\tCTRL-O"
 
-#: ../checkout_action.cpp:40 ../checkout_dlg.cpp:250
+#: ../checkout_action.cpp:40
 msgid "Checkout"
 msgstr "Comprobación"
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
 msgstr "Comprobación de Nueva Copia de Trabajo..."
-
-#: ../main_frame.cpp:331
-msgid "Checkout Test"
-msgstr "Comprobación de prueba"
 
 #: ../columns.cpp:58
 msgid "Checksum"
@@ -480,20 +514,25 @@ msgstr "Suma de comprobación"
 msgid "Checksum: %s"
 msgstr "Suma de comprobación: %s"
 
-#: ../cleanup_action.cpp:39 ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr "Limpieza"
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+#, fuzzy
+msgid "Close"
+msgstr "&Cerrar"
+
+#: ../utils.cpp:297
 #, fuzzy
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr "En&viar...\tCTRL-M"
 
-#: ../main_frame.cpp:265
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr "Columnas"
 
-#: ../rapidsvn_generated.cpp:275 ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr ""
 
@@ -505,11 +544,11 @@ msgstr "Enviar"
 msgid "Commit Log Message"
 msgstr "Enviar el mensaje del registro"
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr ""
 
-#: ../main_frame_helper.cpp:94
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr "Enviar seleccionado"
 
@@ -517,9 +556,19 @@ msgstr "Enviar seleccionado"
 msgid "Committed revision"
 msgstr "Revisión enviada"
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
 msgstr "Comparar:"
+
+#: ../listener.cpp:496
+#, fuzzy, c-format
+msgid "Completed %s at revision %d"
+msgstr "Revisión enviada"
+
+#: ../listener.cpp:486
+#, fuzzy, c-format
+msgid "Completed at revision %d"
+msgstr "Revisión enviada"
 
 #: ../columns.cpp:64
 msgid "Conflict BASE"
@@ -553,6 +602,11 @@ msgstr "Trabajo en conflicto"
 msgid "Conflict Working File: %s"
 msgstr "Archivo de trabajo en conflicto: %s"
 
+#: ../listener.cpp:307
+#, fuzzy
+msgid "Conflicted"
+msgstr "en conflicto"
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr "Copiado"
@@ -567,30 +621,22 @@ msgstr "Copiado desde Rev: %ld"
 msgid "Copied From URL: %s"
 msgstr "Copiado desde URL: %s"
 
-#: ../log_dlg.cpp:244
-msgid "Copied from Path"
-msgstr "Copiado desde ubicación"
-
-#: ../log_dlg.cpp:245
-msgid "Copied from Rev"
-msgstr "Copiado desde Rev"
-
-#: ../dnd_dlg.cpp:108 ../listener.cpp:354 ../main_frame.cpp:1399
-#: ../move_action.cpp:44
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr "Copia"
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 #, fuzzy
 msgid "Copy/Move"
 msgstr "Copia"
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, fuzzy, c-format
 msgid "Copying file into working directory: %s"
 msgstr "No se puede fijar el directorio de trabajo en %s"
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, fuzzy, c-format
 msgid "Copying file: %s"
 msgstr "Archivo de trabajo en conflicto: %s"
@@ -600,7 +646,7 @@ msgstr "Archivo de trabajo en conflicto: %s"
 msgid "Could not set working directory to %s"
 msgstr "No se puede fijar el directorio de trabajo en %s"
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr "Crear repositorio nuevo..."
 
@@ -609,59 +655,51 @@ msgstr "Crear repositorio nuevo..."
 msgid "Create Repository"
 msgstr "Crear repositorio nuevo..."
 
-#: ../rapidsvn_generated.cpp:611
+#: ../rapidsvn_generated.cpp:485
 #, fuzzy
 msgid "Create repository in &directory:"
 msgstr "Seleccionar un directorio de destino"
 
-#: ../columns.cpp:54 ../log_dlg.cpp:165
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr "Fecha"
 
-#: ../rapidsvn_generated.cpp:265 ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr "Fecha:"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 #, fuzzy
 msgid "Default"
 msgstr "Borrar"
 
-#: ../delete_action.cpp:40 ../delete_dlg.cpp:79 ../listener.cpp:355
-#: ../main_frame.cpp:1400
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../main_frame_helper.cpp:75
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr "Borrar archivos y directorios desde el control de versión"
 
-#: ../main_frame_helper.cpp:74
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr "Borrar seleccionados"
 
-#: ../listener.cpp:361 ../listener.cpp:370 ../main_frame.cpp:1406
-#: ../main_frame.cpp:1415
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr "Borrado"
 
-#: ../checkout_dlg.cpp:72 ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
 msgstr "Directorio de destino"
-
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr "Archivo de destino"
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
-msgstr "Ubicación de destino"
 
 #: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr "Diff"
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 #, fuzzy
 msgid "Diff Tool"
 msgstr "Herramienta Diff:"
@@ -682,83 +720,98 @@ msgstr "Diff a otra revisión/fecha"
 msgid "Diff two revisions/dates"
 msgstr "Diff a dos revisiones/fechas"
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
 msgstr ""
 "Diferentes inicios de sesión para cada marcador en la lista de marcadores"
+
+#: ../rapidsvn_generated.cpp:1296
+#, fuzzy
+msgid "Directory"
+msgstr "Directorio:"
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr "Directorio:"
 
-#: ../rapidsvn_generated.cpp:681
+#: ../rapidsvn_generated.cpp:554
 msgid "Disable automatic Log removal"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:685
+#: ../rapidsvn_generated.cpp:557
 msgid "Disable fsync when committing database transactions"
 msgstr ""
 
-#: ../main_frame_helper.cpp:195
+#: ../main_frame_helper.cpp:179
 #, fuzzy
 msgid "Display conflicted files/directories"
 msgstr "¿Deseas desbloquear los archivos/directorios seleccionados?"
 
-#: ../main_frame_helper.cpp:132
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr "Mostrar Información sobre entradas seleccionadas"
 
-#: ../main_frame_helper.cpp:189
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:183
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:177
+#: ../main_frame_helper.cpp:161
 #, fuzzy
 msgid "Display unversioned files/directories"
 msgstr "Mostrar entradas sin versiones"
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr "¿Deseas suprimir los archivos/directorios seleccionados?"
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr "¿Deseas revertir cambios locales?"
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr "¿Deseas desbloquear los archivos/directorios seleccionados?"
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr "&Salir\tCTRL-Q"
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr "EOL:"
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr "Editar"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr "Editar marcador"
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr "Editar propiedad"
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "Edit..."
+msgstr "&Editar..."
+
+#: ../rapidsvn_generated.cpp:1306
+#, fuzzy
+msgid "End &log message"
+msgstr "Introduzca mensaje de registro"
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 #, fuzzy
 msgid "Enter &log message"
 msgstr "Introduzca mensaje de registro"
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr "Introduzca un comentario para este bloqueo"
 
@@ -767,39 +820,20 @@ msgstr "Introduzca un comentario para este bloqueo"
 msgid "Enter a name for the repository"
 msgstr "Introduzca un comentario para este bloqueo"
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr "Introduzca mensaje de registro"
-
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr "Introduzca un nuevo nombre:"
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr "Introduzca la ubicación local donde el código será exportado."
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
 msgstr ""
 "Introduzca la ubicación local donde el código comprobado será colocado."
 
-#: ../checkout_dlg.cpp:70 ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr "Introduzca la URL del repositorio (ubicación no local) aquí."
 
-#: ../export_dlg.cpp:143
-msgid ""
-"Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
-"files."
-msgstr ""
-"Introduzca qué clase de símbolo(s) desea como EOL (Fin de la línea) en "
-"archivos exportados."
-
-#: ../import_dlg.cpp:178 ../import_dlg.cpp:191 ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494 ../log_dlg.cpp:530 ../main_frame.cpp:1865
-#: ../merge_dlg.cpp:52 ../merge_dlg.cpp:91 ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr "Error"
 
@@ -811,11 +845,18 @@ msgstr "Estado de error recuperando:"
 msgid "Error running svnadmin"
 msgstr ""
 
-#: ../property_dlg.cpp:120
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr "Error configurando los valores de las propiedades"
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, fuzzy, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr "Error configurando los valores de las propiedades"
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr "Error validando el certificado del servidor para “%s”:"
@@ -838,26 +879,26 @@ msgstr "Error mientras se preparaba la acción."
 msgid "Error while preparing action: %s"
 msgstr "Error mientras se preparaba la acción: %s"
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr "Error mientras refrescaba la lista de archivos (%s)"
 
-#: ../main_frame.cpp:907
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr "Error mientras actualizaba la lista de archivos"
 
-#: ../main_frame.cpp:894
+#: ../main_frame.cpp:917
 #, c-format
 msgid "Error while updating filelist (%s)"
 msgstr "Error mientras actualizaba la lista de archivos (%s)"
 
-#: ../main_frame.cpp:542
+#: ../main_frame.cpp:561
 #, c-format
 msgid "Error: %s\n"
 msgstr "Error: %s\n"
 
-#: ../main_frame.cpp:1799
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
 msgstr "Excepción ocurrida durante la actualización de la lista de archivos"
 
@@ -894,11 +935,11 @@ msgstr "Ejecutar la herramienta diff: %s"
 msgid "Execute: %s"
 msgstr "Ejecutar: %s"
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr "Explorar...\tF2"
 
-#: ../export_action.cpp:40 ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr "Exportar"
 
@@ -906,52 +947,48 @@ msgstr "Exportar"
 msgid "Extension"
 msgstr "Extensión"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../listener.cpp:405
+#, fuzzy
+msgid "External"
+msgstr "externo"
+
+#: ../rapidsvn_generated.cpp:477
 msgid "FSFS"
 msgstr ""
 
-#: ../listener.cpp:376 ../main_frame.cpp:1421
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr "Bloqueo fallido"
 
-#: ../listener.cpp:377 ../main_frame.cpp:1422
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr "Desbloqueo fallido"
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr "Archivo"
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr "¡La ubicación del archivo es requerida al importar un archivo!"
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr "Huella digital"
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr "¡La primera ubicación o URL es requerida para la fusión!"
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr "Primera copia de trabajo o URL"
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr "Para más información ver:"
 
-#: ../destination_dlg.cpp:80 ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr "Forzar"
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr "Forzar eliminar"
 
-#: ../export_dlg.cpp:123
+#: ../export_dlg.cpp:75
 msgid ""
 "Force to execute even if destination directory not empty, causes overwriting "
 "of files with the same names."
@@ -959,11 +996,11 @@ msgstr ""
 "Forzar ejecución aunque el directorio destino no este vacío, se "
 "sobreescribirán archivos con nombres iguales."
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
 msgstr "Forzar bloqueo aunque no sea el propietario del bloqueo"
 
-#: ../rapidsvn_generated.cpp:41 ../rapidsvn_generated.cpp:649
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr "General"
 
@@ -976,16 +1013,25 @@ msgstr "Obtener archivo %s rev. %s"
 msgid "HEAD"
 msgstr "HEAD"
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+#, fuzzy
+msgid "Help"
+msgstr "&Ayuda"
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr "Historia: revisiones de %d"
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr "Hostname:"
 
-#: ../checkout_dlg.cpp:88 ../export_dlg.cpp:91
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
 msgid ""
 "If not using the latest version of the files, specify which revision to use "
 "here."
@@ -993,7 +1039,7 @@ msgstr ""
 "Si no usa la última versión de los archivos, especificar cual revisión va a "
 "utilizar."
 
-#: ../checkout_dlg.cpp:102 ../export_dlg.cpp:105
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
 msgid ""
 "If the files were renamed or moved some time, specify which peg revision to "
 "use here."
@@ -1006,20 +1052,24 @@ msgstr ""
 msgid "Ignore"
 msgstr "Información"
 
-#: ../main_frame.cpp:275 ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr "Ignorar Externals"
 
-#: ../checkout_dlg.cpp:122 ../export_dlg.cpp:126 ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr "Ignorar externals"
 
-#: ../dnd_dlg.cpp:37 ../dnd_dlg.cpp:97 ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr "Importar"
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+#, fuzzy
+msgid "Import &Path"
+msgstr "Importar"
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr ""
@@ -1029,15 +1079,15 @@ msgstr ""
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr "&Propiedades...\tCTRL-P"
 
-#: ../main_frame.cpp:270
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr ""
 
-#: ../main_frame.cpp:1984
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr "Información"
 
-#: ../main_frame_helper.cpp:131
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr "Información seleccionada"
 
@@ -1045,7 +1095,7 @@ msgstr "Información seleccionada"
 msgid "Internal Error: There is another action running"
 msgstr "Error interno: Hay otra acción ejecutándose"
 
-#: ../main_frame.cpp:1542
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr "Error interno: ¡ningún dato del cliente para realizar la acción!"
 
@@ -1057,34 +1107,17 @@ msgstr "Error interno: ningún contexto disponible"
 msgid "Invalid revision number detected"
 msgstr "Número de revisión inválido detectado"
 
-#: ../log_dlg.cpp:478
-msgid ""
-"Invalid selection. At least one revisions is needed for diff and no more "
-"than two."
-msgstr ""
-"Selección inválida. Por lo menos una las revisiones es necesaria para el "
-"diff y no más de dos."
-
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr ""
-"Selección inválida. Exactamente dos revisiones son necesarias para la fusión."
-
-#: ../log_dlg.cpp:529
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr ""
-"Selección inválida. Solamente una revisión se puede seleccionar para anotar"
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
+#: ../rapidsvn_generated.cpp:159
+#, fuzzy
+msgid "Issuer:"
 msgstr "Edición:"
 
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 #, fuzzy
 msgid "Keep Locks"
 msgstr "Mantener bloqueos"
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr "LF (Unix)"
 
@@ -1106,20 +1139,16 @@ msgstr "Fecha del último cambio"
 msgid "Last Changed Rev: %ld"
 msgstr "Revisión del último cambio: %ld"
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr "Línea"
 
-#: ../main_frame.cpp:330
-msgid "Listener Test"
-msgstr "Prueba de escucha"
-
-#: ../filelist_ctrl.cpp:1058
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr "Listando entradas en “%s”"
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1132,19 +1161,7 @@ msgstr ""
 "Nombre del sistema: %s\n"
 "Nombre canónico: %s\n"
 
-#: ../rapidsvn_app.cpp:198 ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr "Localizar ayuda"
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr "Localizar consejos"
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr "Localizar archivo de consejos"
-
-#: ../lock_action.cpp:40 ../lock_dlg.cpp:100
+#: ../lock_action.cpp:40
 msgid "Lock"
 msgstr "Bloquear"
 
@@ -1179,31 +1196,27 @@ msgstr "Bloquear propietario: %s"
 msgid "Lock Token: %s"
 msgstr "Bloquear símbolo: %s"
 
-#: ../listener.cpp:374 ../main_frame.cpp:1419
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr "Bloqueado"
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr "Registro"
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr "Historia de registro"
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr "Mensaje de registro"
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr "Mensaje de registro:"
-
-#: ../main_frame_helper.cpp:141
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr "Registro seleccionado"
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr "Conexión..."
 
@@ -1228,40 +1241,41 @@ msgstr "Crear &directorio...\tF7"
 msgid "Make directory"
 msgstr "Crear directorio"
 
-#: ../merge_action.cpp:38 ../merge_action.cpp:44 ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr "Fusión"
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 #, fuzzy
 msgid "Merge Tool"
 msgstr "Fusión"
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
-msgstr "Fusionar revisiones"
-
-#: ../main_frame.cpp:294
+#: ../main_frame.cpp:303
 msgid "Merge..."
 msgstr "Fusión..."
+
+#: ../listener.cpp:308
+#, fuzzy
+msgid "Merged"
+msgstr "Fusión"
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr "Mkdir"
 
-#: ../listener.cpp:368 ../main_frame.cpp:1413
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr "Modificado"
 
-#: ../rapidsvn_generated.cpp:692
+#: ../rapidsvn_generated.cpp:563
 msgid "More options"
 msgstr ""
 
-#: ../dnd_dlg.cpp:104 ../move_action.cpp:42
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr "Mover"
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, fuzzy, c-format
 msgid "Moving file: %s"
 msgstr "Archivo de trabajo en conflicto: %s"
@@ -1270,8 +1284,16 @@ msgstr "Archivo de trabajo en conflicto: %s"
 msgid "Multiple Files"
 msgstr ""
 
-#: ../columns.cpp:45 ../listed_dlg.cpp:75 ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr "Nombre"
 
@@ -1280,45 +1302,25 @@ msgstr "Nombre"
 msgid "Name: %s"
 msgstr "Nombre: %s"
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
 msgstr "Nueva propiedad"
-
-#: ../revert_dlg.cpp:57
-msgid "No"
-msgstr ""
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr "La herramienta diff no está configurado en las preferencias"
-
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"No se eligió ningún archivo de ayuda, ¿desea que se le\n"
-" pregunte nuevamente después del próximo inicio la aplicación?"
 
 #: ../userresolve_action.cpp:62
 #, fuzzy
 msgid "No merge tool set in the preferences"
 msgstr "La herramienta diff no está configurado en las preferencias"
 
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"No se eligió ningún archivo de consejos, ¿desea que se le\n"
-" pregunte otra vez después del próximo inicio de la aplicación?"
-
 #: ../file_info.cpp:118
 #, c-format
 msgid "Node Kind: %s"
 msgstr "Clase de nodo: %s"
 
-#: ../checkout_dlg.cpp:106 ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr "No especificado"
 
@@ -1326,39 +1328,38 @@ msgstr "No especificado"
 msgid "Not versioned"
 msgstr "No tiene versión asignada"
 
-#: ../about_dlg.cpp:114 ../annotate_dlg.cpp:42 ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126 ../delete_dlg.cpp:54 ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145 ../import_dlg.cpp:128 ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341 ../lock_dlg.cpp:60 ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191 ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405 ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560 ../rapidsvn_generated.cpp:704
-#: ../report_dlg.cpp:57 ../switch_dlg.cpp:137 ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr "OK"
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr "Abierto…"
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr "Sobreescribir"
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr "Contraseña"
-
-#: ../columns.cpp:46 ../import_dlg.cpp:80 ../log_dlg.cpp:243
+#: ../columns.cpp:46
 msgid "Path"
 msgstr "Ubicación"
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+#, fuzzy
+msgid "Path &type"
 msgstr "Tipo de Ubicación:"
 
-#: ../checkout_dlg.cpp:97 ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr "Etiqueta de la revisión"
 
@@ -1366,28 +1367,28 @@ msgstr "Etiqueta de la revisión"
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr "Preferencias..."
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 #, fuzzy
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr "Argumentos de programa (%1=archivo1, %2=archivo2):"
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr "Argumentos de programa (%1=archivo1, %2=archivo2):"
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr "Argumentos de programa (%1=directorio seleccionado):"
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr "Argumentos de programa (%1=archivo seleccionado):"
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr "Programas"
 
@@ -1403,7 +1404,7 @@ msgstr "Estado de Origen"
 msgid "Properties Last Updated"
 msgstr "Propiedades de la última actualización "
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr "Propiedades:"
 
@@ -1415,22 +1416,21 @@ msgstr "Propiedad"
 msgid "Property Editor"
 msgstr "Editor de propiedades"
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr "Purgar ficheros temporales en la salida del programa"
 
-#: ../main_frame_helper.cpp:65
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr "Poner los archivos y los directorios bajo control de la revisión"
 
-#: ../main_frame.cpp:509
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
+msgstr ""
+
+#: ../main_frame.cpp:528
 msgid "RapidSVN Error"
 msgstr "Error de RapidSVN"
-
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
-msgstr "Ayuda de RapidSVN: %s"
 
 #: ../utils.cpp:192
 msgid "Re&name...\tCTRL-N"
@@ -1444,53 +1444,53 @@ msgstr "Re&solver conflictos\tCTRL-S"
 msgid "Re&vert\tCTRL-V"
 msgstr "In&vertir\tCTRL-V"
 
-#: ../filelist_ctrl.cpp:1134
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr "Listo"
 
-#: ../main_frame.cpp:1522 ../main_frame.cpp:1566
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr "Listo\n"
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr "Entradas recientes:"
 
-#: ../checkout_dlg.cpp:111 ../export_dlg.cpp:114 ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201 ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547 ../revert_dlg.cpp:49 ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: ../main_frame_helper.cpp:206
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr "Refrescar vista\tCTRL-R"
 
-#: ../main_frame_helper.cpp:207
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr "Refrescar la lista de archivos"
 
-#: ../main_frame.cpp:268
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr "Refrescar con actualización"
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 #, fuzzy
 msgid "Relocate"
 msgstr "Reemplazado"
 
-#: ../main_frame_helper.cpp:115
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
 msgstr ""
 "Remover el estado 'en conflicto' en archivos o directorios de la copia de "
 "trabajo"
 
-#: ../main_frame.cpp:1918
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr "Marcador eliminado"
 
@@ -1502,7 +1502,7 @@ msgstr "Renombrar"
 msgid "Rep. Rev."
 msgstr "Remp. Rev."
 
-#: ../listener.cpp:371 ../main_frame.cpp:1416
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr "Reemplazado"
 
@@ -1510,13 +1510,14 @@ msgstr "Reemplazado"
 msgid "Repository"
 msgstr "Repositorio"
 
-#: ../import_dlg.cpp:67 ../main_frame.cpp:1890
+#: ../rapidsvn_generated.cpp:1268
+#, fuzzy
+msgid "Repository &URL for import"
+msgstr "¡URL de Repositorio es requerida para importar!"
+
+#: ../main_frame.cpp:2079
 msgid "Repository URL"
 msgstr "URL de Repositorio"
-
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
-msgstr "¡URL de Repositorio es requerida para importar!"
 
 #: ../file_info.cpp:112
 #, c-format
@@ -1528,11 +1529,11 @@ msgstr "UUID de repositorio: %s"
 msgid "Repository: %s"
 msgstr "Repositorio: %s"
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr "Reajustar columnas"
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr ""
 
@@ -1540,59 +1541,53 @@ msgstr ""
 msgid "Resolve"
 msgstr "Resolver"
 
-#: ../main_frame_helper.cpp:114
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr "Resolver seleccionado"
 
-#: ../listener.cpp:359 ../main_frame.cpp:1404
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr "Resuelto"
 
-#: ../listener.cpp:356 ../main_frame.cpp:1401
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr "Restaurar"
 
-#: ../main_frame_helper.cpp:105
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
 msgstr ""
 "Restaurar copia del archivo de trabajo original (deshace todas las ediciones "
 "locales)"
 
-#: ../rapidsvn_generated.cpp:632
+#: ../rapidsvn_generated.cpp:506
 msgid "Resulting repository filename:"
 msgstr ""
 
-#: ../listener.cpp:357 ../main_frame.cpp:1402 ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr "Revertir"
 
-#: ../main_frame_helper.cpp:104
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr "Revertir seleccionado"
 
-#: ../annotate_dlg.cpp:47 ../checkout_dlg.cpp:83 ../columns.cpp:47
-#: ../export_dlg.cpp:86 ../log_dlg.cpp:163 ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150 ../rapidsvn_generated.cpp:529 ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr "Revisión"
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr "¡El número de la revisión debe estar sin firmar!"
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 #, fuzzy
 msgid "Revision or date #1:"
 msgstr "Revisión o fecha #&1:"
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 #, fuzzy
 msgid "Revision or date #2:"
 msgstr "Revisión o fecha #&2:"
 
-#: ../rapidsvn_generated.cpp:250 ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr "Revisión:"
 
@@ -1606,10 +1601,6 @@ msgstr "Revisión: %ld"
 msgid "Running command %s:"
 msgstr ""
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr "Certificado SSL"
-
 #: ../columns.cpp:62
 msgid "Schedule"
 msgstr "Horario"
@@ -1619,36 +1610,28 @@ msgstr "Horario"
 msgid "Schedule: %s"
 msgstr "Horario: %s"
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr "¡Se requiere la segunda ubicación o URL para la fusión!"
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr " Segunda copia de trabajo o URL "
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr "Seleccionar el archivo del certificado"
 
-#: ../checkout_dlg.cpp:273 ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr "Seleccionar un directorio de destino"
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr "Seleccionar una carpeta de destino para la fusión"
 
 #: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
-#: ../main_frame.cpp:1845
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr "Seleccionar un directorio"
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr "Seleccione un directorio para importar"
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr "Seleccione un archivo a importar "
 
@@ -1678,33 +1661,33 @@ msgstr "Seleccionar el ejecutable del editor estándar"
 msgid "Select standard file explorer executable"
 msgstr "Seleccionar ejecutable del explorador de archivos estándar"
 
-#: ../main_frame_helper.cpp:95
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr "Enviar los cambios de tu copia de trabajo al repositorio"
 
-#: ../checkout_dlg.cpp:94 ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
 msgstr ""
 "Configurar esto para conseguir la última versión de los archivos en el "
 "repositorio."
 
-#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
 msgstr ""
 "Configurar esto para utilizar la revisión (actual) de las etiquetas BASE/"
 "HEAD de los archivos."
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
 msgstr ""
 "Configurar para crear automáticamente un nuevo marcador de la copia de "
 "trabajo."
 
-#: ../checkout_dlg.cpp:114 ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
 msgstr "Configurar para adquirir también todos los subdirectorios de la URL."
 
-#: ../checkout_dlg.cpp:125 ../export_dlg.cpp:129
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
 msgid ""
 "Set to ignore external definitions and the external working copies managed "
 "by them."
@@ -1712,66 +1695,66 @@ msgstr ""
 "Configurar para ignorar las definiciones externas y las copias de trabajo "
 "externas manejadas por ellas."
 
-#: ../main_frame.cpp:320
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr "Mostrar consejos al Inicio"
 
-#: ../main_frame.cpp:274 ../main_frame_helper.cpp:194
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 #, fuzzy
 msgid "Show conflicted entries"
 msgstr "Mostrar entradas sin versiones"
 
-#: ../main_frame_helper.cpp:171
+#: ../main_frame_helper.cpp:155
 #, fuzzy
 msgid "Show entries in subdirectories"
 msgstr "Mostrar entradas sin versiones"
 
-#: ../main_frame.cpp:276
+#: ../main_frame.cpp:285
 #, fuzzy
 msgid "Show ignored entries"
 msgstr "Mostrar entradas sin versiones"
 
-#: ../main_frame.cpp:273 ../main_frame_helper.cpp:188
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 #, fuzzy
 msgid "Show modified entries"
 msgstr "Mostrar entradas sin versiones"
 
-#: ../main_frame.cpp:269 ../main_frame_helper.cpp:170
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 #, fuzzy
 msgid "Show subdirectories"
 msgstr "Mostrar entradas sin versiones"
 
-#: ../main_frame_helper.cpp:142
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr "Mostrar los mensajes del registro para las entradas seleccionadas"
 
-#: ../main_frame.cpp:272 ../main_frame_helper.cpp:182
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 #, fuzzy
 msgid "Show unmodified entries"
 msgstr "Mostrar entradas sin versiones"
 
-#: ../main_frame.cpp:271 ../main_frame_helper.cpp:176
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr "Mostrar entradas sin versiones"
 
-#: ../listener.cpp:360 ../main_frame.cpp:1405
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr "Saltar"
 
-#: ../main_frame.cpp:266
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr "Ordenar"
 
-#: ../main_frame.cpp:242
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr "Orden ascendente"
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 #, fuzzy
 msgid "Standard Editor"
 msgstr "Editor estándar:"
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 #, fuzzy
 msgid "Standard Explorer"
 msgstr "Explorador de archivos sstándar:"
@@ -1780,39 +1763,39 @@ msgstr "Explorador de archivos sstándar:"
 msgid "Status"
 msgstr "Estado"
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr "Robar bloqueo si pertenece a otro usuario"
 
-#: ../main_frame_helper.cpp:219
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr "Detener"
 
-#: ../main_frame_helper.cpp:220
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr "Detener la acción actual"
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr "Almacenar las credenciales de autenticación en el disco duro"
 
-#: ../switch_action.cpp:50 ../switch_dlg.cpp:192
+#: ../switch_action.cpp:50
 msgid "Switch URL"
 msgstr "Cambiar el URL"
 
-#: ../main_frame.cpp:295
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr "Cambiar la URL...\tCTRL-S"
 
-#: ../main_frame.cpp:1352
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr "Duración de la prueba"
 
-#: ../main_frame.cpp:1348
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr "Prueba terminada en"
 
-#: ../main_frame.cpp:1345
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr "Prueba iniciada en"
 
@@ -1834,7 +1817,7 @@ msgstr ""
 msgid "The svnadmin command was not successful."
 msgstr ""
 
-#: ../cert_dlg.cpp:70
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
@@ -1842,14 +1825,14 @@ msgstr ""
 "Había errores validando el certificado del servidor.\n"
 "¿Desea confiar en este certificado?"
 
-#: ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:418
 #, fuzzy
 msgid "This action has resulted in a commit - please enter a &log message"
 msgstr ""
 "Esta acción ha resultado en un envío - por favor introduzca un mensaje de "
 "registro"
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1857,12 +1840,9 @@ msgid ""
 "Available online under:"
 msgstr ""
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr "Árbol"
-
-#: ../checkout_dlg.cpp:65 ../columns.cpp:59 ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521 ../switch_dlg.cpp:77 ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr "URL"
 
@@ -1875,11 +1855,11 @@ msgstr "URL: %s"
 msgid "UUID"
 msgstr "UUID"
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../main_frame.cpp:1494
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr "¡Acción no implementada!"
 
@@ -1888,11 +1868,11 @@ msgstr "¡Acción no implementada!"
 msgid "Unknown destination path"
 msgstr "Ubicación de destino"
 
-#: ../unlock_action.cpp:39 ../unlock_dlg.cpp:80
+#: ../unlock_action.cpp:39
 msgid "Unlock"
 msgstr "Desbloquear"
 
-#: ../listener.cpp:375 ../main_frame.cpp:1420
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr "Desbloqueado"
 
@@ -1900,50 +1880,50 @@ msgstr "Desbloqueado"
 msgid "Update"
 msgstr "Actualizar"
 
-#: ../main_frame_helper.cpp:84
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr "Actualizar seleccionado"
 
-#: ../listener.cpp:363 ../main_frame.cpp:1408
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr "Actualizado"
 
-#: ../main_frame.cpp:1556 ../main_frame.cpp:1561
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr "Actualizando..."
 
-#: ../main_frame.cpp:241
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr "Usar ubicación para ordenamiento"
 
-#: ../rapidsvn_generated.cpp:271 ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 #, fuzzy
 msgid "Use URL/path:"
 msgstr "Usar URL/Ubicación:"
 
-#: ../rapidsvn_generated.cpp:70 ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr "Usar siempre"
 
-#: ../checkout_dlg.cpp:92 ../export_dlg.cpp:95 ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299 ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103 ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr "Usar último"
 
-#: ../auth_dlg.cpp:54 ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr "Usuario"
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr "Válido desde:"
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr "Válido hasta:"
 
-#: ../listed_dlg.cpp:80 ../listed_dlg.cpp:172 ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr "Valor"
 
@@ -1951,11 +1931,29 @@ msgstr "Valor"
 msgid "View"
 msgstr "Ver"
 
-#: ../rapidsvn_generated.cpp:696
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "View..."
+msgstr "&Ver..."
+
+#: ../rapidsvn_generated.cpp:567
 msgid "WARNING"
 msgstr ""
 
-#: ../dnd_dlg.cpp:69
+#: ../dnd_dlg.cpp:48
+#, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr ""
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -1968,33 +1966,29 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr ""
-
-#: ../main_frame.cpp:1863
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
 msgstr ""
 "¡No puede agregar un directorio administrativo de subversión a los "
 "marcadores!"
 
-#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1261
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr "agregar"
 
-#: ../filelist_ctrl.cpp:1226 ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr "agregado"
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr "en conflicto"
 
-#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1264
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr "borrar"
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr "borrado"
 
@@ -2002,7 +1996,7 @@ msgstr "borrado"
 msgid "directory"
 msgstr "directorio"
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr "externo"
 
@@ -2010,63 +2004,67 @@ msgstr "externo"
 msgid "file"
 msgstr "archivo"
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr ""
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr "incompleto"
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr "fusionado"
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr "perdido"
 
-#: ../filelist_ctrl.cpp:1229 ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr "modificado"
 
-#: ../export_dlg.cpp:135 ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr "nativo"
 
-#: ../file_info.cpp:132 ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr "ninguno"
 
-#: ../file_info.cpp:146 ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr "normal"
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr "obstruido"
 
-#: ../filelist_ctrl.cpp:1294 ../filelist_ctrl.cpp:1308
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr "desactualizado"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.4"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.5"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.6"
 msgstr ""
 
-#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1267
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr "reemplazar"
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr "substituido"
 
@@ -2078,17 +2076,123 @@ msgstr ""
 msgid "unknown"
 msgstr "desconocido"
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr "valor desconocido"
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
 msgstr "sin versión"
 
-#: ../main_frame.cpp:329
-msgid "wxString Creation&Tracing Test"
-msgstr "Test wxString Creation&Tracing "
+#~ msgid "Action"
+#~ msgstr "Acción"
+
+#~ msgid "Checkout Test"
+#~ msgstr "Comprobación de prueba"
+
+#~ msgid "Copied from Path"
+#~ msgstr "Copiado desde ubicación"
+
+#~ msgid "Copied from Rev"
+#~ msgstr "Copiado desde Rev"
+
+#~ msgid "Destination file"
+#~ msgstr "Archivo de destino"
+
+#~ msgid "Destination path"
+#~ msgstr "Ubicación de destino"
+
+#~ msgid "EOL:"
+#~ msgstr "EOL:"
+
+#~ msgid "Enter log message"
+#~ msgstr "Introduzca mensaje de registro"
+
+#~ msgid "Enter the local path where you want the code be exported."
+#~ msgstr "Introduzca la ubicación local donde el código será exportado."
+
+#~ msgid ""
+#~ "Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
+#~ "files."
+#~ msgstr ""
+#~ "Introduzca qué clase de símbolo(s) desea como EOL (Fin de la línea) en "
+#~ "archivos exportados."
+
+#~ msgid "File path required when importing a file!"
+#~ msgstr "¡La ubicación del archivo es requerida al importar un archivo!"
+
+#~ msgid "First path or URL is required for merge!"
+#~ msgstr "¡La primera ubicación o URL es requerida para la fusión!"
+
+#~ msgid ""
+#~ "Invalid selection. At least one revisions is needed for diff and no more "
+#~ "than two."
+#~ msgstr ""
+#~ "Selección inválida. Por lo menos una las revisiones es necesaria para el "
+#~ "diff y no más de dos."
+
+#~ msgid "Invalid selection. Exactly two revisions needed for merge."
+#~ msgstr ""
+#~ "Selección inválida. Exactamente dos revisiones son necesarias para la "
+#~ "fusión."
+
+#~ msgid "Invalid selection. Only one revision may be selected for annotate"
+#~ msgstr ""
+#~ "Selección inválida. Solamente una revisión se puede seleccionar para "
+#~ "anotar"
+
+#~ msgid "Listener Test"
+#~ msgstr "Prueba de escucha"
+
+#~ msgid "Locate help"
+#~ msgstr "Localizar ayuda"
+
+#~ msgid "Locate tips"
+#~ msgstr "Localizar consejos"
+
+#~ msgid "Locate tips file"
+#~ msgstr "Localizar archivo de consejos"
+
+#~ msgid "Log Message:"
+#~ msgstr "Mensaje de registro:"
+
+#~ msgid "Merge revisions"
+#~ msgstr "Fusionar revisiones"
+
+#~ msgid ""
+#~ "No help file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "No se eligió ningún archivo de ayuda, ¿desea que se le\n"
+#~ " pregunte nuevamente después del próximo inicio la aplicación?"
+
+#~ msgid ""
+#~ "No tips file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "No se eligió ningún archivo de consejos, ¿desea que se le\n"
+#~ " pregunte otra vez después del próximo inicio de la aplicación?"
+
+#~ msgid "RapidSVN Help: %s"
+#~ msgstr "Ayuda de RapidSVN: %s"
+
+#~ msgid "Revision must be an unsigned number!"
+#~ msgstr "¡El número de la revisión debe estar sin firmar!"
+
+#~ msgid "SSL Certificate"
+#~ msgstr "Certificado SSL"
+
+#~ msgid "Second path or URL is required for merge!"
+#~ msgstr "¡Se requiere la segunda ubicación o URL para la fusión!"
+
+#~ msgid "Second working copy or URL"
+#~ msgstr " Segunda copia de trabajo o URL "
+
+#~ msgid "Tree"
+#~ msgstr "Árbol"
+
+#~ msgid "wxString Creation&Tracing Test"
+#~ msgstr "Test wxString Creation&Tracing "
 
 #~ msgid "Information"
 #~ msgstr "Información"

--- a/librapidsvn/src/locale/fr/rapidsvn.po
+++ b/librapidsvn/src/locale/fr/rapidsvn.po
@@ -5,10 +5,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rapidsvn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-02 17:09+0100\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: 2009-02-21 16:59+0100\n"
 "Last-Translator: Cedric Boudinet <bouced@gmx.fr>\n"
 "Language-Team: RapidSVN Developers <dev@rapidsvn.tigris.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -18,22 +19,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr "%s  code : %ld"
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, c-format
 msgid "%s Version %s"
 msgstr "%s Version %s"
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, c-format
 msgid "%s Version %s Revision %d"
 msgstr "%s Version %s Revision %d"
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr "%x %X"
 
-#: ../main_frame.cpp:323
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr "&À propos..."
 
@@ -41,35 +42,31 @@ msgstr "&À propos..."
 msgid "&Add\tINS"
 msgstr "&Ajouter\tINS"
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr "&Ajouter une copie existante..."
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr "&Annoter"
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 msgid "&Annotate..."
 msgstr "&Annoter..."
 
-#: ../main_frame.cpp:344
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr "&Signets"
 
-#: ../rapidsvn_generated.cpp:676
+#: ../rapidsvn_generated.cpp:549
 msgid "&Browse"
 msgstr "&Parcourir"
 
-#: ../log_dlg.cpp:359
-msgid "&Close"
-msgstr "&Fermer"
-
-#: ../rapidsvn_generated.cpp:655
+#: ../rapidsvn_generated.cpp:528
 msgid "&Compatible with:"
 msgstr "&Compatible avec:"
 
-#: ../main_frame.cpp:316
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr "&Contenu\tF1"
 
@@ -77,7 +74,7 @@ msgstr "&Contenu\tF1"
 msgid "&Copy...\tF5"
 msgstr "&Copier...\tF5"
 
-#: ../main_frame.cpp:290
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr "&Créer..."
 
@@ -85,11 +82,11 @@ msgstr "&Créer..."
 msgid "&Delete\tDEL"
 msgstr "&Supprimer\tDEL"
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr "&Supprimer..."
 
-#: ../log_dlg.cpp:362 ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 msgid "&Diff"
 msgstr "&Diff"
 
@@ -101,43 +98,48 @@ msgstr "&Diff d'après Base...\tCTRL+B"
 msgid "&Diff to Head...\tCTRL+H"
 msgstr "&Diff d'après Head...\tCTRL+H"
 
+#: ../utils.cpp:220
+#, fuzzy
+msgid "&Diff..."
+msgstr "&Diff"
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr "&Diff...\tCTRL+D"
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr "&Editer le signet..."
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr "&Editer..."
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr "&Editer...\tF3"
 
-#: ../main_frame.cpp:288
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr "&Exporter...\tCTRL-E"
 
-#: ../main_frame.cpp:345
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr "&Extras"
 
-#: ../main_frame.cpp:339
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr "&Fichier"
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 msgid "&Files to commit"
 msgstr "&Fichiers à publier"
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 msgid "&Get"
 msgstr "&Obtenir"
 
-#: ../main_frame.cpp:223 ../main_frame.cpp:346
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr "&Aide"
 
@@ -145,11 +147,11 @@ msgstr "&Aide"
 msgid "&Ignore\tCTRL-DEL"
 msgstr "&Ignorer\tCTRL-DEL"
 
-#: ../main_frame.cpp:287
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr "&Importer...\tCTRL-I"
 
-#: ../main_frame.cpp:317
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr "&Index\tShift+F1"
 
@@ -157,7 +159,7 @@ msgstr "&Index\tShift+F1"
 msgid "&Info..."
 msgstr "&Info..."
 
-#: ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:540
 msgid "&Load configuration from directory (optional):"
 msgstr "&Charger la configuration depuis le répertoire (facultatif):"
 
@@ -165,27 +167,42 @@ msgstr "&Charger la configuration depuis le répertoire (facultatif):"
 msgid "&Lock..."
 msgstr "&Vérouiller..."
 
+#: ../utils.cpp:222
+#, fuzzy
+msgid "&Log..."
+msgstr "&Log...\tCTRL-L"
+
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr "&Log...\tCTRL-L"
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 msgid "&Merge"
 msgstr "&Fusionner"
 
-#: ../main_frame.cpp:342
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr "&Modifier"
 
-#: ../rapidsvn_generated.cpp:625
+#: ../rapidsvn_generated.cpp:897
+#, fuzzy
+msgid "&Name"
+msgstr "Nom"
+
+#: ../rapidsvn_generated.cpp:499
 msgid "&Name of the new repository:"
 msgstr "&Nom du nouveau dépot:"
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr "&Nouveau..."
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+#, fuzzy
+msgid "&Password"
+msgstr "Mot de passe"
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr "De façon &permanente"
 
@@ -193,43 +210,48 @@ msgstr "De façon &permanente"
 msgid "&Properties...\tCTRL-P"
 msgstr "&Propriétés...\tCTRL-P"
 
-#: ../main_frame.cpp:343
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr "&Informations"
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 msgid "&Recent entries:"
 msgstr "Entrées &récentes :"
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 msgid "&Remove Bookmark"
 msgstr "&Enlever le signet"
 
-#: ../main_frame.cpp:341
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr "&Dépôt"
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+#, fuzzy
+msgid "&Revision"
+msgstr "Révision"
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr "&Stop"
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr "&Aller vers dépôt URL..."
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr "&Temporairement"
 
-#: ../main_frame.cpp:348
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr "&Tests"
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr "&Basculer"
 
-#: ../rapidsvn_generated.cpp:599
+#: ../rapidsvn_generated.cpp:473
 msgid "&Type:"
 msgstr "&Type:"
 
@@ -237,31 +259,41 @@ msgstr "&Type:"
 msgid "&Unlock"
 msgstr "&Déverrouiller"
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr "&Mise à jour...\tCTRL-U"
 
-#: ../log_dlg.cpp:360 ../main_frame.cpp:340
+#: ../rapidsvn_generated.cpp:89
+#, fuzzy
+msgid "&Username"
+msgstr "Renommer"
+
+#: ../rapidsvn_generated.cpp:904
+#, fuzzy
+msgid "&Value"
+msgstr "Valeur"
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr "&Affichage"
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr "&Affichage..."
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr "- Erreur inconnue avec le certificat."
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr "- Le certificat a expiré."
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr "- Le nom de serveur du certificat ne correspond pas."
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
@@ -269,9 +301,15 @@ msgstr ""
 "- Le certificat n'est pas délivré par un tiers de confiance.\n"
 "  Utiliser l'empreinte pour valider le certificat manuellement!"
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
 msgstr "- Le certificate n'est pas encore valide."
+
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+#, fuzzy
+msgid "..."
+msgstr "&Nouveau..."
 
 #: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
 msgid "<None>"
@@ -285,29 +323,25 @@ msgstr "Un répertoire existant porte déja ce nom"
 msgid "A file of this name exists already"
 msgstr "Un fichier existant porte déja ce nom"
 
-#: ../about_dlg.cpp:68
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr "ANSI"
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr "À propos de %s"
 
-#: ../log_dlg.cpp:242
-msgid "Action"
-msgstr "Action"
-
-#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listener.cpp:353
-#: ../main_frame.cpp:1398
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr "Ajouter"
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr "Ajouter un &dépôt existant..."
 
-#: ../rapidsvn_generated.cpp:642
+#: ../rapidsvn_generated.cpp:516
 msgid "Add a bookmark for the new repository"
 msgstr "Ajouter un signet pour le nouveau dépôt"
 
@@ -315,40 +349,40 @@ msgstr "Ajouter un signet pour le nouveau dépôt"
 msgid "Add r&ecursive"
 msgstr "Ajouter r&écursivement"
 
-#: ../main_frame_helper.cpp:64
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr "Ajouter la sélection"
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr "Ajouter aux signets"
 
-#: ../listener.cpp:362 ../listener.cpp:369 ../main_frame.cpp:1407
-#: ../main_frame.cpp:1414
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr "Ajouté"
 
-#: ../main_frame.cpp:1904
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr "Dépôt ajouté aux signets '%s'"
 
-#: ../main_frame.cpp:1875
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr "Copie de travail ajoutée aux signets '%s'"
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr "Ajouter un répertoire au dépôt : %s"
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, c-format
 msgid "Adding file to repository: %s"
 msgstr "Ajouter un fichier au dépôt : %s"
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr "Fichiers/répertoires affectés"
 
@@ -356,11 +390,11 @@ msgstr "Fichiers/répertoires affectés"
 msgid "All files|*"
 msgstr "Tous les fichiers|*"
 
-#: ../main_frame.cpp:1271 ../main_frame.cpp:1290
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr "Une erreur s'est produite lors du lancement du navigateur"
 
-#: ../main_frame.cpp:1258
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr "Une erreur s'est produite lors de la vérification des actions valides"
 
@@ -368,7 +402,7 @@ msgstr "Une erreur s'est produite lors de la vérification des actions valides"
 msgid "Annotate"
 msgstr "Annoter"
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -387,11 +421,11 @@ msgstr ""
 "\n"
 "  %s?"
 
-#: ../auth_dlg.cpp:117 ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr "Authentification"
 
-#: ../annotate_dlg.cpp:48 ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr "Auteur"
 
@@ -399,11 +433,11 @@ msgstr "Auteur"
 msgid "BASE"
 msgstr "BASE"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../rapidsvn_generated.cpp:477
 msgid "BerkeleyDB"
 msgstr "BerkeleyDB"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr "Signet"
 
@@ -411,17 +445,17 @@ msgstr "Signet"
 msgid "Bookmarks"
 msgstr "Signets"
 
-#: ../main_frame_helper.cpp:85
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr "Importer les changements du dépôt dans la copie de travail"
 
-#: ../rapidsvn_generated.cpp:57 ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119 ../rapidsvn_generated.cpp:146
-#: ../rapidsvn_generated.cpp:620
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr "Parcourir"
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -432,44 +466,44 @@ msgstr ""
 "wxWidgets %d.%d.%d (%s)\n"
 "Subversion %d.%d.%d\n"
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr "CR (MacOS)"
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr "CRLF (Windows)"
 
-#: ../auth_dlg.cpp:73 ../cert_dlg.cpp:138 ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57 ../destination_dlg.cpp:90 ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146 ../import_dlg.cpp:130 ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342 ../lock_dlg.cpp:61 ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195 ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409 ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564 ../rapidsvn_generated.cpp:708
-#: ../switch_dlg.cpp:139 ../unlock_dlg.cpp:58 ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+#, fuzzy
+msgid "Certificate information:"
 msgstr "Information du certificat :"
 
-#: ../main_frame.cpp:289
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr "&Récupérer...\tCTRL-O"
 
-#: ../checkout_action.cpp:40 ../checkout_dlg.cpp:250
+#: ../checkout_action.cpp:40
 msgid "Checkout"
 msgstr "Récupérer"
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
 msgstr "Récupérer une nouvelle copie de travail..."
-
-#: ../main_frame.cpp:331
-msgid "Checkout Test"
-msgstr "Test de récupération"
 
 #: ../columns.cpp:58
 msgid "Checksum"
@@ -480,19 +514,24 @@ msgstr "Somme de contrôle"
 msgid "Checksum: %s"
 msgstr "Somme de contrôle : %s"
 
-#: ../cleanup_action.cpp:39 ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr "Nettoyer"
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+#, fuzzy
+msgid "Close"
+msgstr "&Fermer"
+
+#: ../utils.cpp:297
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr "Pu&blication...\tCTRL-ENTER"
 
-#: ../main_frame.cpp:265
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr "Colonnes"
 
-#: ../rapidsvn_generated.cpp:275 ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr ""
 
@@ -504,11 +543,11 @@ msgstr "Publication"
 msgid "Commit Log Message"
 msgstr "Message de publication"
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr "Message de log de publication: le plus récent par défaut"
 
-#: ../main_frame_helper.cpp:94
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr "Publication de la sélection"
 
@@ -516,9 +555,19 @@ msgstr "Publication de la sélection"
 msgid "Committed revision"
 msgstr "Version envoyée"
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
 msgstr "Comparer :"
+
+#: ../listener.cpp:496
+#, fuzzy, c-format
+msgid "Completed %s at revision %d"
+msgstr "Version envoyée"
+
+#: ../listener.cpp:486
+#, fuzzy, c-format
+msgid "Completed at revision %d"
+msgstr "Version envoyée"
 
 #: ../columns.cpp:64
 msgid "Conflict BASE"
@@ -552,6 +601,11 @@ msgstr "Conflit Travail"
 msgid "Conflict Working File: %s"
 msgstr "Conflit Fichier Travail : %s"
 
+#: ../listener.cpp:307
+#, fuzzy
+msgid "Conflicted"
+msgstr "en conflit"
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr "Copié"
@@ -566,29 +620,21 @@ msgstr "Copié depuis Rev: %ld"
 msgid "Copied From URL: %s"
 msgstr "Copié depuis URL : %s"
 
-#: ../log_dlg.cpp:244
-msgid "Copied from Path"
-msgstr "Copié depuis le chemin"
-
-#: ../log_dlg.cpp:245
-msgid "Copied from Rev"
-msgstr "Copié depuis la révision"
-
-#: ../dnd_dlg.cpp:108 ../listener.cpp:354 ../main_frame.cpp:1399
-#: ../move_action.cpp:44
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr "Copie"
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 msgid "Copy/Move"
 msgstr "Copier/Coller"
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, c-format
 msgid "Copying file into working directory: %s"
 msgstr "Copie du fichier vers le répertoire: %s"
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, c-format
 msgid "Copying file: %s"
 msgstr "Copie du fichier : %s"
@@ -598,7 +644,7 @@ msgstr "Copie du fichier : %s"
 msgid "Could not set working directory to %s"
 msgstr "Impossible de changer de répertoire vers %s"
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr "Créer un nouveau dépôt..."
 
@@ -606,57 +652,49 @@ msgstr "Créer un nouveau dépôt..."
 msgid "Create Repository"
 msgstr "Créer un nouveau dépôt"
 
-#: ../rapidsvn_generated.cpp:611
+#: ../rapidsvn_generated.cpp:485
 msgid "Create repository in &directory:"
 msgstr "Sélectionner un répertoire de &destination:"
 
-#: ../columns.cpp:54 ../log_dlg.cpp:165
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr "Date"
 
-#: ../rapidsvn_generated.cpp:265 ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr "Date :"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "Default"
 msgstr "Défaut"
 
-#: ../delete_action.cpp:40 ../delete_dlg.cpp:79 ../listener.cpp:355
-#: ../main_frame.cpp:1400
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../main_frame_helper.cpp:75
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr "Supprimer fichier et répertoire du contrôle de version"
 
-#: ../main_frame_helper.cpp:74
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr "Supprimer la sélection"
 
-#: ../listener.cpp:361 ../listener.cpp:370 ../main_frame.cpp:1406
-#: ../main_frame.cpp:1415
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr "Supprimé"
 
-#: ../checkout_dlg.cpp:72 ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
 msgstr "Répertoire de destination"
-
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr "Fichier de destination"
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
-msgstr "Chemin de destination"
 
 #: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr "Diff"
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 msgid "Diff Tool"
 msgstr "Outil de diff"
 
@@ -676,79 +714,96 @@ msgstr "Diff d'après une autre révision/date"
 msgid "Diff two revisions/dates"
 msgstr "Diff deux révision/dates"
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
 msgstr "Login différents pour chaque signet dans la liste"
+
+#: ../rapidsvn_generated.cpp:1296
+#, fuzzy
+msgid "Directory"
+msgstr "Répertoire :"
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr "Répertoire :"
 
-#: ../rapidsvn_generated.cpp:681
+#: ../rapidsvn_generated.cpp:554
 msgid "Disable automatic Log removal"
 msgstr "Désactiver la suppression automatique des logs"
 
-#: ../rapidsvn_generated.cpp:685
+#: ../rapidsvn_generated.cpp:557
 msgid "Disable fsync when committing database transactions"
-msgstr "Désactiver fsync lors de la validation des transactions avec la base de données"
+msgstr ""
+"Désactiver fsync lors de la validation des transactions avec la base de "
+"données"
 
-#: ../main_frame_helper.cpp:195
+#: ../main_frame_helper.cpp:179
 msgid "Display conflicted files/directories"
 msgstr "Afficher les fichiers/répertoires en conflit"
 
-#: ../main_frame_helper.cpp:132
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr "Affiche les informations sur les éléments sélectionnés"
 
-#: ../main_frame_helper.cpp:189
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr "Afficher les fichiers/répertoires modifiés"
 
-#: ../main_frame_helper.cpp:183
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr "Afficher les fichiers/répertoires non modifiés"
 
-#: ../main_frame_helper.cpp:177
+#: ../main_frame_helper.cpp:161
 msgid "Display unversioned files/directories"
 msgstr "Montrer les fichiers/répertoires non versionnés"
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr "Voulez vous supprimer les fichiers/répertoires sélectionnés ?"
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr "Voulez vous revenir sur les changements locaux ?"
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr "Voulez vous déverrouiller les fichiers/répertoires sélectionnés ?"
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr "&Quitter\tCTRL-Q"
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr "EOL :"
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr "Editer"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr "Editer le signet"
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr "Editer les propriétés"
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "Edit..."
+msgstr "&Editer..."
+
+#: ../rapidsvn_generated.cpp:1306
+#, fuzzy
+msgid "End &log message"
+msgstr "Entrez un message de log"
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 msgid "Enter &log message"
 msgstr "Entrez un message de log"
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr "Entrer un commentaire pour ce verrou"
 
@@ -756,37 +811,19 @@ msgstr "Entrer un commentaire pour ce verrou"
 msgid "Enter a name for the repository"
 msgstr "Entrez un nom pour le dépôt"
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr "Entrer un message de log"
-
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr "Entrer un nouveau nom :"
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr "Entrer le chemin local vers lequel le code sera exporté."
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
 msgstr "Entrer le chemin local vers lequel le code sera récupéré."
 
-#: ../checkout_dlg.cpp:70 ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr "Entrer l'URL de dépôt (pas de chemin local) ici."
 
-#: ../export_dlg.cpp:143
-msgid ""
-"Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
-"files."
-msgstr ""
-"Quels caratère(s) de fin de ligne voulez vous dans les fichiers exportés ?"
-
-#: ../import_dlg.cpp:178 ../import_dlg.cpp:191 ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494 ../log_dlg.cpp:530 ../main_frame.cpp:1865
-#: ../merge_dlg.cpp:52 ../merge_dlg.cpp:91 ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr "Erreur"
 
@@ -798,11 +835,18 @@ msgstr "Erreur de récupération du statut :"
 msgid "Error running svnadmin"
 msgstr "Erreur à l'exécution de svnadmin"
 
-#: ../property_dlg.cpp:120
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr "Erreur lors de la modification des propriétés"
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, fuzzy, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr "Erreur lors de la modification des propriétés"
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr "Erreur de validation du certificat du serveur pour '%s' :"
@@ -825,26 +869,26 @@ msgstr "Erreur pendant la préparation de l'action."
 msgid "Error while preparing action: %s"
 msgstr "Erreur pendant la préparation de l'action : %s"
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr "Erreur pendant le raffraichissement de la liste de fichier (%s)"
 
-#: ../main_frame.cpp:907
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr "Erreur pendant la mise à jour de la liste de fichier"
 
-#: ../main_frame.cpp:894
+#: ../main_frame.cpp:917
 #, c-format
 msgid "Error while updating filelist (%s)"
 msgstr "Erreur pendant la mise à jour de la liste de fichier (%s)"
 
-#: ../main_frame.cpp:542
+#: ../main_frame.cpp:561
 #, c-format
 msgid "Error: %s\n"
 msgstr "Erreur : %s\n"
 
-#: ../main_frame.cpp:1799
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
 msgstr ""
 "Une exception a été levée pendant la mise à jour de la liste de fichier"
@@ -882,11 +926,11 @@ msgstr "Exécuter l'outil de fusion : %s"
 msgid "Execute: %s"
 msgstr "Exécuter : %s"
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr "Explorateur...\tF2"
 
-#: ../export_action.cpp:40 ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr "Exporter"
 
@@ -894,52 +938,48 @@ msgstr "Exporter"
 msgid "Extension"
 msgstr "Extension"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../listener.cpp:405
+#, fuzzy
+msgid "External"
+msgstr "externe"
+
+#: ../rapidsvn_generated.cpp:477
 msgid "FSFS"
 msgstr ""
 
-#: ../listener.cpp:376 ../main_frame.cpp:1421
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr "Echec du verrouillage"
 
-#: ../listener.cpp:377 ../main_frame.cpp:1422
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr "Echec du déverrouillage"
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr "Fichier"
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr "Un chemin est nécessaire pour importer un fichier!"
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr "Empreinte :"
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr "Un Premier chemin ou une URL est nécessaire pour fusionner!"
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr "Première copie de travail ou URL"
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr "Pour plus d'information voir :"
 
-#: ../destination_dlg.cpp:80 ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr "Forcer"
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr "Forcer l'effacement"
 
-#: ../export_dlg.cpp:123
+#: ../export_dlg.cpp:75
 msgid ""
 "Force to execute even if destination directory not empty, causes overwriting "
 "of files with the same names."
@@ -947,12 +987,12 @@ msgstr ""
 "Forcer l'execution même si le répertoire de destination n'est pas vide, "
 "causant un écrasement des fichiers ayant les mêmes noms."
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
 msgstr ""
 "Forcer le déverrouillage même si vous n'êtes pas le propriétaire du verrou"
 
-#: ../rapidsvn_generated.cpp:41 ../rapidsvn_generated.cpp:649
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr "Général"
 
@@ -965,16 +1005,25 @@ msgstr "Obtenir le fichier %s rev. %s"
 msgid "HEAD"
 msgstr "HEAD"
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+#, fuzzy
+msgid "Help"
+msgstr "&Aide"
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr "Historique : %d révisions"
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr "Hostname :"
 
-#: ../checkout_dlg.cpp:88 ../export_dlg.cpp:91
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
 msgid ""
 "If not using the latest version of the files, specify which revision to use "
 "here."
@@ -982,7 +1031,7 @@ msgstr ""
 "Si vous ne souhaitez pas la dernière version des fichiers, spécifiez quelle "
 "révision utiliser."
 
-#: ../checkout_dlg.cpp:102 ../export_dlg.cpp:105
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
 msgid ""
 "If the files were renamed or moved some time, specify which peg revision to "
 "use here."
@@ -994,20 +1043,24 @@ msgstr ""
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: ../main_frame.cpp:275 ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr "Ignorer les liens externes"
 
-#: ../checkout_dlg.cpp:122 ../export_dlg.cpp:126 ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr "Ignorer les liens externes"
 
-#: ../dnd_dlg.cpp:37 ../dnd_dlg.cpp:97 ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr "Importer"
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+#, fuzzy
+msgid "Import &Path"
+msgstr "Importer"
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr "Import d'un fichier dans le dépôt: %s"
@@ -1016,15 +1069,15 @@ msgstr "Import d'un fichier dans le dépôt: %s"
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr "Résolution in&téractive...\tCTRL-T"
 
-#: ../main_frame.cpp:270
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr "Indiquer les enfants modifiés"
 
-#: ../main_frame.cpp:1984
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr "Informations"
 
-#: ../main_frame_helper.cpp:131
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr "Informations sur la sélection"
 
@@ -1032,7 +1085,7 @@ msgstr "Informations sur la sélection"
 msgid "Internal Error: There is another action running"
 msgstr "Erreur interne : Une autre action est déjà lancée"
 
-#: ../main_frame.cpp:1542
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr "Erreur interne : aucune donnée client pour cette action"
 
@@ -1044,32 +1097,16 @@ msgstr "Erreur interne : aucun contexte disponible"
 msgid "Invalid revision number detected"
 msgstr "Numéro de révision invalide détecté"
 
-#: ../log_dlg.cpp:478
-msgid ""
-"Invalid selection. At least one revisions is needed for diff and no more "
-"than two."
-msgstr ""
-"Sélection invalide. Au moins une révision est nécessaire pour diff et pas "
-"plus de deux."
-
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr "Sélection invalide. Deux révisions sont nécessaires pour fusionner"
-
-#: ../log_dlg.cpp:529
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr ""
-"Sélection invalide. Une seule révision peut être sélectionnée pour annoter"
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
+#: ../rapidsvn_generated.cpp:159
+#, fuzzy
+msgid "Issuer:"
 msgstr "Emission :"
 
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 msgid "Keep Locks"
 msgstr "Garder les verrous"
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr "LF (Unix)"
 
@@ -1091,20 +1128,16 @@ msgstr "Date du dernier changement"
 msgid "Last Changed Rev: %ld"
 msgstr "Révision du dernier changement : %ld"
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr "Ligne"
 
-#: ../main_frame.cpp:330
-msgid "Listener Test"
-msgstr "Listener Test"
-
-#: ../filelist_ctrl.cpp:1058
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr "Entrées listées dans '%s'"
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1117,19 +1150,7 @@ msgstr ""
 "Système: %s\n"
 "Nom canonique: %s\n"
 
-#: ../rapidsvn_app.cpp:198 ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr "Localiser l'aide"
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr "Localiser les astuces"
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr "Localiser le fichier astuces"
-
-#: ../lock_action.cpp:40 ../lock_dlg.cpp:100
+#: ../lock_action.cpp:40
 msgid "Lock"
 msgstr "Verrouiller"
 
@@ -1164,31 +1185,27 @@ msgstr "Propriétaire du verrou : %s"
 msgid "Lock Token: %s"
 msgstr "Marque de verrou : %s"
 
-#: ../listener.cpp:374 ../main_frame.cpp:1419
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr "Verrouillé"
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr "Log"
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr "Historique de log"
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr "Message de log"
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr "Message de log :"
-
-#: ../main_frame_helper.cpp:141
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr "Log de la sélection"
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr "Connexion..."
 
@@ -1213,39 +1230,40 @@ msgstr "Créer &répertoire...\tF7"
 msgid "Make directory"
 msgstr "Créer répertoire"
 
-#: ../merge_action.cpp:38 ../merge_action.cpp:44 ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr "Fusionner"
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 msgid "Merge Tool"
 msgstr "Outil de fusion"
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
-msgstr "Fusionner révisions"
-
-#: ../main_frame.cpp:294
+#: ../main_frame.cpp:303
 msgid "Merge..."
 msgstr "Fusionner..."
+
+#: ../listener.cpp:308
+#, fuzzy
+msgid "Merged"
+msgstr "Fusionner"
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr "Mkdir"
 
-#: ../listener.cpp:368 ../main_frame.cpp:1413
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr "Modifié"
 
-#: ../rapidsvn_generated.cpp:692
+#: ../rapidsvn_generated.cpp:563
 msgid "More options"
 msgstr "Plus d'options"
 
-#: ../dnd_dlg.cpp:104 ../move_action.cpp:42
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr "Déplacer"
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, c-format
 msgid "Moving file: %s"
 msgstr "Déplacement du fichier : %s"
@@ -1254,8 +1272,16 @@ msgstr "Déplacement du fichier : %s"
 msgid "Multiple Files"
 msgstr "Fichiers multiples"
 
-#: ../columns.cpp:45 ../listed_dlg.cpp:75 ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr "Nom"
 
@@ -1264,44 +1290,24 @@ msgstr "Nom"
 msgid "Name: %s"
 msgstr "Nom : %s"
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
 msgstr "Nouvelle propriété"
-
-#: ../revert_dlg.cpp:57
-msgid "No"
-msgstr "Non"
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr "Pas d'outil de diff défini dans les préférences"
 
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Aucun fichier d'aide n'a été choisi, voulez vous être\n"
-"de nouveau interrogé lors du prochain démarrage?"
-
 #: ../userresolve_action.cpp:62
 msgid "No merge tool set in the preferences"
 msgstr "Pas d'outil de fusion défini dans les préférences"
-
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Aucune fichier d'astuce n'a été choisi, voulez vous être\n"
-"de nouveau interrogé au prochain démarrage?"
 
 #: ../file_info.cpp:118
 #, c-format
 msgid "Node Kind: %s"
 msgstr "Type de noeud : %s"
 
-#: ../checkout_dlg.cpp:106 ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr "Non spécifié"
 
@@ -1309,39 +1315,38 @@ msgstr "Non spécifié"
 msgid "Not versioned"
 msgstr "Non versionné"
 
-#: ../about_dlg.cpp:114 ../annotate_dlg.cpp:42 ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126 ../delete_dlg.cpp:54 ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145 ../import_dlg.cpp:128 ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341 ../lock_dlg.cpp:60 ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191 ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405 ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560 ../rapidsvn_generated.cpp:704
-#: ../report_dlg.cpp:57 ../switch_dlg.cpp:137 ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr "OK"
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr "Ouvrir..."
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr "Écraser"
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr "Mot de passe"
-
-#: ../columns.cpp:46 ../import_dlg.cpp:80 ../log_dlg.cpp:243
+#: ../columns.cpp:46
 msgid "Path"
 msgstr "Chemin"
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+#, fuzzy
+msgid "Path &type"
 msgstr "Type de chemin :"
 
-#: ../checkout_dlg.cpp:97 ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr "Révision stable"
 
@@ -1349,27 +1354,27 @@ msgstr "Révision stable"
 msgid "Preferences"
 msgstr "Préférences"
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr "Préférences..."
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr "Arguments du programme (%1=base, %2=leleur %3=lemien %4=resultat) :"
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr "Arguments du programme (%1=fichier1, %2=fichier2) :"
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr "Arguments du programme (%1=répertoire sélectionné) :"
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr "Arguments du programme (%1=fichier sélectionné) :"
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr "Programmes"
 
@@ -1385,7 +1390,7 @@ msgstr "Statut des propriétés"
 msgid "Properties Last Updated"
 msgstr "Dernière mise à jour des propriétés"
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr "Propriétés :"
 
@@ -1397,22 +1402,21 @@ msgstr "Propriété"
 msgid "Property Editor"
 msgstr "Editeur de Propriété"
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr "Effacer les fichiers temporaires à la sortie du programme"
 
-#: ../main_frame_helper.cpp:65
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr "Placer les fichiers et répertoires sous contrôle de version"
 
-#: ../main_frame.cpp:509
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
+msgstr ""
+
+#: ../main_frame.cpp:528
 msgid "RapidSVN Error"
 msgstr "Erreur RapidSVN"
-
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
-msgstr "Aide RapidSVN : %s"
 
 #: ../utils.cpp:192
 msgid "Re&name...\tCTRL-N"
@@ -1426,52 +1430,52 @@ msgstr "Ré&soudre les conflits\tCTRL-S"
 msgid "Re&vert\tCTRL-V"
 msgstr "Ren&verser\tCTRL-V"
 
-#: ../filelist_ctrl.cpp:1134
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr "Prêt"
 
-#: ../main_frame.cpp:1522 ../main_frame.cpp:1566
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr "Prêt\n"
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr "Entrées récentes :"
 
-#: ../checkout_dlg.cpp:111 ../export_dlg.cpp:114 ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201 ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547 ../revert_dlg.cpp:49 ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr "Récursivement"
 
-#: ../main_frame_helper.cpp:206
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr "Raffraichir"
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr "Raffraichir la vue\tCTRL-R"
 
-#: ../main_frame_helper.cpp:207
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr "Raffraichir la liste des fichiers"
 
-#: ../main_frame.cpp:268
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr "Raffraichir avec mise à jour"
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 msgid "Relocate"
 msgstr "Relocaliser"
 
-#: ../main_frame_helper.cpp:115
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
 msgstr ""
 "Enlever les états 'en conflit' pour les fichiers et répertoires de la copie "
 "de travail "
 
-#: ../main_frame.cpp:1918
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr "Signet enlevé"
 
@@ -1483,7 +1487,7 @@ msgstr "Renommer"
 msgid "Rep. Rev."
 msgstr "Dernière révision"
 
-#: ../listener.cpp:371 ../main_frame.cpp:1416
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr "Remplacé"
 
@@ -1491,13 +1495,14 @@ msgstr "Remplacé"
 msgid "Repository"
 msgstr "Dépôt"
 
-#: ../import_dlg.cpp:67 ../main_frame.cpp:1890
+#: ../rapidsvn_generated.cpp:1268
+#, fuzzy
+msgid "Repository &URL for import"
+msgstr "L'URL du dépôt est requise pour l'import !"
+
+#: ../main_frame.cpp:2079
 msgid "Repository URL"
 msgstr "URL du dépôt"
-
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
-msgstr "L'URL du dépôt est requise pour l'import !"
 
 #: ../file_info.cpp:112
 #, c-format
@@ -1509,11 +1514,11 @@ msgstr "UUID du dépôt : %s"
 msgid "Repository: %s"
 msgstr "Dépôt : %s"
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr "Effacer colonnes"
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr "Réinitialiser le mode à plat lors de chaque démarrage du programme"
 
@@ -1521,57 +1526,51 @@ msgstr "Réinitialiser le mode à plat lors de chaque démarrage du programme"
 msgid "Resolve"
 msgstr "Resoudre"
 
-#: ../main_frame_helper.cpp:114
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr "Resoudre la sélection"
 
-#: ../listener.cpp:359 ../main_frame.cpp:1404
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr "Résolu"
 
-#: ../listener.cpp:356 ../main_frame.cpp:1401
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr "Restorer"
 
-#: ../main_frame_helper.cpp:105
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
 msgstr ""
 "Restorer le fichier original de la copie de travail (annuler toute édition "
 "locale)"
 
-#: ../rapidsvn_generated.cpp:632
+#: ../rapidsvn_generated.cpp:506
 msgid "Resulting repository filename:"
 msgstr "Nom du fichier de dépôt résultant:"
 
-#: ../listener.cpp:357 ../main_frame.cpp:1402 ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr "Renverser"
 
-#: ../main_frame_helper.cpp:104
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr "Renverser la sélection"
 
-#: ../annotate_dlg.cpp:47 ../checkout_dlg.cpp:83 ../columns.cpp:47
-#: ../export_dlg.cpp:86 ../log_dlg.cpp:163 ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150 ../rapidsvn_generated.cpp:529 ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr "Révision"
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr "La révision doit être positive!"
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 msgid "Revision or date #1:"
 msgstr "Révision ou date #1:"
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 msgid "Revision or date #2:"
 msgstr "Révision ou date #2:"
 
-#: ../rapidsvn_generated.cpp:250 ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr "Révision :"
 
@@ -1585,10 +1584,6 @@ msgstr "Révision : %ld"
 msgid "Running command %s:"
 msgstr "Execution de la commande %s:"
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr "Certificat SSL"
-
 #: ../columns.cpp:62
 msgid "Schedule"
 msgstr "Calendrier"
@@ -1598,36 +1593,28 @@ msgstr "Calendrier"
 msgid "Schedule: %s"
 msgstr "Calendrier : %s"
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr "Un second chemin ou une URL est nécessaire pour fusionner!"
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr "Seconde copie de travail ou URL"
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr "Sélectionner le fichier de certificat"
 
-#: ../checkout_dlg.cpp:273 ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr "Sélectionner un répertoire de destination"
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr "Sélectionner un répertoire de destination pour fusionner avec"
 
 #: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
-#: ../main_frame.cpp:1845
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr "Sélectionner un répertoire"
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr "Sélectionner un répertoire pour l'import"
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr "Sélectionner un fichier à importer"
 
@@ -1655,27 +1642,27 @@ msgstr "Sélectionner un éditeur de fichier"
 msgid "Select standard file explorer executable"
 msgstr "Sélectionner un gestionnaire de fichier"
 
-#: ../main_frame_helper.cpp:95
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr "Envoyer les changements depuis la copie de travail vers le dépôt"
 
-#: ../checkout_dlg.cpp:94 ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
 msgstr "Obtenir la dernière version des fichiers du dépôt"
 
-#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
 msgstr "Utiliser la révision stable BASE/HEAD (courante) des fichiers"
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
 msgstr "Créer automatiquement un nouveau signet de la copie de travail"
 
-#: ../checkout_dlg.cpp:114 ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
 msgstr "Obtenir également tous les sous-répertoires de l'URL."
 
-#: ../checkout_dlg.cpp:125 ../export_dlg.cpp:129
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
 msgid ""
 "Set to ignore external definitions and the external working copies managed "
 "by them."
@@ -1683,59 +1670,59 @@ msgstr ""
 "Ignorer les définitions externes et les copies de travail externes gérées "
 "par elles."
 
-#: ../main_frame.cpp:320
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr "Montrer les astuces de démarrage"
 
-#: ../main_frame.cpp:274 ../main_frame_helper.cpp:194
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 msgid "Show conflicted entries"
 msgstr "Montrer les entrées en conflit"
 
-#: ../main_frame_helper.cpp:171
+#: ../main_frame_helper.cpp:155
 msgid "Show entries in subdirectories"
 msgstr "Montrer les entrées dans les sous-répertoires"
 
-#: ../main_frame.cpp:276
+#: ../main_frame.cpp:285
 msgid "Show ignored entries"
 msgstr "Montrer les entrées ignorées"
 
-#: ../main_frame.cpp:273 ../main_frame_helper.cpp:188
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 msgid "Show modified entries"
 msgstr "Montrer les entrées modifiées"
 
-#: ../main_frame.cpp:269 ../main_frame_helper.cpp:170
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 msgid "Show subdirectories"
 msgstr "Montrer les sous-répertoires"
 
-#: ../main_frame_helper.cpp:142
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr "Montrer les messages de log pour les entrées sélectionnées"
 
-#: ../main_frame.cpp:272 ../main_frame_helper.cpp:182
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 msgid "Show unmodified entries"
 msgstr "Montrer les entrées non modifiées"
 
-#: ../main_frame.cpp:271 ../main_frame_helper.cpp:176
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr "Montrer les entrées non versionnées"
 
-#: ../listener.cpp:360 ../main_frame.cpp:1405
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr "Passer"
 
-#: ../main_frame.cpp:266
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr "Trier"
 
-#: ../main_frame.cpp:242
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr "Tri ascendant"
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 msgid "Standard Editor"
 msgstr "Editeur standard"
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 msgid "Standard Explorer"
 msgstr "Gestionnaire de fichier standard"
 
@@ -1743,39 +1730,39 @@ msgstr "Gestionnaire de fichier standard"
 msgid "Status"
 msgstr "Statut"
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr "Voler le verrou s'il appartient à un autre utilisateur"
 
-#: ../main_frame_helper.cpp:219
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr "Arrêter"
 
-#: ../main_frame_helper.cpp:220
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr "Arrêter l'action courante"
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr "Garder les crédits d'authentification sur le disque dur"
 
-#: ../switch_action.cpp:50 ../switch_dlg.cpp:192
+#: ../switch_action.cpp:50
 msgid "Switch URL"
 msgstr "Changer d'URL"
 
-#: ../main_frame.cpp:295
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr "Changer d'URL...\tCTRL-S"
 
-#: ../main_frame.cpp:1352
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr "Durée du test"
 
-#: ../main_frame.cpp:1348
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr "Test terminé à"
 
-#: ../main_frame.cpp:1345
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr "Test commencé à"
 
@@ -1797,7 +1784,7 @@ msgstr "Le répertoire de configuration n'existe pas"
 msgid "The svnadmin command was not successful."
 msgstr ""
 
-#: ../cert_dlg.cpp:70
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
@@ -1805,13 +1792,13 @@ msgstr ""
 "Le certificat du serveur n'a pas pu être validé.\n"
 "Voulez vous accepter ce certificat?"
 
-#: ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:418
 msgid "This action has resulted in a commit - please enter a &log message"
 msgstr ""
 "Cette action conduit à une publication - s'il vous plaît, entrer un message "
 "de log"
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1819,12 +1806,9 @@ msgid ""
 "Available online under:"
 msgstr ""
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr "Arbre"
-
-#: ../checkout_dlg.cpp:65 ../columns.cpp:59 ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521 ../switch_dlg.cpp:77 ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr "URL"
 
@@ -1837,11 +1821,11 @@ msgstr "URL : %s"
 msgid "UUID"
 msgstr "UUID"
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../main_frame.cpp:1494
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr "Action non implémentée!"
 
@@ -1849,11 +1833,11 @@ msgstr "Action non implémentée!"
 msgid "Unknown destination path"
 msgstr "Chemin de destination inconnu"
 
-#: ../unlock_action.cpp:39 ../unlock_dlg.cpp:80
+#: ../unlock_action.cpp:39
 msgid "Unlock"
 msgstr "Déverrouiller"
 
-#: ../listener.cpp:375 ../main_frame.cpp:1420
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr "Déverrouillé"
 
@@ -1861,49 +1845,49 @@ msgstr "Déverrouillé"
 msgid "Update"
 msgstr "Mise à jour"
 
-#: ../main_frame_helper.cpp:84
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr "Mise à jour de la sélection"
 
-#: ../listener.cpp:363 ../main_frame.cpp:1408
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr "Mis à jour"
 
-#: ../main_frame.cpp:1556 ../main_frame.cpp:1561
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr "Mise à jour..."
 
-#: ../main_frame.cpp:241
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr "Utiliser le chemin pour trier"
 
-#: ../rapidsvn_generated.cpp:271 ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 msgid "Use URL/path:"
 msgstr "Utiliser l'URL/chemin :"
 
-#: ../rapidsvn_generated.cpp:70 ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr "Toujours utiliser"
 
-#: ../checkout_dlg.cpp:92 ../export_dlg.cpp:95 ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299 ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103 ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr "Utiliser le dernier"
 
-#: ../auth_dlg.cpp:54 ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr "Utilisateur"
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr "Valide depuis :"
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr "Valide jusqu'à :"
 
-#: ../listed_dlg.cpp:80 ../listed_dlg.cpp:172 ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr "Valeur"
 
@@ -1911,11 +1895,37 @@ msgstr "Valeur"
 msgid "View"
 msgstr "Affichage"
 
-#: ../rapidsvn_generated.cpp:696
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "View..."
+msgstr "&Affichage..."
+
+#: ../rapidsvn_generated.cpp:567
 msgid "WARNING"
 msgstr ""
 
-#: ../dnd_dlg.cpp:69
+#: ../dnd_dlg.cpp:48
+#, fuzzy, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr ""
+"Voulez-vous déplacer ou copier\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"dans\n"
+"\n"
+"  %s?"
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -1936,33 +1946,29 @@ msgstr ""
 "\n"
 "  %s?"
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr "Oui"
-
-#: ../main_frame.cpp:1863
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
 msgstr ""
 "Vous ne pouvez pas ajouter un répertoire administratif subversion aux "
 "signets!"
 
-#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1261
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr "ajouter"
 
-#: ../filelist_ctrl.cpp:1226 ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr "ajouté"
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr "en conflit"
 
-#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1264
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr "supprimer"
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr "supprimé"
 
@@ -1970,7 +1976,7 @@ msgstr "supprimé"
 msgid "directory"
 msgstr "répertoire"
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr "externe"
 
@@ -1978,63 +1984,67 @@ msgstr "externe"
 msgid "file"
 msgstr "fichier"
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr "ignoré"
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr "incomplet"
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr "fusionné"
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr "manquant"
 
-#: ../filelist_ctrl.cpp:1229 ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr "modifié"
 
-#: ../export_dlg.cpp:135 ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr "natif"
 
-#: ../file_info.cpp:132 ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr "aucun"
 
-#: ../file_info.cpp:146 ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr "normal"
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr "bouché"
 
-#: ../filelist_ctrl.cpp:1294 ../filelist_ctrl.cpp:1308
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr "dépassé"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.4"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.5"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.6"
 msgstr ""
 
-#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1267
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr "remplacer"
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr "remplacé"
 
@@ -2046,17 +2056,125 @@ msgstr "impossible de trouver svnadmin"
 msgid "unknown"
 msgstr "inconnu"
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr "valeur inconnue"
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
 msgstr "non versionné"
 
-#: ../main_frame.cpp:329
-msgid "wxString Creation&Tracing Test"
-msgstr "wxString Creation&Tracing Test"
+#~ msgid "Action"
+#~ msgstr "Action"
+
+#~ msgid "Checkout Test"
+#~ msgstr "Test de récupération"
+
+#~ msgid "Copied from Path"
+#~ msgstr "Copié depuis le chemin"
+
+#~ msgid "Copied from Rev"
+#~ msgstr "Copié depuis la révision"
+
+#~ msgid "Destination file"
+#~ msgstr "Fichier de destination"
+
+#~ msgid "Destination path"
+#~ msgstr "Chemin de destination"
+
+#~ msgid "EOL:"
+#~ msgstr "EOL :"
+
+#~ msgid "Enter log message"
+#~ msgstr "Entrer un message de log"
+
+#~ msgid "Enter the local path where you want the code be exported."
+#~ msgstr "Entrer le chemin local vers lequel le code sera exporté."
+
+#~ msgid ""
+#~ "Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
+#~ "files."
+#~ msgstr ""
+#~ "Quels caratère(s) de fin de ligne voulez vous dans les fichiers exportés ?"
+
+#~ msgid "File path required when importing a file!"
+#~ msgstr "Un chemin est nécessaire pour importer un fichier!"
+
+#~ msgid "First path or URL is required for merge!"
+#~ msgstr "Un Premier chemin ou une URL est nécessaire pour fusionner!"
+
+#~ msgid ""
+#~ "Invalid selection. At least one revisions is needed for diff and no more "
+#~ "than two."
+#~ msgstr ""
+#~ "Sélection invalide. Au moins une révision est nécessaire pour diff et pas "
+#~ "plus de deux."
+
+#~ msgid "Invalid selection. Exactly two revisions needed for merge."
+#~ msgstr "Sélection invalide. Deux révisions sont nécessaires pour fusionner"
+
+#~ msgid "Invalid selection. Only one revision may be selected for annotate"
+#~ msgstr ""
+#~ "Sélection invalide. Une seule révision peut être sélectionnée pour annoter"
+
+#~ msgid "Listener Test"
+#~ msgstr "Listener Test"
+
+#~ msgid "Locate help"
+#~ msgstr "Localiser l'aide"
+
+#~ msgid "Locate tips"
+#~ msgstr "Localiser les astuces"
+
+#~ msgid "Locate tips file"
+#~ msgstr "Localiser le fichier astuces"
+
+#~ msgid "Log Message:"
+#~ msgstr "Message de log :"
+
+#~ msgid "Merge revisions"
+#~ msgstr "Fusionner révisions"
+
+#~ msgid "No"
+#~ msgstr "Non"
+
+#~ msgid ""
+#~ "No help file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Aucun fichier d'aide n'a été choisi, voulez vous être\n"
+#~ "de nouveau interrogé lors du prochain démarrage?"
+
+#~ msgid ""
+#~ "No tips file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Aucune fichier d'astuce n'a été choisi, voulez vous être\n"
+#~ "de nouveau interrogé au prochain démarrage?"
+
+#~ msgid "RapidSVN Help: %s"
+#~ msgstr "Aide RapidSVN : %s"
+
+#~ msgid "Revision must be an unsigned number!"
+#~ msgstr "La révision doit être positive!"
+
+#~ msgid "SSL Certificate"
+#~ msgstr "Certificat SSL"
+
+#~ msgid "Second path or URL is required for merge!"
+#~ msgstr "Un second chemin ou une URL est nécessaire pour fusionner!"
+
+#~ msgid "Second working copy or URL"
+#~ msgstr "Seconde copie de travail ou URL"
+
+#~ msgid "Tree"
+#~ msgstr "Arbre"
+
+#~ msgid "Yes"
+#~ msgstr "Oui"
+
+#~ msgid "wxString Creation&Tracing Test"
+#~ msgstr "wxString Creation&Tracing Test"
 
 #~ msgid "Information"
 #~ msgstr "Information"

--- a/librapidsvn/src/locale/hu/rapidsvn.po
+++ b/librapidsvn/src/locale/hu/rapidsvn.po
@@ -8,10 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rapidsvn 0.12.0 v02\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-10-13 13:10+0200\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: 2010-06-19 11:16+0100\n"
 "Last-Translator: csola48 <csola48@gmail.com>\n"
 "Language-Team: magyar <csola48@gmail.com>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -24,22 +25,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr "%s  kód: %ld"
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, c-format
 msgid "%s Version %s"
 msgstr "%s Verzió %s"
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, c-format
 msgid "%s Version %s Revision %d"
 msgstr "%s verzió %s revízió %d"
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr "%x %X"
 
-#: ../rapidsvn_frame.cpp:329
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr "&Névjegy..."
 
@@ -47,27 +48,32 @@ msgstr "&Névjegy..."
 msgid "&Add\tINS"
 msgstr "&Hozzáadás\tINS"
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr "&Meglévő munkapéldány hozzáadása..."
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr "&Jegyzetek"
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 msgid "&Annotate..."
 msgstr "&Jegyzetek..."
 
-#: ../rapidsvn_frame.cpp:350
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr "&Könyvjelzők"
 
-#: ../log_dlg.cpp:359
-msgid "&Close"
-msgstr "&Bezár"
+#: ../rapidsvn_generated.cpp:549
+#, fuzzy
+msgid "&Browse"
+msgstr "Böngészik"
 
-#: ../rapidsvn_frame.cpp:322
+#: ../rapidsvn_generated.cpp:528
+msgid "&Compatible with:"
+msgstr ""
+
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr "&Tartalom\tF1"
 
@@ -75,7 +81,7 @@ msgstr "&Tartalom\tF1"
 msgid "&Copy...\tF5"
 msgstr "Más&olás...\tF5"
 
-#: ../rapidsvn_frame.cpp:296
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr "&Létrehoz..."
 
@@ -83,12 +89,11 @@ msgstr "&Létrehoz..."
 msgid "&Delete\tDEL"
 msgstr "Tö&rlés\tDEL"
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr "&Töröl..."
 
-#: ../log_dlg.cpp:362
-#: ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 msgid "&Diff"
 msgstr "Össze&hasonlítás"
 
@@ -100,44 +105,48 @@ msgstr "Összehasonlítás a &BASE-hoz...\tCTRL+B"
 msgid "&Diff to Head...\tCTRL+H"
 msgstr "Összehasonlítás a &HEAD-hez...\tCTRL+H"
 
+#: ../utils.cpp:220
+#, fuzzy
+msgid "&Diff..."
+msgstr "Össze&hasonlítás"
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr "Össze&hasonlítás...\tCTRL+D"
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr "Könyvjelző &szerkesztése..."
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr "Sz&erkeszt..."
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr "&Szerkesztés...\tF3"
 
-#: ../rapidsvn_frame.cpp:294
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr "&Export...\tCTRL-E"
 
-#: ../rapidsvn_frame.cpp:351
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr "&Extrák"
 
-#: ../rapidsvn_frame.cpp:345
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr "&Fájl"
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 msgid "&Files to commit"
 msgstr "&Fájlok beküldése"
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 msgid "&Get"
 msgstr "&Rajta"
 
-#: ../rapidsvn_frame.cpp:229
-#: ../rapidsvn_frame.cpp:352
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr "&Súgó"
 
@@ -145,11 +154,11 @@ msgstr "&Súgó"
 msgid "&Ignore\tCTRL-DEL"
 msgstr "&Mellőz\tCTRL-DEL"
 
-#: ../rapidsvn_frame.cpp:293
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr "&Import...\tCTRL-I"
 
-#: ../rapidsvn_frame.cpp:323
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr "&Index\tShift+F1"
 
@@ -157,27 +166,51 @@ msgstr "&Index\tShift+F1"
 msgid "&Info..."
 msgstr "&Információ..."
 
+#: ../rapidsvn_generated.cpp:540
+msgid "&Load configuration from directory (optional):"
+msgstr ""
+
 #: ../utils.cpp:198
 msgid "&Lock..."
 msgstr "&Zárás..."
+
+#: ../utils.cpp:222
+#, fuzzy
+msgid "&Log..."
+msgstr "&Napló...\tCTRL-L"
 
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr "&Napló...\tCTRL-L"
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 msgid "&Merge"
 msgstr "Össze&fűzés"
 
-#: ../rapidsvn_frame.cpp:348
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr "&Módosít"
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:897
+#, fuzzy
+msgid "&Name"
+msgstr "Név"
+
+#: ../rapidsvn_generated.cpp:499
+#, fuzzy
+msgid "&Name of the new repository:"
+msgstr "Új tároló létrehozása..."
+
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr "Ú&j..."
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+#, fuzzy
+msgid "&Password"
+msgstr "Jelszó"
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr "&Állandó"
 
@@ -185,72 +218,90 @@ msgstr "&Állandó"
 msgid "&Properties...\tCTRL-P"
 msgstr "&Tulajdonságok...\tCTRL-P"
 
-#: ../rapidsvn_frame.cpp:349
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr "&Lekérdezés"
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 msgid "&Recent entries:"
 msgstr "&Jelen bejegyzések:"
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 msgid "&Remove Bookmark"
 msgstr "Könyvjelző &eltávolítása"
 
-#: ../rapidsvn_frame.cpp:347
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr "&Tároló"
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+#, fuzzy
+msgid "&Revision"
+msgstr "Revízió"
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr "&Megállás"
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr "Tároló &URL kapcsolása..."
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr "&Ideiglenes"
 
-#: ../rapidsvn_frame.cpp:354
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr "&Próbák"
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr "&Kapcsoló"
+
+#: ../rapidsvn_generated.cpp:473
+msgid "&Type:"
+msgstr ""
 
 #: ../utils.cpp:199
 msgid "&Unlock"
 msgstr "N&yitás"
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr "&Frissítés...\tCTRL-U"
 
-#: ../log_dlg.cpp:360
-#: ../rapidsvn_frame.cpp:346
+#: ../rapidsvn_generated.cpp:89
+#, fuzzy
+msgid "&Username"
+msgstr "Átnevezés"
+
+#: ../rapidsvn_generated.cpp:904
+#, fuzzy
+msgid "&Value"
+msgstr "Érték"
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr "&Nézet"
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr "&Nézet..."
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr "- A tanúsítványban ismeretlen hiba van."
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr "- A tanúsítvány lejárt"
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr "- A tanúsítvány host neve nem egyezik"
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
@@ -258,80 +309,88 @@ msgstr ""
 "- A tanúsítvány nem felelt meg a biztonsági ellenőrzésen.\n"
 "  Használja az ujjlenyomatot érvényesíteni a tanúsítványt manuálisan!"
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
 msgstr "- A tanúsítvány még nem érvényes."
 
-#: ../file_info.cpp:102
-#: ../file_info.cpp:110
-#: ../file_info.cpp:195
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+#, fuzzy
+msgid "..."
+msgstr "Ú&j..."
+
+#: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
 msgid "<None>"
 msgstr "<Egyik sem>"
 
-#: ../about_dlg.cpp:68
+#: ../create_repos_dlg.cpp:131
+msgid "A directory of this name exists already"
+msgstr ""
+
+#: ../create_repos_dlg.cpp:136
+msgid "A file of this name exists already"
+msgstr ""
+
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr "ANSI"
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr "Névjegy %s"
 
-#: ../log_dlg.cpp:242
-msgid "Action"
-msgstr "Akció"
-
-#: ../add_action.cpp:37
-#: ../add_recursive_action.cpp:37
-#: ../listener.cpp:353
-#: ../rapidsvn_frame.cpp:1627
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr "Meglévő &tároló hozzáadása"
+
+#: ../rapidsvn_generated.cpp:516
+msgid "Add a bookmark for the new repository"
+msgstr ""
 
 #: ../utils.cpp:173
 msgid "Add r&ecursive"
 msgstr "&Rekurzivitás hozzáadása"
 
-#: ../rapidsvn_frame.cpp:553
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr "Kiválasztott hozzáadása"
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr "Hozzáadás könyvjelzőhöz"
 
-#: ../listener.cpp:362
-#: ../listener.cpp:369
-#: ../rapidsvn_frame.cpp:1636
-#: ../rapidsvn_frame.cpp:1643
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr "Hozzáadva"
 
-#: ../rapidsvn_frame.cpp:2146
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr "Tároló hozzáadása a könyvjelzőhöz '%s'"
 
-#: ../rapidsvn_frame.cpp:2117
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr "Munkakópia hozzáadása a könyvjelzőhöz '%s'"
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr "Könyvtár hozzáadása a tárolóhoz: %s"
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, c-format
 msgid "Adding file to repository: %s"
 msgstr "Fájl hozzáadása a tárolóhoz: %s"
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr "Érintett fájl/könyvtár"
 
@@ -339,21 +398,19 @@ msgstr "Érintett fájl/könyvtár"
 msgid "All files|*"
 msgstr "Összes fájl|*"
 
-#: ../rapidsvn_frame.cpp:1501
-#: ../rapidsvn_frame.cpp:1520
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr "Hiba a böngésző indulásakor"
 
-#: ../rapidsvn_frame.cpp:1488
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr "Hiba az érvényesség ellenőrzésekor"
 
-#: ../annotate_action.cpp:80
-#: ../annotate_action.cpp:81
+#: ../annotate_action.cpp:80 ../annotate_action.cpp:81
 msgid "Annotate"
 msgstr "Jegyzetek"
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -372,13 +429,11 @@ msgstr ""
 "\n"
 "  %s?"
 
-#: ../auth_dlg.cpp:117
-#: ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr "Hitelesítés"
 
-#: ../annotate_dlg.cpp:48
-#: ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr "Szerző"
 
@@ -386,7 +441,11 @@ msgstr "Szerző"
 msgid "BASE"
 msgstr "BASE"
 
-#: ../rapidsvn_frame.cpp:2183
+#: ../rapidsvn_generated.cpp:477
+msgid "BerkeleyDB"
+msgstr ""
+
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr "Könyvjelző"
 
@@ -394,18 +453,17 @@ msgstr "Könyvjelző"
 msgid "Bookmarks"
 msgstr "Könyvjelzők"
 
-#: ../rapidsvn_frame.cpp:574
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr "Változások történtek a tárolóból a munka másolatba"
 
-#: ../rapidsvn_generated.cpp:57
-#: ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119
-#: ../rapidsvn_generated.cpp:146
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr "Böngészik"
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -416,57 +474,44 @@ msgstr ""
 "wxWidgets %d.%d.%d (%s)\n"
 "Subversion %d.%d.%d\n"
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr "CR (MacOS)"
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr "CRLF (Windows)"
 
-#: ../auth_dlg.cpp:73
-#: ../cert_dlg.cpp:138
-#: ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57
-#: ../destination_dlg.cpp:90
-#: ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146
-#: ../import_dlg.cpp:130
-#: ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342
-#: ../lock_dlg.cpp:61
-#: ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195
-#: ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409
-#: ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564
-#: ../switch_dlg.cpp:139
-#: ../unlock_dlg.cpp:58
-#: ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+#, fuzzy
+msgid "Certificate information:"
 msgstr "Tanúsítvány információk:"
 
-#: ../rapidsvn_frame.cpp:295
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr "Elle&nőrzés...\tCTRL-O"
 
 #: ../checkout_action.cpp:40
-#: ../checkout_dlg.cpp:250
 msgid "Checkout"
 msgstr "Ellenörzés"
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
 msgstr "Új munka másolat ellenőrzése..."
-
-#: ../rapidsvn_frame.cpp:337
-msgid "Checkout Test"
-msgstr "Ellenőrző teszt"
 
 #: ../columns.cpp:58
 msgid "Checksum"
@@ -477,26 +522,28 @@ msgstr "Ellenőrző összeg"
 msgid "Checksum: %s"
 msgstr "Ellenőrző összeg: %s"
 
-#: ../cleanup_action.cpp:39
-#: ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr "Tisztítás"
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+#, fuzzy
+msgid "Close"
+msgstr "&Bezár"
+
+#: ../utils.cpp:297
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr "&Beküldés...\tCTRL-ENTER"
 
-#: ../rapidsvn_frame.cpp:271
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr "Oszlop"
 
-#: ../rapidsvn_generated.cpp:275
-#: ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr "Kombó!"
 
-#: ../commit_action.cpp:42
-#: ../commit_dlg.cpp:45
+#: ../commit_action.cpp:42 ../commit_dlg.cpp:45
 msgid "Commit"
 msgstr "Beküldés"
 
@@ -504,11 +551,11 @@ msgstr "Beküldés"
 msgid "Commit Log Message"
 msgstr "Napló bejegyzés beküldése"
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr "Napló bejegyzés beküldése: az alap jellemzően a jelenlegi"
 
-#: ../rapidsvn_frame.cpp:583
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr "Beküldés kiválasztása"
 
@@ -516,9 +563,19 @@ msgstr "Beküldés kiválasztása"
 msgid "Committed revision"
 msgstr "Revízió beküldve"
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
 msgstr "Összehasonlítás:"
+
+#: ../listener.cpp:496
+#, fuzzy, c-format
+msgid "Completed %s at revision %d"
+msgstr "Revízió beküldve"
+
+#: ../listener.cpp:486
+#, fuzzy, c-format
+msgid "Completed at revision %d"
+msgstr "Revízió beküldve"
 
 #: ../columns.cpp:64
 msgid "Conflict BASE"
@@ -552,6 +609,11 @@ msgstr "Munka konfliktus"
 msgid "Conflict Working File: %s"
 msgstr "Konfliktus a munka fájlban: %s"
 
+#: ../listener.cpp:307
+#, fuzzy
+msgid "Conflicted"
+msgstr "ellentétes"
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr "Másolva"
@@ -566,31 +628,21 @@ msgstr "Másolva a revízióból: %ld"
 msgid "Copied From URL: %s"
 msgstr "Másolva az URL-ből: %s"
 
-#: ../log_dlg.cpp:244
-msgid "Copied from Path"
-msgstr "Másolva az útvonalból"
-
-#: ../log_dlg.cpp:245
-msgid "Copied from Rev"
-msgstr "Másolva a revízióból"
-
-#: ../dnd_dlg.cpp:108
-#: ../listener.cpp:354
-#: ../move_action.cpp:44
-#: ../rapidsvn_frame.cpp:1628
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr "Másolás"
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 msgid "Copy/Move"
 msgstr "Másolás/Mozgatás"
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, c-format
 msgid "Copying file into working directory: %s"
 msgstr "Fájl másolása a munka könyvtárba: %s"
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, c-format
 msgid "Copying file: %s"
 msgstr "Fájl másolása: %s"
@@ -600,62 +652,59 @@ msgstr "Fájl másolása: %s"
 msgid "Could not set working directory to %s"
 msgstr "Nem állítható be a munka könyvtár: %s"
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr "Új tároló létrehozása..."
 
-#: ../columns.cpp:54
-#: ../log_dlg.cpp:165
+#: ../create_repos_action.cpp:37
+#, fuzzy
+msgid "Create Repository"
+msgstr "Új tároló létrehozása..."
+
+#: ../rapidsvn_generated.cpp:485
+#, fuzzy
+msgid "Create repository in &directory:"
+msgstr "Célkönyvtár kiválasztása"
+
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr "Dátum"
 
-#: ../rapidsvn_generated.cpp:265
-#: ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr "Dátum:"
 
-#: ../delete_action.cpp:40
-#: ../delete_dlg.cpp:79
-#: ../listener.cpp:355
-#: ../rapidsvn_frame.cpp:1629
+#: ../rapidsvn_generated.cpp:532
+msgid "Default"
+msgstr ""
+
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../rapidsvn_frame.cpp:564
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr "Fájlok és könyvtárak törlése a verzió kontrollból"
 
-#: ../rapidsvn_frame.cpp:563
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr "Kiválasztottak törlése"
 
-#: ../listener.cpp:361
-#: ../listener.cpp:370
-#: ../rapidsvn_frame.cpp:1635
-#: ../rapidsvn_frame.cpp:1644
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr "Törölt"
 
-#: ../checkout_dlg.cpp:72
-#: ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
 msgstr "Cél könyvtár"
 
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr "Cél fájl"
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
-msgstr "Cél útvonal"
-
-#: ../diff_action.cpp:191
-#: ../diff_action.cpp:197
-#: ../diff_dlg.cpp:179
+#: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr "Összehasonlítás"
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 msgid "Diff Tool"
 msgstr "Összehasonlító eszköz"
 
@@ -675,109 +724,115 @@ msgstr "Összehasonlítás egy másik revízióhoz/dátumhoz"
 msgid "Diff two revisions/dates"
 msgstr "Összehasonlítás két revízió/dátum között"
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
 msgstr "Különböző bejelentkezés minden könyvjelzőhöz a könyvjelző listában"
+
+#: ../rapidsvn_generated.cpp:1296
+#, fuzzy
+msgid "Directory"
+msgstr "Könyvtár:"
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr "Könyvtár:"
 
-#: ../rapidsvn_frame.cpp:507
+#: ../rapidsvn_generated.cpp:554
+msgid "Disable automatic Log removal"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:557
+msgid "Disable fsync when committing database transactions"
+msgstr ""
+
+#: ../main_frame_helper.cpp:179
 msgid "Display conflicted files/directories"
 msgstr "Konfliktusos fájlok/könyvtárak bemutatása"
 
-#: ../rapidsvn_frame.cpp:620
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr "Bemutatás a kiválasztott bejegyzésekről"
 
-#: ../rapidsvn_frame.cpp:501
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr "Bemutatása a módosított fájloknak/könyvtáraknak"
 
-#: ../rapidsvn_frame.cpp:495
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr "Bemutatása a nem módosított fájloknak/könyvtáraknak"
 
-#: ../rapidsvn_frame.cpp:489
+#: ../main_frame_helper.cpp:161
 msgid "Display unversioned files/directories"
 msgstr "Bemutatása a verzión kívűli fájloknak/könyvtáraknak"
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr "Akarja törölni a kijelölt fájlokat/könyvtárakat?"
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr "Vissza akarja vonni a helyi cseréket?"
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr "Akarja megnyitni a kijelölt fájlokat/könyvtárakat?"
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr "&Kilépés\tCTRL-Q"
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr "EOL:"
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: ../rapidsvn_frame.cpp:2183
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr "Könyvjelző szerkesztése"
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr "Tulajdonságok szerkesztése"
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "Edit..."
+msgstr "Sz&erkeszt..."
+
+#: ../rapidsvn_generated.cpp:1306
+#, fuzzy
+msgid "End &log message"
+msgstr "Napló&bejegyzés"
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 msgid "Enter &log message"
 msgstr "Napló&bejegyzés"
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr "Megjegyzés megadása ehhez a lezáráshoz"
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr "Naplóbejegyzés"
+#: ../create_repos_dlg.cpp:126
+#, fuzzy
+msgid "Enter a name for the repository"
+msgstr "Megjegyzés megadása ehhez a lezáráshoz"
 
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr "Új név megadása:"
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr "Adja meg a helyi útvonalat, ahová akarja a kódot exportálni."
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
 msgstr "Adja meg a helyi útvonalat, ahol akarja a kódot ellenőrizni."
 
-#: ../checkout_dlg.cpp:70
-#: ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr "Adja meg a tároló URL-jét (nem helyi útvonal)."
 
-#: ../export_dlg.cpp:143
-msgid "Enter what kind of symbol(s) do you want as EOL (end of line) in exported files."
-msgstr "Adja meg, milyen jelet akar használni sorvégnek (EOL) az exportált fájlokban."
-
-#: ../import_dlg.cpp:178
-#: ../import_dlg.cpp:191
-#: ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494
-#: ../log_dlg.cpp:530
-#: ../merge_dlg.cpp:52
-#: ../merge_dlg.cpp:91
-#: ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
-#: ../rapidsvn_frame.cpp:2107
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr "Hiba"
 
@@ -785,57 +840,64 @@ msgstr "Hiba"
 msgid "Error retrieving status:"
 msgstr "Hiba a visszavont státusznál:"
 
-#: ../property_dlg.cpp:120
+#: ../create_repos_action.cpp:111
+msgid "Error running svnadmin"
+msgstr ""
+
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr "Hiba a tulajdonságok beállításánál"
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, fuzzy, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr "Hiba a tulajdonságok beállításánál"
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr "Hiba a szerver minősítés ellenőrzésénél '%s':"
 
-#: ../simple_worker.cpp:216
-#: ../threaded_worker.cpp:178
+#: ../simple_worker.cpp:216 ../threaded_worker.cpp:178
 msgid "Error while performing action."
 msgstr "Hiba a végrehajtott akció közben."
 
-#: ../simple_worker.cpp:206
-#: ../threaded_worker.cpp:165
+#: ../simple_worker.cpp:206 ../threaded_worker.cpp:165
 #, c-format
 msgid "Error while performing action: %s"
 msgstr "Hiba a végrehajtott akció közben: %s"
 
-#: ../simple_worker.cpp:167
-#: ../threaded_worker.cpp:286
+#: ../simple_worker.cpp:167 ../threaded_worker.cpp:286
 msgid "Error while preparing action."
 msgstr "Hiba az előkészített akció közben."
 
-#: ../simple_worker.cpp:161
-#: ../threaded_worker.cpp:276
+#: ../simple_worker.cpp:161 ../threaded_worker.cpp:276
 #, c-format
 msgid "Error while preparing action: %s"
 msgstr "Hiba az előkészített akció közben: %s"
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr "Hiba a fájllista frissítése közben (%s)"
 
-#: ../rapidsvn_frame.cpp:1137
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr "Hiba a fájllista frissítése közben"
 
-#: ../rapidsvn_frame.cpp:1124
+#: ../main_frame.cpp:917
 #, c-format
 msgid "Error while updating filelist (%s)"
 msgstr "Hiba a fájllista frissítése közben (%s)"
 
-#: ../rapidsvn_frame.cpp:723
+#: ../main_frame.cpp:561
 #, c-format
 msgid "Error: %s\n"
 msgstr "Hiba: %s\n"
 
-#: ../rapidsvn_frame.cpp:2041
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
 msgstr "Kivétel következett be a fájllista frissítése közben"
 
@@ -852,8 +914,7 @@ msgstr "Végrehajtás"
 msgid "Execute diff tool: %s"
 msgstr "Összehasonlító eszköz végrehajtása: %s"
 
-#: ../external_program_action.cpp:140
-#: ../view_action.cpp:121
+#: ../external_program_action.cpp:140 ../view_action.cpp:121
 #, c-format
 msgid "Execute editor: %s"
 msgstr "Szerkesztő: %s"
@@ -868,18 +929,16 @@ msgstr "Fájl kereső: %s"
 msgid "Execute merge tool: %s"
 msgstr "Összefűző eszköz: %s"
 
-#: ../simple_worker.cpp:175
-#: ../threaded_worker.cpp:143
+#: ../simple_worker.cpp:175 ../threaded_worker.cpp:143
 #, c-format
 msgid "Execute: %s"
 msgstr "Végrehajtás: %s"
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr "Keres...\tF2"
 
-#: ../export_action.cpp:40
-#: ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr "Export"
 
@@ -887,59 +946,60 @@ msgstr "Export"
 msgid "Extension"
 msgstr "Kiterjesztés"
 
-#: ../listener.cpp:376
-#: ../rapidsvn_frame.cpp:1650
+#: ../listener.cpp:405
+#, fuzzy
+msgid "External"
+msgstr "külső"
+
+#: ../rapidsvn_generated.cpp:477
+msgid "FSFS"
+msgstr ""
+
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr "Sikertelen zárás"
 
-#: ../listener.cpp:377
-#: ../rapidsvn_frame.cpp:1651
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr "Sikertelen nyitás"
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr "Fájl"
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr "Szükséges a fájl útvonala importáláskor!"
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr "Ujjlenyomat: "
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr "Első útvonal vagy URL az igényelt összefűzéshez!"
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr "Első munka másolat vagy URL"
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr "További információk:"
 
-#: ../destination_dlg.cpp:80
-#: ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr "Kényszerít"
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr "Kényszerített eltávolítás"
 
-#: ../export_dlg.cpp:123
-msgid "Force to execute even if destination directory not empty, causes overwriting of files with the same names."
-msgstr "Kényszerített végrehajtás akkor is, ha a célkönyvtár nem üres és így a meglévő fájlok felülírását okozza."
+#: ../export_dlg.cpp:75
+msgid ""
+"Force to execute even if destination directory not empty, causes overwriting "
+"of files with the same names."
+msgstr ""
+"Kényszerített végrehajtás akkor is, ha a célkönyvtár nem üres és így a "
+"meglévő fájlok felülírását okozza."
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
 msgstr "Kényszerített nyitás funkció, ha nem ön végezte a zárást."
 
-#: ../rapidsvn_generated.cpp:41
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr "Általános"
 
@@ -952,48 +1012,62 @@ msgstr "Fájl %s rev. %s"
 msgid "HEAD"
 msgstr "HEAD"
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+#, fuzzy
+msgid "Help"
+msgstr "&Súgó"
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr "Előzmények: %d revíziók"
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr "Hostnév:"
 
-#: ../checkout_dlg.cpp:88
-#: ../export_dlg.cpp:91
-msgid "If not using the latest version of the files, specify which revision to use here."
-msgstr "Ha nem a fájlok utolsó verzióját használja, adja meg melyik revízió legyen használva."
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
+msgid ""
+"If not using the latest version of the files, specify which revision to use "
+"here."
+msgstr ""
+"Ha nem a fájlok utolsó verzióját használja, adja meg melyik revízió legyen "
+"használva."
 
-#: ../checkout_dlg.cpp:102
-#: ../export_dlg.cpp:105
-msgid "If the files were renamed or moved some time, specify which peg revision to use here."
-msgstr "Ha a fájlokat átnevezte vagy valamikor áthelyezte, adja meg melyik revízió legyen használva."
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
+msgid ""
+"If the files were renamed or moved some time, specify which peg revision to "
+"use here."
+msgstr ""
+"Ha a fájlokat átnevezte vagy valamikor áthelyezte, adja meg melyik revízió "
+"legyen használva."
 
 #: ../ignore_action.cpp:40
 msgid "Ignore"
 msgstr "Mellőz"
 
-#: ../rapidsvn_frame.cpp:281
-#: ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr "Külsők kihagyása"
 
-#: ../checkout_dlg.cpp:122
-#: ../export_dlg.cpp:126
-#: ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr "Külsők kihagyása"
 
-#: ../dnd_dlg.cpp:37
-#: ../dnd_dlg.cpp:97
-#: ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr "Import"
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+#, fuzzy
+msgid "Import &Path"
+msgstr "Import"
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr "Fájl importálása a tárolóba: %s"
@@ -1002,27 +1076,23 @@ msgstr "Fájl importálása a tárolóba: %s"
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr "Interaktív &döntés...\tCTRL-T"
 
-#: ../rapidsvn_frame.cpp:276
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr "Módosított következmények jelzése"
 
-#: ../rapidsvn_frame.cpp:2226
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr "Információ"
 
-#: ../rapidsvn_frame.cpp:619
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr "Információ kiválasztása"
-
-#: ../rapidsvn_frame.cpp:1716
-msgid "Information"
-msgstr "Információ"
 
 #: ../threaded_worker.cpp:245
 msgid "Internal Error: There is another action running"
 msgstr "Belső hiba: egy másik akció is fut"
 
-#: ../rapidsvn_frame.cpp:1784
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr "Belső hiba: nincs kliens adat az akcióhoz megadva!"
 
@@ -1034,27 +1104,16 @@ msgstr "Belső hiba: nincs használható tartalom"
 msgid "Invalid revision number detected"
 msgstr "Érvénytelen verzió szám érzékelve"
 
-#: ../log_dlg.cpp:478
-msgid "Invalid selection. At least one revisions is needed for diff and no more than two."
-msgstr "Érvénytelen választás. Legkevesebb egy és nem több, mint két revíziót szükséges választani az összehasonlításhoz."
-
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr "Érvénytelen választás. Pontosan két revíziót szükséges összefűzni."
-
-#: ../log_dlg.cpp:529
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr "Érvénytelen választás. Csak egy revíziót lehet választani a jegyzethez"
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
+#: ../rapidsvn_generated.cpp:159
+#, fuzzy
+msgid "Issuer:"
 msgstr "Eredmény:"
 
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 msgid "Keep Locks"
 msgstr "Zárva tart"
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr "LF (Unix)"
 
@@ -1076,20 +1135,16 @@ msgstr "Dátum utolsó változása"
 msgid "Last Changed Rev: %ld"
 msgstr "Felülvizsgálat utolsó változása: %ld"
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr "Sor"
 
-#: ../rapidsvn_frame.cpp:336
-msgid "Listener Test"
-msgstr "Hallgató teszt"
-
-#: ../filelist_ctrl.cpp:1018
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr "Bejegyzések listázása '%s'"
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1102,21 +1157,7 @@ msgstr ""
 "Rendszer neve: %s\n"
 "Canonical megnevezés: %s\n"
 
-#: ../rapidsvn_app.cpp:198
-#: ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr "Súgó helye"
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr "Tippek helye"
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr "Tipp fájlok helye"
-
 #: ../lock_action.cpp:40
-#: ../lock_dlg.cpp:100
 msgid "Lock"
 msgstr "Zárolás"
 
@@ -1151,32 +1192,27 @@ msgstr "Zárolt tulajdonos: %s"
 msgid "Lock Token: %s"
 msgstr "Zárolt token: %s"
 
-#: ../listener.cpp:374
-#: ../rapidsvn_frame.cpp:1648
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr "Zárolt"
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr "Napló"
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr "Napló előzmények"
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr "Napló bejegyzés"
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr "Napló bejegyzés:"
-
-#: ../rapidsvn_frame.cpp:629
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr "Napló választás"
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr "Bejelentkezés..."
 
@@ -1201,39 +1237,40 @@ msgstr "Könyvtár &készítése...\tF7"
 msgid "Make directory"
 msgstr "Könyvtár készítése"
 
-#: ../merge_action.cpp:38
-#: ../merge_action.cpp:44
-#: ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr "Összefűzés"
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 msgid "Merge Tool"
 msgstr "Összefűzés eszközök"
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
-msgstr "Összefűzés átdolgozások"
-
-#: ../rapidsvn_frame.cpp:300
+#: ../main_frame.cpp:303
 msgid "Merge..."
 msgstr "Összefűzés..."
+
+#: ../listener.cpp:308
+#, fuzzy
+msgid "Merged"
+msgstr "Összefűzés"
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr "Mkdir"
 
-#: ../listener.cpp:368
-#: ../rapidsvn_frame.cpp:1642
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr "Módosított"
 
-#: ../dnd_dlg.cpp:104
-#: ../move_action.cpp:42
+#: ../rapidsvn_generated.cpp:563
+msgid "More options"
+msgstr ""
+
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr "Mozgatás"
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, c-format
 msgid "Moving file: %s"
 msgstr "Fájl mozgatása: %s"
@@ -1242,10 +1279,16 @@ msgstr "Fájl mozgatása: %s"
 msgid "Multiple Files"
 msgstr "Fájlok többszörözése"
 
-#: ../columns.cpp:45
-#: ../listed_dlg.cpp:75
-#: ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr "Név"
 
@@ -1254,43 +1297,24 @@ msgstr "Név"
 msgid "Name: %s"
 msgstr "Név: %s"
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
 msgstr "Új tulajdonság"
-
-#: ../revert_dlg.cpp:57
-msgid "No"
-msgstr "Nem"
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr "Nincs kijelölt összehasonlító eszköz a beállításokban"
 
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr "Amennyiben a kiválasztott "
-
 #: ../userresolve_action.cpp:62
 msgid "No merge tool set in the preferences"
 msgstr "Nincs összefűző eszköz kijelölve a beállításokban"
-
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Nincs tipp fájl választás kijelölve. Szeretné, ha a \n"
-"következő indításnál ismét megkérdezné?"
 
 #: ../file_info.cpp:118
 #, c-format
 msgid "Node Kind: %s"
 msgstr "Node fajta: %s"
 
-#: ../checkout_dlg.cpp:106
-#: ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr "Nem meghatározott"
 
@@ -1298,103 +1322,66 @@ msgstr "Nem meghatározott"
 msgid "Not versioned"
 msgstr "Nincs változat"
 
-#: ../about_dlg.cpp:114
-#: ../annotate_dlg.cpp:42
-#: ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126
-#: ../delete_dlg.cpp:54
-#: ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145
-#: ../import_dlg.cpp:128
-#: ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341
-#: ../lock_dlg.cpp:60
-#: ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191
-#: ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405
-#: ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560
-#: ../report_dlg.cpp:57
-#: ../switch_dlg.cpp:137
-#: ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr "OK"
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr "Megnyitás..."
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr "Felülírás"
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr "Jelszó"
-
 #: ../columns.cpp:46
-#: ../import_dlg.cpp:80
-#: ../log_dlg.cpp:243
 msgid "Path"
 msgstr "Útvonal"
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+#, fuzzy
+msgid "Path &type"
 msgstr "Útvonal típusa:"
 
-#: ../checkout_dlg.cpp:97
-#: ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr "Revizió alkalom"
-
-#: ../rapidsvn_frame.cpp:1709
-msgid ""
-"Please use the command line utility 'svnadmin'\n"
-"to create a new repository.\n"
-"\n"
-"This command line utility is not part of the\n"
-"RapidSVN distribution.\n"
-"\n"
-"More information about subversion:\n"
-"http://svnbook.red-bean.com/\n"
-"http://subversion.tigris.org"
-msgstr ""
-"Új tároló létrehozásához használja\n"
-"terminálban az 'svnadmin' parancsot.\n"
-"\n"
-"Ez a parancs nem része a RapidSVN kiadásának.\n"
-"\n"
-"Több információ a subversionról:\n"
-"http://svnbook.red-bean.com/\n"
-"http://subversion.tigris.org"
 
 #: ../preferences_dlg.cpp:48
 msgid "Preferences"
 msgstr "Beállítások"
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr "Beállítások..."
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr "Program argument (%1=alap, %2=övék %3=enyém %4=eredmény):"
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr "Program argument (%1=fájl1, %2=fájl2):"
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr "Program argument (%1=választott könyvtár):"
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr "Program argument (%1=választott fájl):"
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr "Programok"
 
@@ -1410,7 +1397,7 @@ msgstr "Tulajd. állapota"
 msgid "Properties Last Updated"
 msgstr "Utolsó frissítés tulajdonságai"
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr "Tulajdonságok:"
 
@@ -1422,22 +1409,21 @@ msgstr "Tulajdonság"
 msgid "Property Editor"
 msgstr "Tulajdonság szerkesztő"
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr "Ideiglenes fájlok eltávolítása a programból való kilépéskor."
 
-#: ../rapidsvn_frame.cpp:554
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr "Helyezze a fájlokat és könyvtárakat revízió ellenőrzés alá"
 
-#: ../rapidsvn_frame.cpp:690
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
+msgstr ""
+
+#: ../main_frame.cpp:528
 msgid "RapidSVN Error"
 msgstr "RapidSVN hiba"
-
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
-msgstr "RapidSVN súgó: %s"
 
 #: ../utils.cpp:192
 msgid "Re&name...\tCTRL-N"
@@ -1451,56 +1437,51 @@ msgstr "Döntés &ellentétek\tCTRL-S"
 msgid "Re&vert\tCTRL-V"
 msgstr "&Visszavon\tCTRL-V"
 
-#: ../filelist_ctrl.cpp:1088
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr "Kész"
 
-#: ../rapidsvn_frame.cpp:1764
-#: ../rapidsvn_frame.cpp:1808
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr "Kész\n"
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr "Jelen bejegyzés:"
 
-#: ../checkout_dlg.cpp:111
-#: ../export_dlg.cpp:114
-#: ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201
-#: ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547
-#: ../revert_dlg.cpp:49
-#: ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr "Rekurzív"
 
-#: ../rapidsvn_frame.cpp:518
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr "Frissítés"
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr "Nézet frissítése\tCTRL-R"
 
-#: ../rapidsvn_frame.cpp:519
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr "Fájllista frissítése"
 
-#: ../rapidsvn_frame.cpp:274
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr "Frissítés"
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 msgid "Relocate"
 msgstr "Áthelyezés"
 
-#: ../rapidsvn_frame.cpp:604
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
-msgstr "A konfliktusos állapot eltávolítása a fájlok és könyvtárak munka másolatában"
+msgstr ""
+"A konfliktusos állapot eltávolítása a fájlok és könyvtárak munka másolatában"
 
-#: ../rapidsvn_frame.cpp:2160
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr "Könyvjelző eltávolítva"
 
@@ -1512,8 +1493,7 @@ msgstr "Átnevezés"
 msgid "Rep. Rev."
 msgstr "Tároló revízió"
 
-#: ../listener.cpp:371
-#: ../rapidsvn_frame.cpp:1645
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr "Cserélt"
 
@@ -1521,14 +1501,14 @@ msgstr "Cserélt"
 msgid "Repository"
 msgstr "Tároló"
 
-#: ../import_dlg.cpp:67
-#: ../rapidsvn_frame.cpp:2132
+#: ../rapidsvn_generated.cpp:1268
+#, fuzzy
+msgid "Repository &URL for import"
+msgstr "Tároló URL szükséges az importhoz!"
+
+#: ../main_frame.cpp:2079
 msgid "Repository URL"
 msgstr "Tároló URL"
-
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
-msgstr "Tároló URL szükséges az importhoz!"
 
 #: ../file_info.cpp:112
 #, c-format
@@ -1540,75 +1520,63 @@ msgstr "Tároló UUID: %s"
 msgid "Repository: %s"
 msgstr "Tároló: %s"
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr "Oszlopok alaphelyzetbe"
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr "Flat mód újraindítása minden program indításkor"
 
-#: ../resolve_action.cpp:37
-#: ../userresolve_action.cpp:44
+#: ../resolve_action.cpp:37 ../userresolve_action.cpp:44
 msgid "Resolve"
 msgstr "Feloldás"
 
-#: ../rapidsvn_frame.cpp:603
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr "Kiválasztás feloldása"
 
-#: ../listener.cpp:359
-#: ../rapidsvn_frame.cpp:1633
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr "Feloldott"
 
-#: ../listener.cpp:356
-#: ../rapidsvn_frame.cpp:1630
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr "Visszaállít"
 
-#: ../rapidsvn_frame.cpp:594
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
-msgstr "Eredeti munka másolat fájlok visszatöltése (minden helyi szerkesztés visszavonása)"
+msgstr ""
+"Eredeti munka másolat fájlok visszatöltése (minden helyi szerkesztés "
+"visszavonása)"
 
-#: ../listener.cpp:357
-#: ../rapidsvn_frame.cpp:1631
-#: ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../rapidsvn_generated.cpp:506
+msgid "Resulting repository filename:"
+msgstr ""
+
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr "Visszavon"
 
-#: ../rapidsvn_frame.cpp:593
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr "Kijelölés visszavonása"
 
-#: ../annotate_dlg.cpp:47
-#: ../checkout_dlg.cpp:83
-#: ../columns.cpp:47
-#: ../export_dlg.cpp:86
-#: ../log_dlg.cpp:163
-#: ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150
-#: ../rapidsvn_generated.cpp:529
-#: ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr "Revízió"
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr "A revízió egy aláíratlan szám kell legyen!"
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 msgid "Revision or date #1:"
 msgstr "Revízió vagy dátum #1:"
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 msgid "Revision or date #2:"
 msgstr "Revízió vagy dátum #2:"
 
-#: ../rapidsvn_generated.cpp:250
-#: ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr "Revízió:"
 
@@ -1617,9 +1585,10 @@ msgstr "Revízió:"
 msgid "Revision: %ld"
 msgstr "Revízió: %ld"
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr "SSL tanúsítvány"
+#: ../create_repos_action.cpp:104
+#, c-format
+msgid "Running command %s:"
+msgstr ""
 
 #: ../columns.cpp:62
 msgid "Schedule"
@@ -1630,38 +1599,35 @@ msgstr "Ütemterv"
 msgid "Schedule: %s"
 msgstr "Ütemterv: %s"
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr "Második útvonal vagy URL szükséges az összefűzéshez"
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr "Második munka másolat vagy URL"
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr "Tanúsítvány fájl kiválasztása"
 
-#: ../checkout_dlg.cpp:273
-#: ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr "Célkönyvtár kiválasztása"
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr "Válasszon egy célkönyvtárat az összefűzéshez"
 
-#: ../rapidsvn_frame.cpp:2087
+#: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr "Könyvtár kiválasztása"
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr "Könyvtár kiválasztása importra"
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr "Fájl kiválasztása importra"
+
+#: ../create_repos_dlg.cpp:121
+#, fuzzy
+msgid "Select an existing directory for the repository"
+msgstr "Könyvtár hozzáadása a tárolóhoz: %s"
 
 #: ../move_action.cpp:63
 msgid "Select destination:"
@@ -1683,93 +1649,87 @@ msgstr "Állandó szerkesztő kiválasztása"
 msgid "Select standard file explorer executable"
 msgstr "Állandó fájl kereső kiválasztása"
 
-#: ../rapidsvn_frame.cpp:584
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr "Munka másolat változásának küldése a tárolóba"
 
-#: ../checkout_dlg.cpp:94
-#: ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
 msgstr "Fájl utolsó verziókénti választása a tárolóban."
 
-#: ../checkout_dlg.cpp:108
-#: ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
 msgstr "Fájl BASE/HEAD revíziókénti használatának beállítása"
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
 msgstr "Automatikus készítése egy új munka másolat könyvjelzőnek."
 
-#: ../checkout_dlg.cpp:114
-#: ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
 msgstr "Össze alkönyvtár kiválasztás a megadott URL-hez."
 
-#: ../checkout_dlg.cpp:125
-#: ../export_dlg.cpp:129
-msgid "Set to ignore external definitions and the external working copies managed by them."
-msgstr "Mellőzze a külső meghatározásokat és a külső munka másolatok menedzselését általuk."
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
+msgid ""
+"Set to ignore external definitions and the external working copies managed "
+"by them."
+msgstr ""
+"Mellőzze a külső meghatározásokat és a külső munka másolatok menedzselését "
+"általuk."
 
-#: ../rapidsvn_frame.cpp:326
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr "Indulási tippek mutatása"
 
-#: ../rapidsvn_frame.cpp:280
-#: ../rapidsvn_frame.cpp:506
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 msgid "Show conflicted entries"
 msgstr "Ellentétes bejegyzések mutatása"
 
-#: ../rapidsvn_frame.cpp:483
+#: ../main_frame_helper.cpp:155
 msgid "Show entries in subdirectories"
 msgstr "Alkönyvtárakban lévő bejegyzések mutatása"
 
-#: ../rapidsvn_frame.cpp:282
+#: ../main_frame.cpp:285
 msgid "Show ignored entries"
 msgstr "Kihagyott bejegyzések mutatása"
 
-#: ../rapidsvn_frame.cpp:279
-#: ../rapidsvn_frame.cpp:500
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 msgid "Show modified entries"
 msgstr "Módosított bejegyzések mutatása"
 
-#: ../rapidsvn_frame.cpp:275
-#: ../rapidsvn_frame.cpp:482
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 msgid "Show subdirectories"
 msgstr "Alkönyvtárak mutatása"
 
-#: ../rapidsvn_frame.cpp:630
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr "Naplójegyzetek mutatása a kiválasztott bejegyzésekhez"
 
-#: ../rapidsvn_frame.cpp:278
-#: ../rapidsvn_frame.cpp:494
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 msgid "Show unmodified entries"
 msgstr "Nem módosított bejegyzések mutatása"
 
-#: ../rapidsvn_frame.cpp:277
-#: ../rapidsvn_frame.cpp:488
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr "Nem kategorizált bejegyzések mutatása"
 
-#: ../listener.cpp:360
-#: ../rapidsvn_frame.cpp:1634
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr "Átugrás"
 
-#: ../rapidsvn_frame.cpp:272
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr "Rendezés"
 
-#: ../rapidsvn_frame.cpp:248
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr "Növekvő rendezés"
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 msgid "Standard Editor"
 msgstr "Normál szerkesztő"
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 msgid "Standard Explorer"
 msgstr "Normál kereső"
 
@@ -1777,40 +1737,39 @@ msgstr "Normál kereső"
 msgid "Status"
 msgstr "Állapot"
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr "Zárás "
 
-#: ../rapidsvn_frame.cpp:531
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr "Megállás"
 
-#: ../rapidsvn_frame.cpp:532
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr "Jelen akció megállítása"
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr "Hitelesítések tárolása a merevlemezen."
 
 #: ../switch_action.cpp:50
-#: ../switch_dlg.cpp:192
 msgid "Switch URL"
 msgstr "URL kapcsoló"
 
-#: ../rapidsvn_frame.cpp:301
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr "URL kapcsoló...\tCTRL-S"
 
-#: ../rapidsvn_frame.cpp:1581
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr "Kipróbálás időtartama"
 
-#: ../rapidsvn_frame.cpp:1577
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr "Kipróbálás vége"
 
-#: ../rapidsvn_frame.cpp:1574
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr "Kipróbálás kezdete"
 
@@ -1820,9 +1779,19 @@ msgstr "Utolsó javított szöveg"
 
 #: ../view_action.cpp:96
 msgid "The Editor is not configured. Please check Edit->Preferences>Programs"
-msgstr "A szerkesztő nincs beállítva. Ellenőrizze: Szerkesztés->Beállítások->Programok"
+msgstr ""
+"A szerkesztő nincs beállítva. Ellenőrizze: Szerkesztés->Beállítások-"
+">Programok"
 
-#: ../cert_dlg.cpp:70
+#: ../create_repos_dlg.cpp:141
+msgid "The configuration directory does not exist"
+msgstr ""
+
+#: ../create_repos_action.cpp:121
+msgid "The svnadmin command was not successful."
+msgstr ""
+
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
@@ -1830,11 +1799,13 @@ msgstr ""
 "Hiba a szerver minősítés ellenőrzésekor.\n"
 "Megbízik ebben a minősítésben?"
 
-#: ../rapidsvn_generated.cpp:384
-msgid "This action has resulted in a commit - please enter a log message"
-msgstr "Ennek az akciónak beküldés az eredménye - készítsen egy naplóbejegyzést"
+#: ../rapidsvn_generated.cpp:418
+#, fuzzy
+msgid "This action has resulted in a commit - please enter a &log message"
+msgstr ""
+"Ennek az akciónak beküldés az eredménye - készítsen egy naplóbejegyzést"
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1846,16 +1817,9 @@ msgstr ""
 "\n"
 "Ez online megtekinthető:"
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr "Fa"
-
-#: ../checkout_dlg.cpp:65
-#: ../columns.cpp:59
-#: ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521
-#: ../switch_dlg.cpp:77
-#: ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr "URL"
 
@@ -1868,11 +1832,11 @@ msgstr "URL: %s"
 msgid "UUID"
 msgstr "UUID"
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr "Unikód"
 
-#: ../rapidsvn_frame.cpp:1736
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr "Eszköz nélküli akció!"
 
@@ -1881,75 +1845,60 @@ msgid "Unknown destination path"
 msgstr "Ismeretlen célútvonal"
 
 #: ../unlock_action.cpp:39
-#: ../unlock_dlg.cpp:80
 msgid "Unlock"
 msgstr "Nyitás"
 
-#: ../listener.cpp:375
-#: ../rapidsvn_frame.cpp:1649
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr "Kinyitott"
 
-#: ../get_action.cpp:38
-#: ../update_action.cpp:39
-#: ../update_action.cpp:51
+#: ../get_action.cpp:38 ../update_action.cpp:39 ../update_action.cpp:51
 msgid "Update"
 msgstr "Frissítés"
 
-#: ../rapidsvn_frame.cpp:573
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr "Kiválasztott frissítése"
 
-#: ../listener.cpp:363
-#: ../rapidsvn_frame.cpp:1637
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr "Frissítve"
 
-#: ../rapidsvn_frame.cpp:1798
-#: ../rapidsvn_frame.cpp:1803
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr "Frissítés..."
 
-#: ../rapidsvn_frame.cpp:247
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr "Útvonal használata rendezéshez"
 
-#: ../rapidsvn_generated.cpp:271
-#: ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 msgid "Use URL/path:"
 msgstr "URL/útvonal használata"
 
-#: ../rapidsvn_generated.cpp:70
-#: ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr "Már használt"
 
-#: ../checkout_dlg.cpp:92
-#: ../export_dlg.cpp:95
-#: ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299
-#: ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103
-#: ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr "Utolsó használata"
 
-#: ../auth_dlg.cpp:54
-#: ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr "Felhasználó"
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr "Érvényesség kezdete:"
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr "Érvényesség vége:"
 
-#: ../listed_dlg.cpp:80
-#: ../listed_dlg.cpp:172
-#: ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr "Érték"
 
@@ -1957,7 +1906,37 @@ msgstr "Érték"
 msgid "View"
 msgstr "Nézet"
 
-#: ../dnd_dlg.cpp:69
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "View..."
+msgstr "&Nézet..."
+
+#: ../rapidsvn_generated.cpp:567
+msgid "WARNING"
+msgstr ""
+
+#: ../dnd_dlg.cpp:48
+#, fuzzy, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr ""
+"Kívánja mozgatni vagy másolni\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"ide\n"
+"\n"
+"  %s?"
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -1978,33 +1957,28 @@ msgstr ""
 "\n"
 "  %s?"
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr "Igen"
-
-#: ../rapidsvn_frame.cpp:2105
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
-msgstr "Nem tudta hozzáadni a subversion adminisztrációs könyvtárat a könyvjelzőhöz!"
+msgstr ""
+"Nem tudta hozzáadni a subversion adminisztrációs könyvtárat a könyvjelzőhöz!"
 
-#: ../file_info.cpp:150
-#: ../filelist_ctrl.cpp:1196
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr "hozzáadás"
 
-#: ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr "hozzáadva"
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr "ellentétes"
 
-#: ../file_info.cpp:154
-#: ../filelist_ctrl.cpp:1199
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr "törlés"
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr "törölve"
 
@@ -2012,7 +1986,7 @@ msgstr "törölve"
 msgid "directory"
 msgstr "könyvtár"
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr "külső"
 
@@ -2020,73 +1994,216 @@ msgstr "külső"
 msgid "file"
 msgstr "fájl"
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr "mellőz"
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr "hiányos"
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr "összefűzött"
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr "elveszett"
 
-#: ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr "módosított"
 
-#: ../export_dlg.cpp:135
-#: ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr "natív"
 
-#: ../file_info.cpp:132
-#: ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr "egyik sem"
 
-#: ../file_info.cpp:146
-#: ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr "normál"
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr "akadályozott"
 
-#: ../filelist_ctrl.cpp:1229
-#: ../filelist_ctrl.cpp:1243
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr "lejárt"
 
-#: ../file_info.cpp:158
-#: ../filelist_ctrl.cpp:1202
+#: ../rapidsvn_generated.cpp:532
+msgid "pre Subversion 1.4"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:532
+msgid "pre Subversion 1.5"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:532
+msgid "pre Subversion 1.6"
+msgstr ""
+
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr "cserél"
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr "cserélt"
 
-#: ../file_info.cpp:137
-#: ../file_info.cpp:162
+#: ../create_repos_dlg.cpp:116
+msgid "svnadmin could not be found"
+msgstr ""
+
+#: ../file_info.cpp:137 ../file_info.cpp:162
 msgid "unknown"
 msgstr "ismeretlen"
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr "ismeretlen érték"
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
 msgstr "verzió nélküli"
 
-#: ../rapidsvn_frame.cpp:335
-msgid "wxString Creation&Tracing Test"
-msgstr "wxString készítés&nyomkövető teszt"
+#~ msgid "Action"
+#~ msgstr "Akció"
 
+#~ msgid "Checkout Test"
+#~ msgstr "Ellenőrző teszt"
+
+#~ msgid "Copied from Path"
+#~ msgstr "Másolva az útvonalból"
+
+#~ msgid "Copied from Rev"
+#~ msgstr "Másolva a revízióból"
+
+#~ msgid "Destination file"
+#~ msgstr "Cél fájl"
+
+#~ msgid "Destination path"
+#~ msgstr "Cél útvonal"
+
+#~ msgid "EOL:"
+#~ msgstr "EOL:"
+
+#~ msgid "Enter log message"
+#~ msgstr "Naplóbejegyzés"
+
+#~ msgid "Enter the local path where you want the code be exported."
+#~ msgstr "Adja meg a helyi útvonalat, ahová akarja a kódot exportálni."
+
+#~ msgid ""
+#~ "Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
+#~ "files."
+#~ msgstr ""
+#~ "Adja meg, milyen jelet akar használni sorvégnek (EOL) az exportált "
+#~ "fájlokban."
+
+#~ msgid "File path required when importing a file!"
+#~ msgstr "Szükséges a fájl útvonala importáláskor!"
+
+#~ msgid "First path or URL is required for merge!"
+#~ msgstr "Első útvonal vagy URL az igényelt összefűzéshez!"
+
+#~ msgid "Information"
+#~ msgstr "Információ"
+
+#~ msgid ""
+#~ "Invalid selection. At least one revisions is needed for diff and no more "
+#~ "than two."
+#~ msgstr ""
+#~ "Érvénytelen választás. Legkevesebb egy és nem több, mint két revíziót "
+#~ "szükséges választani az összehasonlításhoz."
+
+#~ msgid "Invalid selection. Exactly two revisions needed for merge."
+#~ msgstr "Érvénytelen választás. Pontosan két revíziót szükséges összefűzni."
+
+#~ msgid "Invalid selection. Only one revision may be selected for annotate"
+#~ msgstr ""
+#~ "Érvénytelen választás. Csak egy revíziót lehet választani a jegyzethez"
+
+#~ msgid "Listener Test"
+#~ msgstr "Hallgató teszt"
+
+#~ msgid "Locate help"
+#~ msgstr "Súgó helye"
+
+#~ msgid "Locate tips"
+#~ msgstr "Tippek helye"
+
+#~ msgid "Locate tips file"
+#~ msgstr "Tipp fájlok helye"
+
+#~ msgid "Log Message:"
+#~ msgstr "Napló bejegyzés:"
+
+#~ msgid "Merge revisions"
+#~ msgstr "Összefűzés átdolgozások"
+
+#~ msgid "No"
+#~ msgstr "Nem"
+
+#~ msgid ""
+#~ "No help file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr "Amennyiben a kiválasztott "
+
+#~ msgid ""
+#~ "No tips file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Nincs tipp fájl választás kijelölve. Szeretné, ha a \n"
+#~ "következő indításnál ismét megkérdezné?"
+
+#~ msgid ""
+#~ "Please use the command line utility 'svnadmin'\n"
+#~ "to create a new repository.\n"
+#~ "\n"
+#~ "This command line utility is not part of the\n"
+#~ "RapidSVN distribution.\n"
+#~ "\n"
+#~ "More information about subversion:\n"
+#~ "http://svnbook.red-bean.com/\n"
+#~ "http://subversion.tigris.org"
+#~ msgstr ""
+#~ "Új tároló létrehozásához használja\n"
+#~ "terminálban az 'svnadmin' parancsot.\n"
+#~ "\n"
+#~ "Ez a parancs nem része a RapidSVN kiadásának.\n"
+#~ "\n"
+#~ "Több információ a subversionról:\n"
+#~ "http://svnbook.red-bean.com/\n"
+#~ "http://subversion.tigris.org"
+
+#~ msgid "RapidSVN Help: %s"
+#~ msgstr "RapidSVN súgó: %s"
+
+#~ msgid "Revision must be an unsigned number!"
+#~ msgstr "A revízió egy aláíratlan szám kell legyen!"
+
+#~ msgid "SSL Certificate"
+#~ msgstr "SSL tanúsítvány"
+
+#~ msgid "Second path or URL is required for merge!"
+#~ msgstr "Második útvonal vagy URL szükséges az összefűzéshez"
+
+#~ msgid "Second working copy or URL"
+#~ msgstr "Második munka másolat vagy URL"
+
+#~ msgid "Tree"
+#~ msgstr "Fa"
+
+#~ msgid "Yes"
+#~ msgstr "Igen"
+
+#~ msgid "wxString Creation&Tracing Test"
+#~ msgstr "wxString készítés&nyomkövető teszt"

--- a/librapidsvn/src/locale/it_IT/rapidsvn.po
+++ b/librapidsvn/src/locale/it_IT/rapidsvn.po
@@ -8,10 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RapidSVN 0.9.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-02 17:09+0100\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: 2006-11-01 20:03+0100\n"
 "Last-Translator: Luca Vercelli\n"
 "Language-Team:\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,22 +24,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr "%s  codice: %ld"
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, fuzzy, c-format
 msgid "%s Version %s"
 msgstr "%s Versione %d.%d.%d"
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, fuzzy, c-format
 msgid "%s Version %s Revision %d"
 msgstr "%s Versione %d.%d.%d"
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr ""
 
-#: ../main_frame.cpp:323
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr "&About..."
 
@@ -46,36 +47,32 @@ msgstr "&About..."
 msgid "&Add\tINS"
 msgstr "&Aggiungi\tINS"
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr "&Aggiungi una copia di lavoro esistente..."
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr "Annota"
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 msgid "&Annotate..."
 msgstr "&Annota..."
 
-#: ../main_frame.cpp:344
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr "&Segnalibri"
 
-#: ../rapidsvn_generated.cpp:676
+#: ../rapidsvn_generated.cpp:549
 #, fuzzy
 msgid "&Browse"
 msgstr "&Chiudi"
 
-#: ../log_dlg.cpp:359
-msgid "&Close"
-msgstr "&Chiudi"
-
-#: ../rapidsvn_generated.cpp:655
+#: ../rapidsvn_generated.cpp:528
 msgid "&Compatible with:"
 msgstr ""
 
-#: ../main_frame.cpp:316
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr "&Contenuti\tF1"
 
@@ -83,7 +80,7 @@ msgstr "&Contenuti\tF1"
 msgid "&Copy...\tF5"
 msgstr "&Copia...\tF5"
 
-#: ../main_frame.cpp:290
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr "&Crea..."
 
@@ -91,11 +88,11 @@ msgstr "&Crea..."
 msgid "&Delete\tDEL"
 msgstr "&Cancella\tDEL"
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr "&Cancella..."
 
-#: ../log_dlg.cpp:362 ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 msgid "&Diff"
 msgstr "&Diff"
 
@@ -107,47 +104,52 @@ msgstr "&Differenze dal piu' vecchio...\tCTRL+B"
 msgid "&Diff to Head...\tCTRL+H"
 msgstr "&Differenze dal piu' recente...\tCTRL+H"
 
+#: ../utils.cpp:220
+#, fuzzy
+msgid "&Diff..."
+msgstr "&Diff"
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr "&Differenze...\tCTRL+D"
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr "&Modifica segnalibro..."
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr "&Modifica..."
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr "&Modifica...\tF3"
 
 # : dialog Properties
 # msgid "&New..."
 # msgstr "&Nuovo..."
-#: ../main_frame.cpp:288
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr "&Esporta...\tCTRL-E"
 
-#: ../main_frame.cpp:345
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr "&Extra"
 
-#: ../main_frame.cpp:339
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr "&File"
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 #, fuzzy
 msgid "&Files to commit"
 msgstr "Lock falito"
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 msgid "&Get"
 msgstr "&Prendi"
 
-#: ../main_frame.cpp:223 ../main_frame.cpp:346
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr "&Aiuto"
 
@@ -155,11 +157,11 @@ msgstr "&Aiuto"
 msgid "&Ignore\tCTRL-DEL"
 msgstr "&Ignora\tCTRL-DEL"
 
-#: ../main_frame.cpp:287
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr "&Importa...\tCTRL-I"
 
-#: ../main_frame.cpp:317
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr "&Indice\tShift+F1"
 
@@ -167,7 +169,7 @@ msgstr "&Indice\tShift+F1"
 msgid "&Info..."
 msgstr "&Info..."
 
-#: ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:540
 msgid "&Load configuration from directory (optional):"
 msgstr ""
 
@@ -175,28 +177,43 @@ msgstr ""
 msgid "&Lock..."
 msgstr "&Blocca (lock)..."
 
+#: ../utils.cpp:222
+#, fuzzy
+msgid "&Log..."
+msgstr "&Log...\tCTRL-L"
+
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr "&Log...\tCTRL-L"
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 msgid "&Merge"
 msgstr "&Unisci (merge)"
 
-#: ../main_frame.cpp:342
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr "&Modifica"
 
-#: ../rapidsvn_generated.cpp:625
+#: ../rapidsvn_generated.cpp:897
+#, fuzzy
+msgid "&Name"
+msgstr "Nome"
+
+#: ../rapidsvn_generated.cpp:499
 #, fuzzy
 msgid "&Name of the new repository:"
 msgstr "Crea Nuovo Repository..."
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr "&Nuovo..."
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+#, fuzzy
+msgid "&Password"
+msgstr "Password"
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr "&Permanentemente"
 
@@ -204,44 +221,49 @@ msgstr "&Permanentemente"
 msgid "&Properties...\tCTRL-P"
 msgstr "&Proprieta'...\tCTRL-P"
 
-#: ../main_frame.cpp:343
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr "&Consulta"
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 #, fuzzy
 msgid "&Recent entries:"
 msgstr "Ultime voci:"
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 msgid "&Remove Bookmark"
 msgstr "&Elimina segnalibro"
 
-#: ../main_frame.cpp:341
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr "&Repository"
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+#, fuzzy
+msgid "&Revision"
+msgstr "Revisione"
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr "&Ferma"
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr "&Cambia la URL del Repository..."
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr "&Temporaneamente"
 
-#: ../main_frame.cpp:348
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr "&Test"
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:599
+#: ../rapidsvn_generated.cpp:473
 msgid "&Type:"
 msgstr ""
 
@@ -249,31 +271,41 @@ msgstr ""
 msgid "&Unlock"
 msgstr "&Sblocca (unlock)"
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr "&Aggiorna...\tCTRL-U"
 
-#: ../log_dlg.cpp:360 ../main_frame.cpp:340
+#: ../rapidsvn_generated.cpp:89
+#, fuzzy
+msgid "&Username"
+msgstr "Rinomina"
+
+#: ../rapidsvn_generated.cpp:904
+#, fuzzy
+msgid "&Value"
+msgstr "Valore"
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr "&Visualizza"
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr "&Visualizza..."
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr "- Il certificato ha un errore sconosciuto."
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr "- Certificato scaduto."
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr "- Il nome della macchina non corrisponde al certificato."
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
@@ -281,9 +313,15 @@ msgstr ""
 "- Il certificato non e' stato emesso da una Autorita' riconosciuta.\n"
 "- Use il fingerprint per validare manualmente il certificato!"
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
 msgstr "- Certificato non ancora valido."
+
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+#, fuzzy
+msgid "..."
+msgstr "&Nuovo..."
 
 #: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
 msgid "<None>"
@@ -297,30 +335,25 @@ msgstr ""
 msgid "A file of this name exists already"
 msgstr ""
 
-#: ../about_dlg.cpp:68
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr "ANSI"
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr "Informazioni %s"
 
-#: ../log_dlg.cpp:242
-#, fuzzy
-msgid "Action"
-msgstr "Autenticazione"
-
-#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listener.cpp:353
-#: ../main_frame.cpp:1398
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr "Aggiungi &Repository Esistente..."
 
-#: ../rapidsvn_generated.cpp:642
+#: ../rapidsvn_generated.cpp:516
 msgid "Add a bookmark for the new repository"
 msgstr ""
 
@@ -328,40 +361,40 @@ msgstr ""
 msgid "Add r&ecursive"
 msgstr "Aggiungi ricorsivam&ente"
 
-#: ../main_frame_helper.cpp:64
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr "Aggiungi i file selezionati"
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr "Aggiungi ai segnalibri"
 
-#: ../listener.cpp:362 ../listener.cpp:369 ../main_frame.cpp:1407
-#: ../main_frame.cpp:1414
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr "Aggiunto"
 
-#: ../main_frame.cpp:1904
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr "Repository aggiunto ai segnalibri '%s'"
 
-#: ../main_frame.cpp:1875
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr "Copia di lavoro aggiunta ai segnalibri '%s'"
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, fuzzy, c-format
 msgid "Adding file to repository: %s"
 msgstr "Repository: %s"
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr ""
 
@@ -369,11 +402,11 @@ msgstr ""
 msgid "All files|*"
 msgstr "Tutti i file|*"
 
-#: ../main_frame.cpp:1271 ../main_frame.cpp:1290
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr ""
 
-#: ../main_frame.cpp:1258
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr ""
 
@@ -381,7 +414,7 @@ msgstr ""
 msgid "Annotate"
 msgstr "Annotate"
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -393,11 +426,11 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../auth_dlg.cpp:117 ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr "Autenticazione"
 
-#: ../annotate_dlg.cpp:48 ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr "Autore"
 
@@ -405,11 +438,11 @@ msgstr "Autore"
 msgid "BASE"
 msgstr "BASE"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../rapidsvn_generated.cpp:477
 msgid "BerkeleyDB"
 msgstr ""
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr "Segnalibro"
 
@@ -417,17 +450,17 @@ msgstr "Segnalibro"
 msgid "Bookmarks"
 msgstr "Segnalibri"
 
-#: ../main_frame_helper.cpp:85
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr "Sposta le modifiche dal repository alla copia di lavoro"
 
-#: ../rapidsvn_generated.cpp:57 ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119 ../rapidsvn_generated.cpp:146
-#: ../rapidsvn_generated.cpp:620
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr ""
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -438,44 +471,44 @@ msgstr ""
 "wxWidgets %d.%d.%d (%s)\n"
 "Subversion %d.%d.%d\n"
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr "CR (MacOS)"
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr "CRLF (Windows)"
 
-#: ../auth_dlg.cpp:73 ../cert_dlg.cpp:138 ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57 ../destination_dlg.cpp:90 ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146 ../import_dlg.cpp:130 ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342 ../lock_dlg.cpp:61 ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195 ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409 ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564 ../rapidsvn_generated.cpp:708
-#: ../switch_dlg.cpp:139 ../unlock_dlg.cpp:58 ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr "Cancella"
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+#, fuzzy
+msgid "Certificate information:"
 msgstr "Informazioni del Certificato:"
 
-#: ../main_frame.cpp:289
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr "Check&out...\tCTRL-O"
 
-#: ../checkout_action.cpp:40 ../checkout_dlg.cpp:250
+#: ../checkout_action.cpp:40
 msgid "Checkout"
 msgstr "Checkout"
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
 msgstr "Crea una nuova copia di lavoro (checkout)..."
-
-#: ../main_frame.cpp:331
-msgid "Checkout Test"
-msgstr "Prova di Checkout"
 
 #: ../columns.cpp:58
 msgid "Checksum"
@@ -486,20 +519,25 @@ msgstr "Checksum"
 msgid "Checksum: %s"
 msgstr "Checksum: %s"
 
-#: ../cleanup_action.cpp:39 ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr "Pulisci"
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+#, fuzzy
+msgid "Close"
+msgstr "&Chiudi"
+
+#: ../utils.cpp:297
 #, fuzzy
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr "Co&mmit...\tCTRL-M"
 
-#: ../main_frame.cpp:265
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr "Colonne"
 
-#: ../rapidsvn_generated.cpp:275 ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr ""
 
@@ -511,11 +549,11 @@ msgstr "Commit"
 msgid "Commit Log Message"
 msgstr "Messaggio da registrare con il Commit"
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr "Commenti dei commit: di default usa il piu' recente"
 
-#: ../main_frame_helper.cpp:94
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr "Fai il Commit dei selezionati"
 
@@ -523,9 +561,19 @@ msgstr "Fai il Commit dei selezionati"
 msgid "Committed revision"
 msgstr "Revisione salvata (commited)"
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
 msgstr "Confronta:"
+
+#: ../listener.cpp:496
+#, fuzzy, c-format
+msgid "Completed %s at revision %d"
+msgstr "Revisione salvata (commited)"
+
+#: ../listener.cpp:486
+#, fuzzy, c-format
+msgid "Completed at revision %d"
+msgstr "Revisione salvata (commited)"
 
 #: ../columns.cpp:64
 msgid "Conflict BASE"
@@ -559,6 +607,11 @@ msgstr "Conflitto"
 msgid "Conflict Working File: %s"
 msgstr "File in Conflitto: %s"
 
+#: ../listener.cpp:307
+#, fuzzy
+msgid "Conflicted"
+msgstr "in conflitto"
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr "Copiato"
@@ -573,32 +626,22 @@ msgstr "Copiato dalla Rev: %ld"
 msgid "Copied From URL: %s"
 msgstr "Copiato dalla URL: %s"
 
-#: ../log_dlg.cpp:244
-#, fuzzy
-msgid "Copied from Path"
-msgstr "Copiato dalla URL: %s"
-
-#: ../log_dlg.cpp:245
-#, fuzzy
-msgid "Copied from Rev"
-msgstr "Copiato dalla Rev: %ld"
-
-#: ../dnd_dlg.cpp:108 ../listener.cpp:354 ../main_frame.cpp:1399
-#: ../move_action.cpp:44
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr "copia"
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 #, fuzzy
 msgid "Copy/Move"
 msgstr "copia"
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, fuzzy, c-format
 msgid "Copying file into working directory: %s"
 msgstr "Impossibile impostare la copia di lavoro a %s"
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, fuzzy, c-format
 msgid "Copying file: %s"
 msgstr "File in Conflitto: %s"
@@ -608,7 +651,7 @@ msgstr "File in Conflitto: %s"
 msgid "Could not set working directory to %s"
 msgstr "Impossibile impostare la copia di lavoro a %s"
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr "Crea Nuovo Repository..."
 
@@ -617,59 +660,51 @@ msgstr "Crea Nuovo Repository..."
 msgid "Create Repository"
 msgstr "Crea Nuovo Repository..."
 
-#: ../rapidsvn_generated.cpp:611
+#: ../rapidsvn_generated.cpp:485
 #, fuzzy
 msgid "Create repository in &directory:"
 msgstr "Seleziona la cartella di destinazione"
 
-#: ../columns.cpp:54 ../log_dlg.cpp:165
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr "Data"
 
-#: ../rapidsvn_generated.cpp:265 ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr "Data:"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 #, fuzzy
 msgid "Default"
 msgstr "Cancella"
 
-#: ../delete_action.cpp:40 ../delete_dlg.cpp:79 ../listener.cpp:355
-#: ../main_frame.cpp:1400
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr "Cancella"
 
-#: ../main_frame_helper.cpp:75
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr "Cancella File e cartella dal controllo versione"
 
-#: ../main_frame_helper.cpp:74
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr "Cancella i selezionati"
 
-#: ../listener.cpp:361 ../listener.cpp:370 ../main_frame.cpp:1406
-#: ../main_frame.cpp:1415
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr "Cancellato"
 
-#: ../checkout_dlg.cpp:72 ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
 msgstr "Cartella di Destinazione"
-
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr "File di Destinazione"
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
-msgstr "Percorso di Destinazione"
 
 #: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr "Diff"
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 msgid "Diff Tool"
 msgstr "Diff"
 
@@ -689,83 +724,98 @@ msgstr "Diff da un'altra versione/data"
 msgid "Diff two revisions/dates"
 msgstr "Diff fra due revisioni/date"
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
 msgstr ""
 "Autenticazione differente per ciascun segnalibro nella lista dei segnalibri"
+
+#: ../rapidsvn_generated.cpp:1296
+#, fuzzy
+msgid "Directory"
+msgstr "Cartella:"
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr "Cartella:"
 
-#: ../rapidsvn_generated.cpp:681
+#: ../rapidsvn_generated.cpp:554
 msgid "Disable automatic Log removal"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:685
+#: ../rapidsvn_generated.cpp:557
 msgid "Disable fsync when committing database transactions"
 msgstr ""
 
-#: ../main_frame_helper.cpp:195
+#: ../main_frame_helper.cpp:179
 #, fuzzy
 msgid "Display conflicted files/directories"
 msgstr "Vuoi sbloccare i file/cartelle selezionati?"
 
-#: ../main_frame_helper.cpp:132
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr "Mostra Informazioni sulla voce selezionata"
 
-#: ../main_frame_helper.cpp:189
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:183
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:177
+#: ../main_frame_helper.cpp:161
 #, fuzzy
 msgid "Display unversioned files/directories"
 msgstr "Mostra le voci non versionate"
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr "Vuoi cancellare i file/cartelle selezionati?"
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr "Vuoi anullare (revert) le tue modifiche locali?"
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr "Vuoi sbloccare i file/cartelle selezionati?"
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr "E&sci\tCTRL-Q"
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr "EOL:"
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr "Edita"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr "Modifica segnalibro"
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr "Modifica Proprieta'"
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "Edit..."
+msgstr "&Modifica..."
+
+#: ../rapidsvn_generated.cpp:1306
+#, fuzzy
+msgid "End &log message"
+msgstr "Scrivi un commento"
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 #, fuzzy
 msgid "Enter &log message"
 msgstr "Scrivi un commento"
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr "Scrivi un commento a questo lock"
 
@@ -774,37 +824,19 @@ msgstr "Scrivi un commento a questo lock"
 msgid "Enter a name for the repository"
 msgstr "Scrivi un commento a questo lock"
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr "Scrivi un commento"
-
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr "Scrivi il nuovo nome:"
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr "Scrivi il percorso nel quale il codice verra' esportato."
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
 msgstr "Scrivi il percorso nel quale il codice verra' messo (checked out)."
 
-#: ../checkout_dlg.cpp:70 ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr "Scrivi l'URL del repository (non il percorso locale)."
 
-#: ../export_dlg.cpp:143
-msgid ""
-"Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
-"files."
-msgstr ""
-"Scegli quale tipo di simbolo usare come fine linea (EOL) nei File esportati"
-
-#: ../import_dlg.cpp:178 ../import_dlg.cpp:191 ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494 ../log_dlg.cpp:530 ../main_frame.cpp:1865
-#: ../merge_dlg.cpp:52 ../merge_dlg.cpp:91 ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr "Errore"
 
@@ -816,11 +848,18 @@ msgstr "Errore ricercando lo stato:"
 msgid "Error running svnadmin"
 msgstr ""
 
-#: ../property_dlg.cpp:120
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr "Errore impostando il valore della proprieta'"
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, fuzzy, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr "Errore impostando il valore della proprieta'"
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr "Errore validando il certificato per '%s':"
@@ -843,26 +882,26 @@ msgstr "Errore durante la preparazione dell'esecuzione."
 msgid "Error while preparing action: %s"
 msgstr "Errore durante la preparazione dell'esecuzione: %s"
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr "Errore rileggendo la lista dei file (%s)"
 
-#: ../main_frame.cpp:907
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr "Errore durante l'aggiornamento dei file"
 
-#: ../main_frame.cpp:894
+#: ../main_frame.cpp:917
 #, fuzzy, c-format
 msgid "Error while updating filelist (%s)"
 msgstr "Errore durante l'aggiornamento dei file"
 
-#: ../main_frame.cpp:542
+#: ../main_frame.cpp:561
 #, c-format
 msgid "Error: %s\n"
 msgstr "Errore: %s\n"
 
-#: ../main_frame.cpp:1799
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
 msgstr "Eccezione occorsa durante l'aggiornamento dei file "
 
@@ -899,11 +938,11 @@ msgstr "Esegui il diff: %s"
 msgid "Execute: %s"
 msgstr "Esegui: %s"
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr "Esplora cartella...\tF2"
 
-#: ../export_action.cpp:40 ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr "Esporta"
 
@@ -911,52 +950,48 @@ msgstr "Esporta"
 msgid "Extension"
 msgstr "Estensione"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../listener.cpp:405
+#, fuzzy
+msgid "External"
+msgstr "esterno"
+
+#: ../rapidsvn_generated.cpp:477
 msgid "FSFS"
 msgstr ""
 
-#: ../listener.cpp:376 ../main_frame.cpp:1421
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr "Lock falito"
 
-#: ../listener.cpp:377 ../main_frame.cpp:1422
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr "Unlock fallito"
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr "File"
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr "Devi immettere un percorso quando importi un file!"
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr "Fingerprint:"
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr "Per unire 2 file e' necessario il primo percorso o un URL!"
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr "Prima copia di lavoro o URL"
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr "Per altre Informazioni vedi:"
 
-#: ../destination_dlg.cpp:80 ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr "Forza"
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr "Forza la rimozione"
 
-#: ../export_dlg.cpp:123
+#: ../export_dlg.cpp:75
 msgid ""
 "Force to execute even if destination directory not empty, causes overwriting "
 "of files with the same names."
@@ -964,11 +999,11 @@ msgstr ""
 "Forzare l'esecuzione anche se la cartella di destinazione non e' vuota  puo' "
 "causare la sovrascrittura di file con lo stesso nome"
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
 msgstr "Forza l'unlock anche se non sei l'autore del blocco"
 
-#: ../rapidsvn_generated.cpp:41 ../rapidsvn_generated.cpp:649
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr "Generale"
 
@@ -981,16 +1016,25 @@ msgstr "Prendi File %s rev. %s"
 msgid "HEAD"
 msgstr "HEAD"
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+#, fuzzy
+msgid "Help"
+msgstr "&Aiuto"
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr "Storia: %d revisione"
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr "Nome della macchina:"
 
-#: ../checkout_dlg.cpp:88 ../export_dlg.cpp:91
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
 msgid ""
 "If not using the latest version of the files, specify which revision to use "
 "here."
@@ -998,7 +1042,7 @@ msgstr ""
 "Se non usi l'ultima versione dei File, specifica quale revisione  deve "
 "essere usata"
 
-#: ../checkout_dlg.cpp:102 ../export_dlg.cpp:105
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
 #, fuzzy
 msgid ""
 "If the files were renamed or moved some time, specify which peg revision to "
@@ -1012,20 +1056,24 @@ msgstr ""
 msgid "Ignore"
 msgstr "Informazioni"
 
-#: ../main_frame.cpp:275 ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr "Ignora gli Externals"
 
-#: ../checkout_dlg.cpp:122 ../export_dlg.cpp:126 ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr "Ignora gli Externals"
 
-#: ../dnd_dlg.cpp:37 ../dnd_dlg.cpp:97 ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr "Importa"
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+#, fuzzy
+msgid "Import &Path"
+msgstr "Importa"
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr ""
@@ -1034,15 +1082,15 @@ msgstr ""
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr "Risoluzione confli&tti guidata...\tCTRL-T"
 
-#: ../main_frame.cpp:270
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr ""
 
-#: ../main_frame.cpp:1984
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr "Informazioni"
 
-#: ../main_frame_helper.cpp:131
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr "Informazioni sul file selezionato"
 
@@ -1050,7 +1098,7 @@ msgstr "Informazioni sul file selezionato"
 msgid "Internal Error: There is another action running"
 msgstr "Errore Interno: C'e' un'altra azione in corso"
 
-#: ../main_frame.cpp:1542
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr "Errore Interno: nessun dato per fare l'azione!"
 
@@ -1062,32 +1110,17 @@ msgstr "Errore Interno: nessun contesto disponibile"
 msgid "Invalid revision number detected"
 msgstr "Trovato un numero invalido di revisione"
 
-#: ../log_dlg.cpp:478
-msgid ""
-"Invalid selection. At least one revisions is needed for diff and no more "
-"than two."
-msgstr ""
-"Selezione invalida. Sono necessarie una o due revisioni per fare un diff"
-
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr "Selezione invalida. Sono necessarie due revisioni per fare un merge."
-
-#: ../log_dlg.cpp:529
+#: ../rapidsvn_generated.cpp:159
 #, fuzzy
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr "Selezione invalida. Sono necessarie due revisioni per fare un merge."
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
+msgid "Issuer:"
 msgstr "Edizione:"
 
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 #, fuzzy
 msgid "Keep Locks"
 msgstr "Mantieni il lock"
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr "LF (Unix)"
 
@@ -1109,20 +1142,16 @@ msgstr "Data dell'ultima modifica"
 msgid "Last Changed Rev: %ld"
 msgstr "Revisione dell'ultima modifica: %ld"
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr "Linea"
 
-#: ../main_frame.cpp:330
-msgid "Listener Test"
-msgstr "Test di ascolto"
-
-#: ../filelist_ctrl.cpp:1058
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr "Listando le voci in '%s'"
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1135,19 +1164,7 @@ msgstr ""
 "Nome del Sistema: %s\n"
 "Nome Canonico: %s\n"
 
-#: ../rapidsvn_app.cpp:198 ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr "cerca aiuto"
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr "Cerca consigli"
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr "Cerca file dei consigli"
-
-#: ../lock_action.cpp:40 ../lock_dlg.cpp:100
+#: ../lock_action.cpp:40
 msgid "Lock"
 msgstr "Blocca"
 
@@ -1182,31 +1199,27 @@ msgstr "Proprietario del lock: %s"
 msgid "Lock Token: %s"
 msgstr "Parola del lock: %s"
 
-#: ../listener.cpp:374 ../main_frame.cpp:1419
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr "Locked"
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr "Registro"
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr "Cronologia"
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr "Registro dei messaggi"
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr "Registro dei messaggi:"
-
-#: ../main_frame_helper.cpp:141
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr "Registro del file selezionato"
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr "Connetti..."
 
@@ -1231,40 +1244,41 @@ msgstr "C&rea cartella...\tF7"
 msgid "Make directory"
 msgstr "Crea cartella"
 
-#: ../merge_action.cpp:38 ../merge_action.cpp:44 ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr "Unisci (merge)"
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 #, fuzzy
 msgid "Merge Tool"
 msgstr "Unisci (merge)"
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
-msgstr "Unisci (merge) con le revisioni"
-
-#: ../main_frame.cpp:294
+#: ../main_frame.cpp:303
 msgid "Merge..."
 msgstr "Unisci (merge)..."
+
+#: ../listener.cpp:308
+#, fuzzy
+msgid "Merged"
+msgstr "Unisci (merge)"
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr "Crea cartella"
 
-#: ../listener.cpp:368 ../main_frame.cpp:1413
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr "Modificato"
 
-#: ../rapidsvn_generated.cpp:692
+#: ../rapidsvn_generated.cpp:563
 msgid "More options"
 msgstr ""
 
-#: ../dnd_dlg.cpp:104 ../move_action.cpp:42
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr "Sposta"
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, fuzzy, c-format
 msgid "Moving file: %s"
 msgstr "File in Conflitto: %s"
@@ -1273,8 +1287,16 @@ msgstr "File in Conflitto: %s"
 msgid "Multiple Files"
 msgstr ""
 
-#: ../columns.cpp:45 ../listed_dlg.cpp:75 ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr "Nome"
 
@@ -1283,45 +1305,25 @@ msgstr "Nome"
 msgid "Name: %s"
 msgstr "Nome: %s"
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
 msgstr "Nuova Proprieta'"
-
-#: ../revert_dlg.cpp:57
-msgid "No"
-msgstr ""
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr "Non c'e' un programma di diff impostato nelle preferenze"
-
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Nessun File di aiuto scelto, rivuoi \n"
-"questa domanda al prossimo avvio?"
 
 #: ../userresolve_action.cpp:62
 #, fuzzy
 msgid "No merge tool set in the preferences"
 msgstr "Non c'e' un programma di diff impostato nelle preferenze"
 
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Nessun File dei consigli scelto, vuoi ancora\n"
-"questa domanda al prossimo avvio?"
-
 #: ../file_info.cpp:118
 #, c-format
 msgid "Node Kind: %s"
 msgstr "Tipo di Nodo: %s"
 
-#: ../checkout_dlg.cpp:106 ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr "Non specificato"
 
@@ -1329,39 +1331,38 @@ msgstr "Non specificato"
 msgid "Not versioned"
 msgstr "Non versionato"
 
-#: ../about_dlg.cpp:114 ../annotate_dlg.cpp:42 ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126 ../delete_dlg.cpp:54 ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145 ../import_dlg.cpp:128 ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341 ../lock_dlg.cpp:60 ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191 ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405 ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560 ../rapidsvn_generated.cpp:704
-#: ../report_dlg.cpp:57 ../switch_dlg.cpp:137 ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr "OK"
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr "Apri..."
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr "Sovrascrivi"
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr "Password"
-
-#: ../columns.cpp:46 ../import_dlg.cpp:80 ../log_dlg.cpp:243
+#: ../columns.cpp:46
 msgid "Path"
 msgstr "Percorso"
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+#, fuzzy
+msgid "Path &type"
 msgstr "Tipo di Percorso:"
 
-#: ../checkout_dlg.cpp:97 ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr "Etichetta della Revisione"
 
@@ -1369,28 +1370,28 @@ msgstr "Etichetta della Revisione"
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr "Preferenze..."
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 #, fuzzy
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr "Argomento (%1=arq1, %2=arq2):"
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr "Argomento (%1=arq1, %2=arq2):"
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr "Argomento (%1=cartella selezionata):"
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr "Argomento (%1=File selezionato):"
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr "Programmi"
 
@@ -1406,7 +1407,7 @@ msgstr "Stato Prop."
 msgid "Properties Last Updated"
 msgstr "Ultima modifica delle Proprieta'"
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr "Proprieta':"
 
@@ -1418,22 +1419,21 @@ msgstr "Proprieta'"
 msgid "Property Editor"
 msgstr "Editor delle Proprieta'"
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr "Cancella i file temporanei all'uscita del programma"
 
-#: ../main_frame_helper.cpp:65
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr "Aggiungi file e cartella sotto controllo revisione"
 
-#: ../main_frame.cpp:509
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
+msgstr ""
+
+#: ../main_frame.cpp:528
 msgid "RapidSVN Error"
 msgstr "Errore di RapidSVN"
-
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
-msgstr "Aiuto di RapidSVN: %s"
 
 #: ../utils.cpp:192
 msgid "Re&name...\tCTRL-N"
@@ -1447,50 +1447,50 @@ msgstr "Ho ri&solto i conflitti\tCTRL-S"
 msgid "Re&vert\tCTRL-V"
 msgstr "Ripristina (re&vert)\tCTRL-V"
 
-#: ../filelist_ctrl.cpp:1134
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr "Pronto"
 
-#: ../main_frame.cpp:1522 ../main_frame.cpp:1566
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr "Pronto\n"
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr "Ultime voci:"
 
-#: ../checkout_dlg.cpp:111 ../export_dlg.cpp:114 ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201 ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547 ../revert_dlg.cpp:49 ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr "Ricorsivo"
 
-#: ../main_frame_helper.cpp:206
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr "&Aggiorna la vista\tCTRL-R"
 
-#: ../main_frame_helper.cpp:207
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr "Rileggi la lista dei file"
 
-#: ../main_frame.cpp:268
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr "Rileggi la lista dei file a aggiornali"
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 msgid "Relocate"
 msgstr "Sposta"
 
-#: ../main_frame_helper.cpp:115
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
 msgstr "Rimuovi lo stato di 'Conflitto' nella copia di lavoro"
 
-#: ../main_frame.cpp:1918
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr "Segnalibro rimosso"
 
@@ -1502,7 +1502,7 @@ msgstr "Rinomina"
 msgid "Rep. Rev."
 msgstr "Rev. Rep."
 
-#: ../listener.cpp:371 ../main_frame.cpp:1416
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr "Rimpiazzato"
 
@@ -1510,13 +1510,14 @@ msgstr "Rimpiazzato"
 msgid "Repository"
 msgstr "Repository"
 
-#: ../import_dlg.cpp:67 ../main_frame.cpp:1890
+#: ../rapidsvn_generated.cpp:1268
+#, fuzzy
+msgid "Repository &URL for import"
+msgstr "La URL del repository e' necessaria per fare un import!"
+
+#: ../main_frame.cpp:2079
 msgid "Repository URL"
 msgstr "URL del repository"
-
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
-msgstr "La URL del repository e' necessaria per fare un import!"
 
 #: ../file_info.cpp:112
 #, c-format
@@ -1528,11 +1529,11 @@ msgstr "UUID del repository: %s"
 msgid "Repository: %s"
 msgstr "Repository: %s"
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr "Dimensioni predefinite"
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr "Imposta la Modalita' Flat ad ogni avvio del programma"
 
@@ -1540,56 +1541,50 @@ msgstr "Imposta la Modalita' Flat ad ogni avvio del programma"
 msgid "Resolve"
 msgstr "Risolvi conflitto"
 
-#: ../main_frame_helper.cpp:114
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr "Risolvi conflitto del file selezionato"
 
-#: ../listener.cpp:359 ../main_frame.cpp:1404
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr "Conflitto risolto"
 
-#: ../listener.cpp:356 ../main_frame.cpp:1401
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr "Ripristina (restore)"
 
-#: ../main_frame_helper.cpp:105
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
 msgstr ""
 "Ripristina la copia di lavoro originale (perderai tutte le modifiche locali)"
 
-#: ../rapidsvn_generated.cpp:632
+#: ../rapidsvn_generated.cpp:506
 msgid "Resulting repository filename:"
 msgstr ""
 
-#: ../listener.cpp:357 ../main_frame.cpp:1402 ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr "Ripristina (revert)"
 
-#: ../main_frame_helper.cpp:104
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr "Ripristina selezionato/i"
 
-#: ../annotate_dlg.cpp:47 ../checkout_dlg.cpp:83 ../columns.cpp:47
-#: ../export_dlg.cpp:86 ../log_dlg.cpp:163 ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150 ../rapidsvn_generated.cpp:529 ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr "Revisione"
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr "Il numero di revisione e' senza segno!"
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 msgid "Revision or date #1:"
 msgstr "Revisione o data #1:"
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 msgid "Revision or date #2:"
 msgstr "Revisione o data #2:"
 
-#: ../rapidsvn_generated.cpp:250 ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr "Revisione:"
 
@@ -1603,10 +1598,6 @@ msgstr "Revisione: %ld"
 msgid "Running command %s:"
 msgstr ""
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr "Certificato SSL"
-
 #: ../columns.cpp:62
 msgid "Schedule"
 msgstr "Agenda"
@@ -1616,36 +1607,28 @@ msgstr "Agenda"
 msgid "Schedule: %s"
 msgstr "Agenda: %s"
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr "Il merge richiede un secondo percorso o URL!"
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr "Secondo URL o percorso della copia di lavoro"
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr "Selezione il File del Certificato"
 
-#: ../checkout_dlg.cpp:273 ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr "Seleziona la cartella di destinazione"
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr "Seleziona la cartella di destinazione per il merge"
 
 #: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
-#: ../main_frame.cpp:1845
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr "Seleziona una cartella"
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr "Seleziona la cartella da importare"
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr "Seleziona il file da importare"
 
@@ -1675,92 +1658,92 @@ msgstr "Seleziona il programma per modificare i file"
 msgid "Select standard file explorer executable"
 msgstr "Seleziona il programma per navigare fra i file"
 
-#: ../main_frame_helper.cpp:95
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr "Invia le modifiche dalla copia di lavoro al repository"
 
-#: ../checkout_dlg.cpp:94 ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
 msgstr ""
 "Imposta questa versione come l'ultima versione del file nel repository."
 
-#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
 msgstr "Imposta questa versione come ultima (BASE/HEAD) revisione del File."
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
 msgstr ""
 "Metti automaticamente nei segnalibri il percorso della copia di lavoro."
 
-#: ../checkout_dlg.cpp:114 ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
 msgstr "Prendi anche tutte le sottocartelle dall'URL."
 
-#: ../checkout_dlg.cpp:125 ../export_dlg.cpp:129
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
 msgid ""
 "Set to ignore external definitions and the external working copies managed "
 "by them."
 msgstr "Ignora le Externals Definitions e le copie di lavoro che esse indicano"
 
-#: ../main_frame.cpp:320
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr "All'avvio mosta il consiglio del giorno"
 
-#: ../main_frame.cpp:274 ../main_frame_helper.cpp:194
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 #, fuzzy
 msgid "Show conflicted entries"
 msgstr "Mostra i files ignorati"
 
-#: ../main_frame_helper.cpp:171
+#: ../main_frame_helper.cpp:155
 #, fuzzy
 msgid "Show entries in subdirectories"
 msgstr "Mostra le cartelle nascoste"
 
-#: ../main_frame.cpp:276
+#: ../main_frame.cpp:285
 msgid "Show ignored entries"
 msgstr "Mostra i files ignorati"
 
-#: ../main_frame.cpp:273 ../main_frame_helper.cpp:188
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 #, fuzzy
 msgid "Show modified entries"
 msgstr "Mostra i files ignorati"
 
-#: ../main_frame.cpp:269 ../main_frame_helper.cpp:170
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 #, fuzzy
 msgid "Show subdirectories"
 msgstr "Mostra le cartelle nascoste"
 
-#: ../main_frame_helper.cpp:142
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr "Mostra i messaggi di log per le voci selezionate"
 
-#: ../main_frame.cpp:272 ../main_frame_helper.cpp:182
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 #, fuzzy
 msgid "Show unmodified entries"
 msgstr "Mostra i files ignorati"
 
-#: ../main_frame.cpp:271 ../main_frame_helper.cpp:176
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr "Mostra le voci non versionate"
 
-#: ../listener.cpp:360 ../main_frame.cpp:1405
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr "Salta"
 
-#: ../main_frame.cpp:266
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr "Ordina"
 
-#: ../main_frame.cpp:242
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr "Ordinamento Ascendente"
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 msgid "Standard Editor"
 msgstr "Editor"
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 msgid "Standard Explorer"
 msgstr "Navigatore"
 
@@ -1768,39 +1751,39 @@ msgstr "Navigatore"
 msgid "Status"
 msgstr "Stato"
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr "Prendi il blocco se e' stato impostato da un altro utente"
 
-#: ../main_frame_helper.cpp:219
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr "Interrompi"
 
-#: ../main_frame_helper.cpp:220
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr "Interrompi l'azione corrente"
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr "Memorizza le credenziali su disco"
 
-#: ../switch_action.cpp:50 ../switch_dlg.cpp:192
+#: ../switch_action.cpp:50
 msgid "Switch URL"
 msgstr "Cambia URL"
 
-#: ../main_frame.cpp:295
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr "Cambia URL...\tCTRL-S"
 
-#: ../main_frame.cpp:1352
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr "Test di durata"
 
-#: ../main_frame.cpp:1348
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr "Test concluso alle"
 
-#: ../main_frame.cpp:1345
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr "Teste iniziato alle"
 
@@ -1822,7 +1805,7 @@ msgstr ""
 msgid "The svnadmin command was not successful."
 msgstr ""
 
-#: ../cert_dlg.cpp:70
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
@@ -1830,12 +1813,12 @@ msgstr ""
 "C'e' stato un errore nel validare il certificato.\n"
 "Vuoi accettarlo lo stesso?"
 
-#: ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:418
 #, fuzzy
 msgid "This action has resulted in a commit - please enter a &log message"
 msgstr "Questa azione genera un Commit - inserisci un commento da registrare"
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1843,12 +1826,9 @@ msgid ""
 "Available online under:"
 msgstr ""
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr "Álbero"
-
-#: ../checkout_dlg.cpp:65 ../columns.cpp:59 ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521 ../switch_dlg.cpp:77 ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr "URL"
 
@@ -1861,11 +1841,11 @@ msgstr "URL: %s"
 msgid "UUID"
 msgstr "UUID"
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../main_frame.cpp:1494
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr "Azione non implementata!"
 
@@ -1874,11 +1854,11 @@ msgstr "Azione non implementata!"
 msgid "Unknown destination path"
 msgstr "Percorso di Destinazione"
 
-#: ../unlock_action.cpp:39 ../unlock_dlg.cpp:80
+#: ../unlock_action.cpp:39
 msgid "Unlock"
 msgstr "Sblocca"
 
-#: ../listener.cpp:375 ../main_frame.cpp:1420
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr "Sbloccato"
 
@@ -1886,49 +1866,49 @@ msgstr "Sbloccato"
 msgid "Update"
 msgstr "Aggiorna"
 
-#: ../main_frame_helper.cpp:84
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr "Aggiorna selezionato/i"
 
-#: ../listener.cpp:363 ../main_frame.cpp:1408
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr "Aggiornato"
 
-#: ../main_frame.cpp:1556 ../main_frame.cpp:1561
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr "Aggiornamento in corso..."
 
-#: ../main_frame.cpp:241
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr "Ordina in base al percorso"
 
-#: ../rapidsvn_generated.cpp:271 ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 msgid "Use URL/path:"
 msgstr "Usa URL/path:"
 
-#: ../rapidsvn_generated.cpp:70 ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr "Usa sempre"
 
-#: ../checkout_dlg.cpp:92 ../export_dlg.cpp:95 ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299 ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103 ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr "Usa il piu' recente"
 
-#: ../auth_dlg.cpp:54 ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr "Utente"
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr "Valido da:"
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr "Valido fino a:"
 
-#: ../listed_dlg.cpp:80 ../listed_dlg.cpp:172 ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr "Valore"
 
@@ -1936,11 +1916,29 @@ msgstr "Valore"
 msgid "View"
 msgstr "Visualizza"
 
-#: ../rapidsvn_generated.cpp:696
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "View..."
+msgstr "&Visualizza..."
+
+#: ../rapidsvn_generated.cpp:567
 msgid "WARNING"
 msgstr ""
 
-#: ../dnd_dlg.cpp:69
+#: ../dnd_dlg.cpp:48
+#, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr ""
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -1953,32 +1951,28 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr ""
-
-#: ../main_frame.cpp:1863
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
 msgstr ""
 "Non puoi mettere nei segnalibri una cartella di amministrazione di SVN!"
 
-#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1261
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr "agguingi"
 
-#: ../filelist_ctrl.cpp:1226 ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr "aggiunto"
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr "in conflitto"
 
-#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1264
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr "cancella"
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr "cancellato"
 
@@ -1986,7 +1980,7 @@ msgstr "cancellato"
 msgid "directory"
 msgstr "cartella"
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr "esterno"
 
@@ -1994,63 +1988,67 @@ msgstr "esterno"
 msgid "file"
 msgstr "File"
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr ""
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr "incompleto"
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr "unito (merged)"
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr "assente"
 
-#: ../filelist_ctrl.cpp:1229 ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr "modificato"
 
-#: ../export_dlg.cpp:135 ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr "nativo"
 
-#: ../file_info.cpp:132 ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr "nessuno"
 
-#: ../file_info.cpp:146 ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr "normal"
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr "ostruito"
 
-#: ../filelist_ctrl.cpp:1294 ../filelist_ctrl.cpp:1308
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr "vecchio"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.4"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.5"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.6"
 msgstr ""
 
-#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1267
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr "rimiazzare"
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr "rimiazzato"
 
@@ -2062,17 +2060,124 @@ msgstr ""
 msgid "unknown"
 msgstr "sconosciuto"
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr "valore sconosciuto"
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
 msgstr "senza versione"
 
-#: ../main_frame.cpp:329
-msgid "wxString Creation&Tracing Test"
-msgstr "wxString Creation&Tracing Test"
+#, fuzzy
+#~ msgid "Action"
+#~ msgstr "Autenticazione"
+
+#~ msgid "Checkout Test"
+#~ msgstr "Prova di Checkout"
+
+#, fuzzy
+#~ msgid "Copied from Path"
+#~ msgstr "Copiato dalla URL: %s"
+
+#, fuzzy
+#~ msgid "Copied from Rev"
+#~ msgstr "Copiato dalla Rev: %ld"
+
+#~ msgid "Destination file"
+#~ msgstr "File di Destinazione"
+
+#~ msgid "Destination path"
+#~ msgstr "Percorso di Destinazione"
+
+#~ msgid "EOL:"
+#~ msgstr "EOL:"
+
+#~ msgid "Enter log message"
+#~ msgstr "Scrivi un commento"
+
+#~ msgid "Enter the local path where you want the code be exported."
+#~ msgstr "Scrivi il percorso nel quale il codice verra' esportato."
+
+#~ msgid ""
+#~ "Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
+#~ "files."
+#~ msgstr ""
+#~ "Scegli quale tipo di simbolo usare come fine linea (EOL) nei File "
+#~ "esportati"
+
+#~ msgid "File path required when importing a file!"
+#~ msgstr "Devi immettere un percorso quando importi un file!"
+
+#~ msgid "First path or URL is required for merge!"
+#~ msgstr "Per unire 2 file e' necessario il primo percorso o un URL!"
+
+#~ msgid ""
+#~ "Invalid selection. At least one revisions is needed for diff and no more "
+#~ "than two."
+#~ msgstr ""
+#~ "Selezione invalida. Sono necessarie una o due revisioni per fare un diff"
+
+#~ msgid "Invalid selection. Exactly two revisions needed for merge."
+#~ msgstr ""
+#~ "Selezione invalida. Sono necessarie due revisioni per fare un merge."
+
+#, fuzzy
+#~ msgid "Invalid selection. Only one revision may be selected for annotate"
+#~ msgstr ""
+#~ "Selezione invalida. Sono necessarie due revisioni per fare un merge."
+
+#~ msgid "Listener Test"
+#~ msgstr "Test di ascolto"
+
+#~ msgid "Locate help"
+#~ msgstr "cerca aiuto"
+
+#~ msgid "Locate tips"
+#~ msgstr "Cerca consigli"
+
+#~ msgid "Locate tips file"
+#~ msgstr "Cerca file dei consigli"
+
+#~ msgid "Log Message:"
+#~ msgstr "Registro dei messaggi:"
+
+#~ msgid "Merge revisions"
+#~ msgstr "Unisci (merge) con le revisioni"
+
+#~ msgid ""
+#~ "No help file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Nessun File di aiuto scelto, rivuoi \n"
+#~ "questa domanda al prossimo avvio?"
+
+#~ msgid ""
+#~ "No tips file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Nessun File dei consigli scelto, vuoi ancora\n"
+#~ "questa domanda al prossimo avvio?"
+
+#~ msgid "RapidSVN Help: %s"
+#~ msgstr "Aiuto di RapidSVN: %s"
+
+#~ msgid "Revision must be an unsigned number!"
+#~ msgstr "Il numero di revisione e' senza segno!"
+
+#~ msgid "SSL Certificate"
+#~ msgstr "Certificato SSL"
+
+#~ msgid "Second path or URL is required for merge!"
+#~ msgstr "Il merge richiede un secondo percorso o URL!"
+
+#~ msgid "Second working copy or URL"
+#~ msgstr "Secondo URL o percorso della copia di lavoro"
+
+#~ msgid "Tree"
+#~ msgstr "Álbero"
+
+#~ msgid "wxString Creation&Tracing Test"
+#~ msgstr "wxString Creation&Tracing Test"
 
 #~ msgid "Information"
 #~ msgstr "Informazioni"

--- a/librapidsvn/src/locale/ja/rapidsvn.po
+++ b/librapidsvn/src/locale/ja/rapidsvn.po
@@ -6,10 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RapidSVN 0.9.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-02 17:09+0100\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: 2009-11-16 00:51+0900\n"
 "Last-Translator: Hisateru Tanaka <tanakahisateru@gmail.com>\n"
 "Language-Team: Hisateru Tanaka <tanakahisateru@gmail.com>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -20,22 +21,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr "%s コード: %ld"
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, c-format
 msgid "%s Version %s"
 msgstr "%s バージョン %s"
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, c-format
 msgid "%s Version %s Revision %d"
 msgstr "%s バージョン %s リビジョン %d"
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr "%Y-%m-%d %H:%M:%S"
 
-#: ../main_frame.cpp:323
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr "このソフトウェアについて(&A)..."
 
@@ -43,35 +44,31 @@ msgstr "このソフトウェアについて(&A)..."
 msgid "&Add\tINS"
 msgstr "追加(&A)\tINS"
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr "既存の作業コピーを追加(&A)..."
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr "注釈(&A)"
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 msgid "&Annotate..."
 msgstr "注釈(&A)..."
 
-#: ../main_frame.cpp:344
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr "ブックマーク(&B)"
 
-#: ../rapidsvn_generated.cpp:676
+#: ../rapidsvn_generated.cpp:549
 msgid "&Browse"
 msgstr "参照(&B)"
 
-#: ../log_dlg.cpp:359
-msgid "&Close"
-msgstr "閉じる(&C)"
-
-#: ../rapidsvn_generated.cpp:655
+#: ../rapidsvn_generated.cpp:528
 msgid "&Compatible with:"
 msgstr "互換性(&C):"
 
-#: ../main_frame.cpp:316
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr "コンテンツ(&C)\tF1"
 
@@ -79,7 +76,7 @@ msgstr "コンテンツ(&C)\tF1"
 msgid "&Copy...\tF5"
 msgstr "コピー(&C)...\tF5"
 
-#: ../main_frame.cpp:290
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr "作成(&C)..."
 
@@ -87,11 +84,11 @@ msgstr "作成(&C)..."
 msgid "&Delete\tDEL"
 msgstr "削除(&D)\tDEL"
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr "削除(&D)..."
 
-#: ../log_dlg.cpp:362 ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 msgid "&Diff"
 msgstr "比較(&D)"
 
@@ -103,43 +100,48 @@ msgstr "BASEと比較(&D)...\tCTRL+B"
 msgid "&Diff to Head...\tCTRL+H"
 msgstr "HEADと比較(&D)...\tCTRL+H"
 
+#: ../utils.cpp:220
+#, fuzzy
+msgid "&Diff..."
+msgstr "比較(&D)"
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr "比較(&D)...\tCTRL+D"
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr "ブックマークの編集(&E)..."
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr "編集(&E)..."
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr "編集(&E)...\tF3"
 
-#: ../main_frame.cpp:288
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr "エクスポート(&E)...\tCTRL-E"
 
-#: ../main_frame.cpp:345
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr "特別(&E)"
 
-#: ../main_frame.cpp:339
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr "ファイル(&F)"
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 msgid "&Files to commit"
 msgstr "コミット(&F)"
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 msgid "&Get"
 msgstr "取得(&G)"
 
-#: ../main_frame.cpp:223 ../main_frame.cpp:346
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr "ヘルプ(&H)"
 
@@ -147,11 +149,11 @@ msgstr "ヘルプ(&H)"
 msgid "&Ignore\tCTRL-DEL"
 msgstr "無視(&I)\tCTRL-DEL"
 
-#: ../main_frame.cpp:287
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr "インポート(&I)...\tCTRL-I"
 
-#: ../main_frame.cpp:317
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr "目次(&I)\tShift+F1"
 
@@ -159,7 +161,7 @@ msgstr "目次(&I)\tShift+F1"
 msgid "&Info..."
 msgstr "情報(&I)..."
 
-#: ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:540
 msgid "&Load configuration from directory (optional):"
 msgstr "設定を読み込むディレクトリ(&L) (オプション):"
 
@@ -167,27 +169,42 @@ msgstr "設定を読み込むディレクトリ(&L) (オプション):"
 msgid "&Lock..."
 msgstr "ロック(&L)..."
 
+#: ../utils.cpp:222
+#, fuzzy
+msgid "&Log..."
+msgstr "ログ(&L)...\tCTRL-L"
+
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr "ログ(&L)...\tCTRL-L"
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 msgid "&Merge"
 msgstr "マージ(&M)"
 
-#: ../main_frame.cpp:342
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr "変更(&M)"
 
-#: ../rapidsvn_generated.cpp:625
+#: ../rapidsvn_generated.cpp:897
+#, fuzzy
+msgid "&Name"
+msgstr "名前"
+
+#: ../rapidsvn_generated.cpp:499
 msgid "&Name of the new repository:"
 msgstr "新規リポジトリの名前(&N):"
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr "新規(&N)..."
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+#, fuzzy
+msgid "&Password"
+msgstr "パスワード"
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr "常に(&P)"
 
@@ -195,43 +212,48 @@ msgstr "常に(&P)"
 msgid "&Properties...\tCTRL-P"
 msgstr "属性(&P)...\tCTRL-P"
 
-#: ../main_frame.cpp:343
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr "クエリ(&Q)"
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 msgid "&Recent entries:"
 msgstr "最近のエントリ(&R):"
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 msgid "&Remove Bookmark"
 msgstr "ブックマークの削除(&R)"
 
-#: ../main_frame.cpp:341
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr "リポジトリ(&R)"
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+#, fuzzy
+msgid "&Revision"
+msgstr "リビジョン"
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr "停止(&S)"
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr "リポジトリURLの切り替え(&S)..."
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr "今回だけ(&T)"
 
-#: ../main_frame.cpp:348
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr "テスト(&T)"
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr "反転(&T)"
 
-#: ../rapidsvn_generated.cpp:599
+#: ../rapidsvn_generated.cpp:473
 msgid "&Type:"
 msgstr "タイプ(&T)"
 
@@ -239,31 +261,41 @@ msgstr "タイプ(&T)"
 msgid "&Unlock"
 msgstr "ロック解除(&U)"
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr "更新(&U)...\tCTRL-U"
 
-#: ../log_dlg.cpp:360 ../main_frame.cpp:340
+#: ../rapidsvn_generated.cpp:89
+#, fuzzy
+msgid "&Username"
+msgstr "名前の変更"
+
+#: ../rapidsvn_generated.cpp:904
+#, fuzzy
+msgid "&Value"
+msgstr "値"
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr "表示(&V)"
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr "表示(&V)..."
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr "- 証明書には不明なエラーがあります。"
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr "- 証明書は期限切れです。"
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr "- 証明書のホスト名は一致しません。"
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
@@ -271,9 +303,15 @@ msgstr ""
 "- 証明書は信頼された認証期間から発行されていません。\n"
 "  フィンガープリントを見て、証明書を検証してください！"
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
 msgstr "- 無効な証明書です。"
+
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+#, fuzzy
+msgid "..."
+msgstr "新規(&N)..."
 
 #: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
 msgid "<None>"
@@ -287,29 +325,25 @@ msgstr "この名前のディレクトリはすでに存在します"
 msgid "A file of this name exists already"
 msgstr "この名前のファイルはすでに存在します"
 
-#: ../about_dlg.cpp:68
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr "ANSI"
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr "%s について"
 
-#: ../log_dlg.cpp:242
-msgid "Action"
-msgstr "アクション"
-
-#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listener.cpp:353
-#: ../main_frame.cpp:1398
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr "追加"
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr "既存のリポジトリを追加(&R)..."
 
-#: ../rapidsvn_generated.cpp:642
+#: ../rapidsvn_generated.cpp:516
 msgid "Add a bookmark for the new repository"
 msgstr "新規リポジトリのブックマークを追加"
 
@@ -317,40 +351,40 @@ msgstr "新規リポジトリのブックマークを追加"
 msgid "Add r&ecursive"
 msgstr "子階層も追加(&E)"
 
-#: ../main_frame_helper.cpp:64
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr "追加"
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr "ブックマークに追加"
 
-#: ../listener.cpp:362 ../listener.cpp:369 ../main_frame.cpp:1407
-#: ../main_frame.cpp:1414
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr "追加"
 
-#: ../main_frame.cpp:1904
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr "リポジトリはブックマーク '%s' に追加されました"
 
-#: ../main_frame.cpp:1875
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr "作業コピーはブックマーク '%s' に追加されました"
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr "ディレクトリをリポジトリに追加します: %s"
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, c-format
 msgid "Adding file to repository: %s"
 msgstr "ファイルをリポジトリに追加しています: %s"
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr "影響を受けたファイル/ディレクトリ"
 
@@ -358,11 +392,11 @@ msgstr "影響を受けたファイル/ディレクトリ"
 msgid "All files|*"
 msgstr "全てのファイル|*"
 
-#: ../main_frame.cpp:1271 ../main_frame.cpp:1290
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr "ブラウザの起動中にエラーが発生しました"
 
-#: ../main_frame.cpp:1258
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr "アクションのチェック中にエラーが発生しました"
 
@@ -370,7 +404,7 @@ msgstr "アクションのチェック中にエラーが発生しました"
 msgid "Annotate"
 msgstr "注釈履歴"
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -389,11 +423,11 @@ msgstr ""
 "\n"
 "  %s"
 
-#: ../auth_dlg.cpp:117 ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr "認証"
 
-#: ../annotate_dlg.cpp:48 ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr "作者"
 
@@ -401,11 +435,11 @@ msgstr "作者"
 msgid "BASE"
 msgstr "BASE"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../rapidsvn_generated.cpp:477
 msgid "BerkeleyDB"
 msgstr "BerkeleyDB"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr "ブックマーク"
 
@@ -413,17 +447,17 @@ msgstr "ブックマーク"
 msgid "Bookmarks"
 msgstr "ブックマーク"
 
-#: ../main_frame_helper.cpp:85
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr "リポジトリの変更を作業コピーに反映"
 
-#: ../rapidsvn_generated.cpp:57 ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119 ../rapidsvn_generated.cpp:146
-#: ../rapidsvn_generated.cpp:620
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr "参照"
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -434,44 +468,44 @@ msgstr ""
 "wxWidgets %d.%d.%d (%s)\n"
 "Subversion %d.%d.%d\n"
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr "CR (MacOS)"
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr "CRLF (Windows)"
 
-#: ../auth_dlg.cpp:73 ../cert_dlg.cpp:138 ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57 ../destination_dlg.cpp:90 ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146 ../import_dlg.cpp:130 ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342 ../lock_dlg.cpp:61 ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195 ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409 ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564 ../rapidsvn_generated.cpp:708
-#: ../switch_dlg.cpp:139 ../unlock_dlg.cpp:58 ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+#, fuzzy
+msgid "Certificate information:"
 msgstr "証明書情報:"
 
-#: ../main_frame.cpp:289
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr "チェックアウト(&O)...\tCTRL-O"
 
-#: ../checkout_action.cpp:40 ../checkout_dlg.cpp:250
+#: ../checkout_action.cpp:40
 msgid "Checkout"
 msgstr "チェックアウト"
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
 msgstr "新しい作業コピーをチェックアウト"
-
-#: ../main_frame.cpp:331
-msgid "Checkout Test"
-msgstr "チェックアウトテスト"
 
 #: ../columns.cpp:58
 msgid "Checksum"
@@ -482,19 +516,24 @@ msgstr "チェックサム"
 msgid "Checksum: %s"
 msgstr "チェックサム: %s"
 
-#: ../cleanup_action.cpp:39 ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr "クリーンアップ"
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+#, fuzzy
+msgid "Close"
+msgstr "閉じる(&C)"
+
+#: ../utils.cpp:297
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr "コミット(&M)...\tCTRL-ENTER"
 
-#: ../main_frame.cpp:265
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr "列の表示"
 
-#: ../rapidsvn_generated.cpp:275 ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr "Combo!"
 
@@ -506,11 +545,11 @@ msgstr "コミット"
 msgid "Commit Log Message"
 msgstr "ログメッセージをコミット"
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr "コミットログメッセージ: 最近のものをデフォルトに"
 
-#: ../main_frame_helper.cpp:94
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr "コミット"
 
@@ -518,9 +557,19 @@ msgstr "コミット"
 msgid "Committed revision"
 msgstr "コミットしたリビジョン"
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
 msgstr "比較:"
+
+#: ../listener.cpp:496
+#, fuzzy, c-format
+msgid "Completed %s at revision %d"
+msgstr "コミットしたリビジョン"
+
+#: ../listener.cpp:486
+#, fuzzy, c-format
+msgid "Completed at revision %d"
+msgstr "コミットしたリビジョン"
 
 #: ../columns.cpp:64
 msgid "Conflict BASE"
@@ -554,6 +603,11 @@ msgstr "作業コピーと衝突"
 msgid "Conflict Working File: %s"
 msgstr "作業コピーと衝突するファイル: %s"
 
+#: ../listener.cpp:307
+#, fuzzy
+msgid "Conflicted"
+msgstr "衝突"
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr "コピー"
@@ -568,29 +622,21 @@ msgstr "コピー元リビジョン: %ld"
 msgid "Copied From URL: %s"
 msgstr "コピー元URL: %s"
 
-#: ../log_dlg.cpp:244
-msgid "Copied from Path"
-msgstr "コピー元パス"
-
-#: ../log_dlg.cpp:245
-msgid "Copied from Rev"
-msgstr "コピー元リビジョン"
-
-#: ../dnd_dlg.cpp:108 ../listener.cpp:354 ../main_frame.cpp:1399
-#: ../move_action.cpp:44
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr "コピー"
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 msgid "Copy/Move"
 msgstr "コピー/移動"
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, c-format
 msgid "Copying file into working directory: %s"
 msgstr "作業ディレクトリにファイルをコピーしています: %s"
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, c-format
 msgid "Copying file: %s"
 msgstr "ファイルをコピーしています: %s"
@@ -600,7 +646,7 @@ msgstr "ファイルをコピーしています: %s"
 msgid "Could not set working directory to %s"
 msgstr "作業ディレクトリを%sに設定できません"
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr "リポジトリの新規作成..."
 
@@ -608,57 +654,49 @@ msgstr "リポジトリの新規作成..."
 msgid "Create Repository"
 msgstr "リポジトリの新規作成"
 
-#: ../rapidsvn_generated.cpp:611
+#: ../rapidsvn_generated.cpp:485
 msgid "Create repository in &directory:"
 msgstr "リポジトリを作成するディレクトリ(&D):"
 
-#: ../columns.cpp:54 ../log_dlg.cpp:165
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr "日付"
 
-#: ../rapidsvn_generated.cpp:265 ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr "日付:"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "Default"
 msgstr "デフォルト"
 
-#: ../delete_action.cpp:40 ../delete_dlg.cpp:79 ../listener.cpp:355
-#: ../main_frame.cpp:1400
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr "削除"
 
-#: ../main_frame_helper.cpp:75
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr "ファイルおよびディレクトリをバージョン管理から削除"
 
-#: ../main_frame_helper.cpp:74
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr "削除"
 
-#: ../listener.cpp:361 ../listener.cpp:370 ../main_frame.cpp:1406
-#: ../main_frame.cpp:1415
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr "削除"
 
-#: ../checkout_dlg.cpp:72 ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
 msgstr "出力ディレクトリ"
-
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr "出力ファイル"
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
-msgstr "出力パス"
 
 #: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr "比較"
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 msgid "Diff Tool"
 msgstr "比較ツール"
 
@@ -678,79 +716,94 @@ msgstr "他のリビジョン/日付と比較する"
 msgid "Diff two revisions/dates"
 msgstr "2つのリビジョン/日付を比較"
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
 msgstr "ブックマークごとに異なるログインを使う"
+
+#: ../rapidsvn_generated.cpp:1296
+#, fuzzy
+msgid "Directory"
+msgstr "ディレクトリ:"
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr "ディレクトリ:"
 
-#: ../rapidsvn_generated.cpp:681
+#: ../rapidsvn_generated.cpp:554
 msgid "Disable automatic Log removal"
 msgstr "自動ログ削除をしない"
 
-#: ../rapidsvn_generated.cpp:685
+#: ../rapidsvn_generated.cpp:557
 msgid "Disable fsync when committing database transactions"
 msgstr "データベーストランザクションのコミット時にfsyncしない"
 
-#: ../main_frame_helper.cpp:195
+#: ../main_frame_helper.cpp:179
 msgid "Display conflicted files/directories"
 msgstr "競合ファイル/ディレクトリを表示します"
 
-#: ../main_frame_helper.cpp:132
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr "選択したエントリの情報を表示します"
 
-#: ../main_frame_helper.cpp:189
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr "変更ファイル/ディレクトリを表示します"
 
-#: ../main_frame_helper.cpp:183
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr "未変更ファイル/ディレクトリを表示します"
 
-#: ../main_frame_helper.cpp:177
+#: ../main_frame_helper.cpp:161
 msgid "Display unversioned files/directories"
 msgstr "バージョン管理されていないファイル/ディレクトリを表示します"
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr "選択したファイル/ディレクトリを削除しますか?"
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr "ローカルな変更を元に戻しますか?"
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr "選択したファイル/ディレクトリのロックを解除しますか?"
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr "終了(&X)\tCTRL-Q"
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr "EOL:"
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr "編集"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr "ブックマークの編集"
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr "属性の編集"
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "Edit..."
+msgstr "編集(&E)..."
+
+#: ../rapidsvn_generated.cpp:1306
+#, fuzzy
+msgid "End &log message"
+msgstr "ログメッセージを入力してください(&L)"
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 msgid "Enter &log message"
 msgstr "ログメッセージを入力してください(&L)"
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr "このロックにコメントを入力してください"
 
@@ -758,38 +811,19 @@ msgstr "このロックにコメントを入力してください"
 msgid "Enter a name for the repository"
 msgstr "このリポジトリにコメントを入力してください"
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr "ログメッセージを入力してください"
-
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr "新しい名前を入力:"
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr "コードをエクスポートしたいローカルパスを入力してください。"
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
 msgstr "コードをチェックアウトしたいローカルパスを入力してください。"
 
-#: ../checkout_dlg.cpp:70 ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr "リポジトリURL(ローカルパスではありません)を入力してください。"
 
-#: ../export_dlg.cpp:143
-msgid ""
-"Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
-"files."
-msgstr ""
-"エクスポートされるファイル中のEOL(行終端)として望ましい記号の種類を入力してく"
-"ださい。"
-
-#: ../import_dlg.cpp:178 ../import_dlg.cpp:191 ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494 ../log_dlg.cpp:530 ../main_frame.cpp:1865
-#: ../merge_dlg.cpp:52 ../merge_dlg.cpp:91 ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr "エラー"
 
@@ -801,11 +835,18 @@ msgstr "ステータス取得エラー:"
 msgid "Error running svnadmin"
 msgstr "svnadmin 実行エラー"
 
-#: ../property_dlg.cpp:120
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr "属性値設定エラー"
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, fuzzy, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr "属性値設定エラー"
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr "サーバ証明書 '%s' 検証エラー:"
@@ -828,26 +869,26 @@ msgstr "アクション準備中にエラー"
 msgid "Error while preparing action: %s"
 msgstr "アクション準備中にエラー: %s"
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr "ファイルリスのトリフレッシュ中にエラー (%s)"
 
-#: ../main_frame.cpp:907
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr "ファイルリスト更新中にエラー"
 
-#: ../main_frame.cpp:894
+#: ../main_frame.cpp:917
 #, c-format
 msgid "Error while updating filelist (%s)"
 msgstr "ファイルリスト更新中にエラー(%s)"
 
-#: ../main_frame.cpp:542
+#: ../main_frame.cpp:561
 #, c-format
 msgid "Error: %s\n"
 msgstr "エラー: %s\n"
 
-#: ../main_frame.cpp:1799
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
 msgstr "ファイルリスト更新中に例外が発生"
 
@@ -884,11 +925,11 @@ msgstr "マージツールを実行: %s"
 msgid "Execute: %s"
 msgstr "実行: %s"
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr "エクスプローラ...\tF2"
 
-#: ../export_action.cpp:40 ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr "エクスポート"
 
@@ -896,52 +937,48 @@ msgstr "エクスポート"
 msgid "Extension"
 msgstr "拡張子"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../listener.cpp:405
+#, fuzzy
+msgid "External"
+msgstr "外部参照"
+
+#: ../rapidsvn_generated.cpp:477
 msgid "FSFS"
 msgstr "FSFS"
 
-#: ../listener.cpp:376 ../main_frame.cpp:1421
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr "ロックに失敗しました"
 
-#: ../listener.cpp:377 ../main_frame.cpp:1422
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr "ロック解除に失敗しました"
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr "ファイル"
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr "ファイルをインポートするにはファイルパスが必要です!"
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr "フィンガープリント:"
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr "マージには第1パスまたはURLが必要です!"
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr "第1パスまたはURL"
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr "詳しくは以下を参照:"
 
-#: ../destination_dlg.cpp:80 ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr "強制"
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr "強制削除"
 
-#: ../export_dlg.cpp:123
+#: ../export_dlg.cpp:75
 msgid ""
 "Force to execute even if destination directory not empty, causes overwriting "
 "of files with the same names."
@@ -949,11 +986,11 @@ msgstr ""
 "出力先ディレクトリが空でなくても強制的に実行します。ファイルは同じ名前で上書"
 "きされます。"
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
 msgstr "自分がロック所有者でなくても強制的にロックを解除する"
 
-#: ../rapidsvn_generated.cpp:41 ../rapidsvn_generated.cpp:649
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr "一般"
 
@@ -966,16 +1003,25 @@ msgstr "ファイルを取得: %s リビジョン %s"
 msgid "HEAD"
 msgstr "HEAD"
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+#, fuzzy
+msgid "Help"
+msgstr "ヘルプ(&H)"
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr "履歴: 計 %d リビジョン"
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr "ホスト名:"
 
-#: ../checkout_dlg.cpp:88 ../export_dlg.cpp:91
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
 msgid ""
 "If not using the latest version of the files, specify which revision to use "
 "here."
@@ -983,7 +1029,7 @@ msgstr ""
 "最新バージョンのファイルを使わない場合、どのリビジョンを使うか指定してくださ"
 "い。"
 
-#: ../checkout_dlg.cpp:102 ../export_dlg.cpp:105
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
 msgid ""
 "If the files were renamed or moved some time, specify which peg revision to "
 "use here."
@@ -995,20 +1041,24 @@ msgstr ""
 msgid "Ignore"
 msgstr "無視"
 
-#: ../main_frame.cpp:275 ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr "外部参照を無視"
 
-#: ../checkout_dlg.cpp:122 ../export_dlg.cpp:126 ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr "外部参照を無視"
 
-#: ../dnd_dlg.cpp:37 ../dnd_dlg.cpp:97 ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr "インポート"
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+#, fuzzy
+msgid "Import &Path"
+msgstr "インポート"
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr "リポジトリにファイルをインポートします: %s"
@@ -1017,15 +1067,15 @@ msgstr "リポジトリにファイルをインポートします: %s"
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr "対話的に衝突を解消(&T)...\tCTRL-T"
 
-#: ../main_frame.cpp:270
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr "子の変更を表示"
 
-#: ../main_frame.cpp:1984
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr "情報"
 
-#: ../main_frame_helper.cpp:131
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr "情報"
 
@@ -1033,7 +1083,7 @@ msgstr "情報"
 msgid "Internal Error: There is another action running"
 msgstr "内部エラー: 実行中の他アクションがあります"
 
-#: ../main_frame.cpp:1542
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr "内部エラー: アクションイベントのためのクライアントデータがありません!"
 
@@ -1045,30 +1095,16 @@ msgstr "内部エラー: コンテキストがありません"
 msgid "Invalid revision number detected"
 msgstr "無効なリビジョン番号が検出されました"
 
-#: ../log_dlg.cpp:478
-msgid ""
-"Invalid selection. At least one revisions is needed for diff and no more "
-"than two."
-msgstr ""
-"無効な選択。比較には少なくとも1つ(かつ、2つ以下)のリビジョンが必要です。"
-
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr "無効な選択。マージには2つのリビジョンが必要です。"
-
-#: ../log_dlg.cpp:529
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr "無効な選択。注釈には1つのリビジョンしか選べません"
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
+#: ../rapidsvn_generated.cpp:159
+#, fuzzy
+msgid "Issuer:"
 msgstr "発行元:"
 
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 msgid "Keep Locks"
 msgstr "ロックを維持"
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr "LF (Unix)"
 
@@ -1090,20 +1126,16 @@ msgstr "最終更新日"
 msgid "Last Changed Rev: %ld"
 msgstr "最終更新リビジョン: %ld"
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr "行"
 
-#: ../main_frame.cpp:330
-msgid "Listener Test"
-msgstr "リスナテスト"
-
-#: ../filelist_ctrl.cpp:1058
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr "'%s' のエントリを一覧しています"
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1116,19 +1148,7 @@ msgstr ""
 "システム名: %s\n"
 "正式名称: %s\n"
 
-#: ../rapidsvn_app.cpp:198 ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr "ヘルプを探す"
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr "ヒントを探す"
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr "ヒントのファイルを探す"
-
-#: ../lock_action.cpp:40 ../lock_dlg.cpp:100
+#: ../lock_action.cpp:40
 msgid "Lock"
 msgstr "ロック"
 
@@ -1163,31 +1183,27 @@ msgstr "ロック所有者: %s"
 msgid "Lock Token: %s"
 msgstr "ロックトークン: %s"
 
-#: ../listener.cpp:374 ../main_frame.cpp:1419
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr "ロック"
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr "ログ"
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr "ログ履歴"
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr "ログメッセージ"
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr "ログメッセージ:"
-
-#: ../main_frame_helper.cpp:141
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr "ログ"
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr "ログイン..."
 
@@ -1212,39 +1228,40 @@ msgstr "ディレクトリの作成(&D)...\tF7"
 msgid "Make directory"
 msgstr "ディレクトリの作成"
 
-#: ../merge_action.cpp:38 ../merge_action.cpp:44 ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr "マージ"
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 msgid "Merge Tool"
 msgstr "マージツール"
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
-msgstr "リビジョン間でマージ"
-
-#: ../main_frame.cpp:294
+#: ../main_frame.cpp:303
 msgid "Merge..."
 msgstr "マージ..."
+
+#: ../listener.cpp:308
+#, fuzzy
+msgid "Merged"
+msgstr "マージ"
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr "Mkdir"
 
-#: ../listener.cpp:368 ../main_frame.cpp:1413
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr "変更"
 
-#: ../rapidsvn_generated.cpp:692
+#: ../rapidsvn_generated.cpp:563
 msgid "More options"
 msgstr "拡張オプション"
 
-#: ../dnd_dlg.cpp:104 ../move_action.cpp:42
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr "移動"
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, c-format
 msgid "Moving file: %s"
 msgstr "ファイルを移動しています: %s"
@@ -1253,8 +1270,16 @@ msgstr "ファイルを移動しています: %s"
 msgid "Multiple Files"
 msgstr "複数ファイル"
 
-#: ../columns.cpp:45 ../listed_dlg.cpp:75 ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr "名前"
 
@@ -1263,44 +1288,24 @@ msgstr "名前"
 msgid "Name: %s"
 msgstr "名前: %s"
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
 msgstr "新しい属性"
-
-#: ../revert_dlg.cpp:57
-msgid "No"
-msgstr "いいえ"
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr "設定で比較ツールが指定されていません"
 
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"ヘルプファイルが選択されていません。\n"
-"次回起動時にも問い合わせますか?"
-
 #: ../userresolve_action.cpp:62
 msgid "No merge tool set in the preferences"
 msgstr "設定でマージツールが指定されていません"
-
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"ヒントファイルが選択されていません。\n"
-"次回起動時にも問い合わせますか?"
 
 #: ../file_info.cpp:118
 #, c-format
 msgid "Node Kind: %s"
 msgstr "ノードの種類: %s"
 
-#: ../checkout_dlg.cpp:106 ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr "指定しない"
 
@@ -1308,39 +1313,38 @@ msgstr "指定しない"
 msgid "Not versioned"
 msgstr "バージョン管理されていません"
 
-#: ../about_dlg.cpp:114 ../annotate_dlg.cpp:42 ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126 ../delete_dlg.cpp:54 ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145 ../import_dlg.cpp:128 ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341 ../lock_dlg.cpp:60 ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191 ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405 ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560 ../rapidsvn_generated.cpp:704
-#: ../report_dlg.cpp:57 ../switch_dlg.cpp:137 ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr "OK"
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr "開く..."
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr "上書き"
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr "パスワード"
-
-#: ../columns.cpp:46 ../import_dlg.cpp:80 ../log_dlg.cpp:243
+#: ../columns.cpp:46
 msgid "Path"
 msgstr "パス"
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+#, fuzzy
+msgid "Path &type"
 msgstr "パスの種類:"
 
-#: ../checkout_dlg.cpp:97 ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr "ペグ・リビジョン"
 
@@ -1348,27 +1352,27 @@ msgstr "ペグ・リビジョン"
 msgid "Preferences"
 msgstr "設定"
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr "設定..."
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr "プログラム引数 (%1=ベース, %2=相手 %3=自分 %4=結果):"
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr "プログラム引数 (%1=ファイル1, %2=ファイル2):"
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr "プログラム引数 (%1=選択中ディレクトリ)"
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr "プログラム引数 (%1=選択中ファイル):"
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr "プログラム"
 
@@ -1384,7 +1388,7 @@ msgstr "属性の状態"
 msgid "Properties Last Updated"
 msgstr "属性の最終更新"
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr "属性:"
 
@@ -1396,22 +1400,21 @@ msgstr "属性"
 msgid "Property Editor"
 msgstr "属性エディタ"
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr "プログラム終了時に一時ファイルを破棄する"
 
-#: ../main_frame_helper.cpp:65
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr "ファイルとディレクトリをバージョン管理下に置く"
 
-#: ../main_frame.cpp:509
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
+msgstr ""
+
+#: ../main_frame.cpp:528
 msgid "RapidSVN Error"
 msgstr "RapidSVNエラー"
-
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
-msgstr "RapidSVN ヘルプ: %s"
 
 #: ../utils.cpp:192
 msgid "Re&name...\tCTRL-N"
@@ -1425,50 +1428,50 @@ msgstr "衝突の解消(&S)\tCtrl+S"
 msgid "Re&vert\tCTRL-V"
 msgstr "元に戻す(&V)\tCTRL-V"
 
-#: ../filelist_ctrl.cpp:1134
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr "レディ"
 
-#: ../main_frame.cpp:1522 ../main_frame.cpp:1566
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr "レディ\n"
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr "最近のエントリ:"
 
-#: ../checkout_dlg.cpp:111 ../export_dlg.cpp:114 ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201 ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547 ../revert_dlg.cpp:49 ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr "子階層を含む"
 
-#: ../main_frame_helper.cpp:206
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr "リフレッシュ"
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr "表示をリフレッシュ\tCTRL-R"
 
-#: ../main_frame_helper.cpp:207
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr "ファイルリストをリフレッシュ"
 
-#: ../main_frame.cpp:268
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr "リフレッシュ時に更新も行う"
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 msgid "Relocate"
 msgstr "再配置"
 
-#: ../main_frame_helper.cpp:115
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
 msgstr "作業コピーのファイルまたはディレクトリの衝突状態を取り除く"
 
-#: ../main_frame.cpp:1918
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr "削除済みブックマーク"
 
@@ -1480,7 +1483,7 @@ msgstr "名前の変更"
 msgid "Rep. Rev."
 msgstr "リポジトリ リビジョン"
 
-#: ../listener.cpp:371 ../main_frame.cpp:1416
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr "置換"
 
@@ -1488,13 +1491,14 @@ msgstr "置換"
 msgid "Repository"
 msgstr "リポジトリ"
 
-#: ../import_dlg.cpp:67 ../main_frame.cpp:1890
+#: ../rapidsvn_generated.cpp:1268
+#, fuzzy
+msgid "Repository &URL for import"
+msgstr "インポートにはリポジトリURLが必要です!"
+
+#: ../main_frame.cpp:2079
 msgid "Repository URL"
 msgstr "リポジトリURL"
-
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
-msgstr "インポートにはリポジトリURLが必要です!"
 
 #: ../file_info.cpp:112
 #, c-format
@@ -1506,11 +1510,11 @@ msgstr "リポジトリ UUID: %s"
 msgid "Repository: %s"
 msgstr "リポジトリ: %s"
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr "列を初期化"
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr "プログラムを開始するたびにフラットモードをリセット"
 
@@ -1518,55 +1522,49 @@ msgstr "プログラムを開始するたびにフラットモードをリセッ
 msgid "Resolve"
 msgstr "衝突の解消"
 
-#: ../main_frame_helper.cpp:114
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr "衝突の解消"
 
-#: ../listener.cpp:359 ../main_frame.cpp:1404
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr "解消"
 
-#: ../listener.cpp:356 ../main_frame.cpp:1401
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr "復元"
 
-#: ../main_frame_helper.cpp:105
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
 msgstr "初期作業コピーファイルを復元(すべてのローカル編集を元に戻す)"
 
-#: ../rapidsvn_generated.cpp:632
+#: ../rapidsvn_generated.cpp:506
 msgid "Resulting repository filename:"
 msgstr "結果リポジトリファイル名:"
 
-#: ../listener.cpp:357 ../main_frame.cpp:1402 ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr "元に戻す"
 
-#: ../main_frame_helper.cpp:104
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr "元に戻す"
 
-#: ../annotate_dlg.cpp:47 ../checkout_dlg.cpp:83 ../columns.cpp:47
-#: ../export_dlg.cpp:86 ../log_dlg.cpp:163 ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150 ../rapidsvn_generated.cpp:529 ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr "リビジョン"
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr "リビジョンは正の数でなければなりません!"
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 msgid "Revision or date #1:"
 msgstr "リビジョンまたは日付 #1:"
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 msgid "Revision or date #2:"
 msgstr "リビジョンまたは日付 #2:"
 
-#: ../rapidsvn_generated.cpp:250 ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr "リビジョン:"
 
@@ -1580,10 +1578,6 @@ msgstr "リビジョン: %ld"
 msgid "Running command %s:"
 msgstr "実行中コマンド %s:"
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr "SSL証明書"
-
 #: ../columns.cpp:62
 msgid "Schedule"
 msgstr "スケジュール"
@@ -1593,36 +1587,28 @@ msgstr "スケジュール"
 msgid "Schedule: %s"
 msgstr "スケジュール: %s"
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr "マージには第2パスまたはURLが必要です!"
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr "第2パスまたはURL"
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr "証明書ファイルを選択してください"
 
-#: ../checkout_dlg.cpp:273 ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr "出力ディレクトリを選択してください"
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr "マージの出力先フォルダを選択してください"
 
 #: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
-#: ../main_frame.cpp:1845
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr "ディレクトリを選択してください"
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr "インポートするディレクトリを選択してください"
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr "インポートするファイルを選択してください"
 
@@ -1650,27 +1636,28 @@ msgstr "実行可能な標準エディタを選択してください"
 msgid "Select standard file explorer executable"
 msgstr "実行可能なファイルエクスプローラを選択してください"
 
-#: ../main_frame_helper.cpp:95
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr "変更を作業コピーからリポジトリに送信"
 
-#: ../checkout_dlg.cpp:94 ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
 msgstr "リポジトリ内のファイルの最新バージョンを得るにはこれをチェックします。"
 
-#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
-msgstr "ファイルのBASE/HEAD(現行)ペグ・リビジョンを使用するにはこれをチェックします。"
+msgstr ""
+"ファイルのBASE/HEAD(現行)ペグ・リビジョンを使用するにはこれをチェックします。"
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
 msgstr "チェックすると、作業コピーのブックマークが自動的に作成されます。"
 
-#: ../checkout_dlg.cpp:114 ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
 msgstr "チェックすると、URLからすべてのサブディレクトリを取得します。"
 
-#: ../checkout_dlg.cpp:125 ../export_dlg.cpp:129
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
 msgid ""
 "Set to ignore external definitions and the external working copies managed "
 "by them."
@@ -1678,59 +1665,59 @@ msgstr ""
 "チェックすると、ここで管理されている外部定義と外部参照作業コピーを無視しま"
 "す。"
 
-#: ../main_frame.cpp:320
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr "起動時にヒントを表示"
 
-#: ../main_frame.cpp:274 ../main_frame_helper.cpp:194
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 msgid "Show conflicted entries"
 msgstr "競合エントリを表示"
 
-#: ../main_frame_helper.cpp:171
+#: ../main_frame_helper.cpp:155
 msgid "Show entries in subdirectories"
 msgstr "サブディレクトリ内のエントリを表示"
 
-#: ../main_frame.cpp:276
+#: ../main_frame.cpp:285
 msgid "Show ignored entries"
 msgstr "無視エントリを表示"
 
-#: ../main_frame.cpp:273 ../main_frame_helper.cpp:188
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 msgid "Show modified entries"
 msgstr "変更エントリを表示"
 
-#: ../main_frame.cpp:269 ../main_frame_helper.cpp:170
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 msgid "Show subdirectories"
 msgstr "サブディレクトリを表示"
 
-#: ../main_frame_helper.cpp:142
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr "選択されたエントリのログメッセージを表示"
 
-#: ../main_frame.cpp:272 ../main_frame_helper.cpp:182
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 msgid "Show unmodified entries"
 msgstr "未変更エントリを表示"
 
-#: ../main_frame.cpp:271 ../main_frame_helper.cpp:176
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr "バージョン管理されていないエントリを表示"
 
-#: ../listener.cpp:360 ../main_frame.cpp:1405
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr "スキップ"
 
-#: ../main_frame.cpp:266
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr "並び替え"
 
-#: ../main_frame.cpp:242
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr "昇順に並び替え"
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 msgid "Standard Editor"
 msgstr "標準エディタ"
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 msgid "Standard Explorer"
 msgstr "標準エクスプローラ"
 
@@ -1738,39 +1725,39 @@ msgstr "標準エクスプローラ"
 msgid "Status"
 msgstr "状態"
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr "ロックが他のユーザに属している場合は奪う"
 
-#: ../main_frame_helper.cpp:219
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr "停止"
 
-#: ../main_frame_helper.cpp:220
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr "現在のアクションを停止"
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr "認証証明書をハードディスクに保存"
 
-#: ../switch_action.cpp:50 ../switch_dlg.cpp:192
+#: ../switch_action.cpp:50
 msgid "Switch URL"
 msgstr "URLの切り替え"
 
-#: ../main_frame.cpp:295
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr "URLの切り替え...\tCTRL-S"
 
-#: ../main_frame.cpp:1352
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr "テスト所要時間"
 
-#: ../main_frame.cpp:1348
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr "テスト終了時刻"
 
-#: ../main_frame.cpp:1345
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr "テスト開始時刻"
 
@@ -1780,7 +1767,8 @@ msgstr "テキスト最終更新"
 
 #: ../view_action.cpp:96
 msgid "The Editor is not configured. Please check Edit->Preferences>Programs"
-msgstr "エディタが設定されていません。編集->設定->プログラムを確認してください。"
+msgstr ""
+"エディタが設定されていません。編集->設定->プログラムを確認してください。"
 
 #: ../create_repos_dlg.cpp:141
 msgid "The configuration directory does not exist"
@@ -1790,7 +1778,7 @@ msgstr "設定ディレクトリがありません"
 msgid "The svnadmin command was not successful."
 msgstr "svnadmin コマンドが成功しませんでした。"
 
-#: ../cert_dlg.cpp:70
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
@@ -1798,11 +1786,13 @@ msgstr ""
 "サーバ証明書の検証エラーがありました。\n"
 "本当にこの証明書を信用しますか?"
 
-#: ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:418
 msgid "This action has resulted in a commit - please enter a &log message"
-msgstr "このアクションによってコミットが発生します。ログメッセージを入力してください。(&L)"
+msgstr ""
+"このアクションによってコミットが発生します。ログメッセージを入力してくださ"
+"い。(&L)"
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1814,12 +1804,9 @@ msgstr ""
 "\n"
 "以下よりオンラインで読めます:"
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr "ツリー"
-
-#: ../checkout_dlg.cpp:65 ../columns.cpp:59 ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521 ../switch_dlg.cpp:77 ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr "URL"
 
@@ -1832,11 +1819,11 @@ msgstr "URL: %s"
 msgid "UUID"
 msgstr "UUID"
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../main_frame.cpp:1494
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr "未実装アクション!"
 
@@ -1844,11 +1831,11 @@ msgstr "未実装アクション!"
 msgid "Unknown destination path"
 msgstr "未知の出力パス"
 
-#: ../unlock_action.cpp:39 ../unlock_dlg.cpp:80
+#: ../unlock_action.cpp:39
 msgid "Unlock"
 msgstr "ロック解除"
 
-#: ../listener.cpp:375 ../main_frame.cpp:1420
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr "ロックが解除"
 
@@ -1856,49 +1843,49 @@ msgstr "ロックが解除"
 msgid "Update"
 msgstr "更新"
 
-#: ../main_frame_helper.cpp:84
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr "更新"
 
-#: ../listener.cpp:363 ../main_frame.cpp:1408
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr "更新"
 
-#: ../main_frame.cpp:1556 ../main_frame.cpp:1561
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr "更新しています..."
 
-#: ../main_frame.cpp:241
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr "並び替えにパスを使用"
 
-#: ../rapidsvn_generated.cpp:271 ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 msgid "Use URL/path:"
 msgstr "URL/パスを使用"
 
-#: ../rapidsvn_generated.cpp:70 ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr "常に使用"
 
-#: ../checkout_dlg.cpp:92 ../export_dlg.cpp:95 ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299 ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103 ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr "最新を使用"
 
-#: ../auth_dlg.cpp:54 ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr "ユーザ"
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr "発効日:"
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr "有効期限:"
 
-#: ../listed_dlg.cpp:80 ../listed_dlg.cpp:172 ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr "値"
 
@@ -1906,11 +1893,37 @@ msgstr "値"
 msgid "View"
 msgstr "表示"
 
-#: ../rapidsvn_generated.cpp:696
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "View..."
+msgstr "表示(&V)..."
+
+#: ../rapidsvn_generated.cpp:567
 msgid "WARNING"
 msgstr "警告"
 
-#: ../dnd_dlg.cpp:69
+#: ../dnd_dlg.cpp:48
+#, fuzzy, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr ""
+"以下をコピーもしくは移動しますか\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"保存先\n"
+"\n"
+"  %s"
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -1931,31 +1944,27 @@ msgstr ""
 "\n"
 "  %s"
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr "はい"
-
-#: ../main_frame.cpp:1863
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
 msgstr "Subversion管理ディレクトリをブックマークに追加することはできません!"
 
-#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1261
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr "追加"
 
-#: ../filelist_ctrl.cpp:1226 ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr "追加"
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr "衝突"
 
-#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1264
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr "削除"
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr "削除"
 
@@ -1963,7 +1972,7 @@ msgstr "削除"
 msgid "directory"
 msgstr "ディレクトリ"
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr "外部参照"
 
@@ -1971,63 +1980,67 @@ msgstr "外部参照"
 msgid "file"
 msgstr "ファイル"
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr "無視"
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr "未完了"
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr "マージ"
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr "紛失"
 
-#: ../filelist_ctrl.cpp:1229 ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr "変更"
 
-#: ../export_dlg.cpp:135 ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr "ネイティブ"
 
-#: ../file_info.cpp:132 ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr "なし"
 
-#: ../file_info.cpp:146 ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr "通常"
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr "妨害"
 
-#: ../filelist_ctrl.cpp:1294 ../filelist_ctrl.cpp:1308
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr "期限切れ"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.4"
 msgstr "Subversion 1.4 以下"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.5"
 msgstr "Subversion 1.5 以下"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.6"
 msgstr "Subversion 1.6 以下"
 
-#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1267
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr "置換"
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr "置換"
 
@@ -2039,17 +2052,124 @@ msgstr "svnadminが見つかりません"
 msgid "unknown"
 msgstr "不明"
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr "不明な値"
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
 msgstr "バージョン管理外"
 
-#: ../main_frame.cpp:329
-msgid "wxString Creation&Tracing Test"
-msgstr "wxString Creation&Tracing Test"
+#~ msgid "Action"
+#~ msgstr "アクション"
+
+#~ msgid "Checkout Test"
+#~ msgstr "チェックアウトテスト"
+
+#~ msgid "Copied from Path"
+#~ msgstr "コピー元パス"
+
+#~ msgid "Copied from Rev"
+#~ msgstr "コピー元リビジョン"
+
+#~ msgid "Destination file"
+#~ msgstr "出力ファイル"
+
+#~ msgid "Destination path"
+#~ msgstr "出力パス"
+
+#~ msgid "EOL:"
+#~ msgstr "EOL:"
+
+#~ msgid "Enter log message"
+#~ msgstr "ログメッセージを入力してください"
+
+#~ msgid "Enter the local path where you want the code be exported."
+#~ msgstr "コードをエクスポートしたいローカルパスを入力してください。"
+
+#~ msgid ""
+#~ "Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
+#~ "files."
+#~ msgstr ""
+#~ "エクスポートされるファイル中のEOL(行終端)として望ましい記号の種類を入力し"
+#~ "てください。"
+
+#~ msgid "File path required when importing a file!"
+#~ msgstr "ファイルをインポートするにはファイルパスが必要です!"
+
+#~ msgid "First path or URL is required for merge!"
+#~ msgstr "マージには第1パスまたはURLが必要です!"
+
+#~ msgid ""
+#~ "Invalid selection. At least one revisions is needed for diff and no more "
+#~ "than two."
+#~ msgstr ""
+#~ "無効な選択。比較には少なくとも1つ(かつ、2つ以下)のリビジョンが必要です。"
+
+#~ msgid "Invalid selection. Exactly two revisions needed for merge."
+#~ msgstr "無効な選択。マージには2つのリビジョンが必要です。"
+
+#~ msgid "Invalid selection. Only one revision may be selected for annotate"
+#~ msgstr "無効な選択。注釈には1つのリビジョンしか選べません"
+
+#~ msgid "Listener Test"
+#~ msgstr "リスナテスト"
+
+#~ msgid "Locate help"
+#~ msgstr "ヘルプを探す"
+
+#~ msgid "Locate tips"
+#~ msgstr "ヒントを探す"
+
+#~ msgid "Locate tips file"
+#~ msgstr "ヒントのファイルを探す"
+
+#~ msgid "Log Message:"
+#~ msgstr "ログメッセージ:"
+
+#~ msgid "Merge revisions"
+#~ msgstr "リビジョン間でマージ"
+
+#~ msgid "No"
+#~ msgstr "いいえ"
+
+#~ msgid ""
+#~ "No help file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "ヘルプファイルが選択されていません。\n"
+#~ "次回起動時にも問い合わせますか?"
+
+#~ msgid ""
+#~ "No tips file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "ヒントファイルが選択されていません。\n"
+#~ "次回起動時にも問い合わせますか?"
+
+#~ msgid "RapidSVN Help: %s"
+#~ msgstr "RapidSVN ヘルプ: %s"
+
+#~ msgid "Revision must be an unsigned number!"
+#~ msgstr "リビジョンは正の数でなければなりません!"
+
+#~ msgid "SSL Certificate"
+#~ msgstr "SSL証明書"
+
+#~ msgid "Second path or URL is required for merge!"
+#~ msgstr "マージには第2パスまたはURLが必要です!"
+
+#~ msgid "Second working copy or URL"
+#~ msgstr "第2パスまたはURL"
+
+#~ msgid "Tree"
+#~ msgstr "ツリー"
+
+#~ msgid "Yes"
+#~ msgstr "はい"
+
+#~ msgid "wxString Creation&Tracing Test"
+#~ msgstr "wxString Creation&Tracing Test"
 
 #~ msgid "Information"
 #~ msgstr "情報"

--- a/librapidsvn/src/locale/pt_BR/rapidsvn.po
+++ b/librapidsvn/src/locale/pt_BR/rapidsvn.po
@@ -8,10 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RapidSVN 0.9.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-02 17:09+0100\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: 2006-09-20 12:00-0300\n"
 "Last-Translator: Jose Carlos Medeiros <jose@psabs.com.br>\n"
 "Language-Team: Portuguese/Brazil <gnome-l10n-br@listas.cipsga.org.br>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,22 +24,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr "%s  código: %ld"
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, fuzzy, c-format
 msgid "%s Version %s"
 msgstr "%s Versão %d.%d.%d"
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, fuzzy, c-format
 msgid "%s Version %s Revision %d"
 msgstr "%s Versão %d.%d.%d"
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr ""
 
-#: ../main_frame.cpp:323
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr "&Sobre..."
 
@@ -46,38 +47,33 @@ msgstr "&Sobre..."
 msgid "&Add\tINS"
 msgstr ""
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr "&Adicionar Cópia de Trabalho..."
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr ""
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 #, fuzzy
 msgid "&Annotate..."
 msgstr "&Sobre..."
 
-#: ../main_frame.cpp:344
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr "&Favoritos"
 
-#: ../rapidsvn_generated.cpp:676
+#: ../rapidsvn_generated.cpp:549
 #, fuzzy
 msgid "&Browse"
 msgstr "Fechar"
 
-#: ../log_dlg.cpp:359
-#, fuzzy
-msgid "&Close"
-msgstr "Fechar"
-
-#: ../rapidsvn_generated.cpp:655
+#: ../rapidsvn_generated.cpp:528
 msgid "&Compatible with:"
 msgstr ""
 
-#: ../main_frame.cpp:316
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr "&Conteúdo\tF1"
 
@@ -85,7 +81,7 @@ msgstr "&Conteúdo\tF1"
 msgid "&Copy...\tF5"
 msgstr "&Copiar...\tF5"
 
-#: ../main_frame.cpp:290
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr "&Criar..."
 
@@ -93,11 +89,11 @@ msgstr "&Criar..."
 msgid "&Delete\tDEL"
 msgstr "&Excluir\tDEL"
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr "&Excluir..."
 
-#: ../log_dlg.cpp:362 ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 #, fuzzy
 msgid "&Diff"
 msgstr "Diff"
@@ -110,45 +106,50 @@ msgstr "&Diff para a Base...\tCTRL+B"
 msgid "&Diff to Head...\tCTRL+H"
 msgstr "&Diff para o Head...\tCTRL+H"
 
+#: ../utils.cpp:220
+#, fuzzy
+msgid "&Diff..."
+msgstr "Diff"
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr "&Diff...\tCTRL+D"
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr "&Editar Favorito..."
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr "&Editar..."
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr "&Editar...\tF3"
 
-#: ../main_frame.cpp:288
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr "&Exportar...\tCTRL-E"
 
-#: ../main_frame.cpp:345
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr "&Extras"
 
-#: ../main_frame.cpp:339
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr "&Arquivo"
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 #, fuzzy
 msgid "&Files to commit"
 msgstr "Falhou ao bloquear"
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 #, fuzzy
 msgid "&Get"
 msgstr "Baixar"
 
-#: ../main_frame.cpp:223 ../main_frame.cpp:346
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr "&Ajudar"
 
@@ -157,11 +158,11 @@ msgstr "&Ajudar"
 msgid "&Ignore\tCTRL-DEL"
 msgstr "&Exportar...\tCTRL-E"
 
-#: ../main_frame.cpp:287
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr "&Importar...\tCTRL-I"
 
-#: ../main_frame.cpp:317
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr "&Índice\tShift+F1"
 
@@ -169,7 +170,7 @@ msgstr "&Índice\tShift+F1"
 msgid "&Info..."
 msgstr "&Info..."
 
-#: ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:540
 msgid "&Load configuration from directory (optional):"
 msgstr ""
 
@@ -177,29 +178,44 @@ msgstr ""
 msgid "&Lock..."
 msgstr "&Bloquear..."
 
+#: ../utils.cpp:222
+#, fuzzy
+msgid "&Log..."
+msgstr "&Registro...\tCTRL-L"
+
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr "&Registro...\tCTRL-L"
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 #, fuzzy
 msgid "&Merge"
 msgstr "Fundir (merge)"
 
-#: ../main_frame.cpp:342
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr "&Modificar"
 
-#: ../rapidsvn_generated.cpp:625
+#: ../rapidsvn_generated.cpp:897
+#, fuzzy
+msgid "&Name"
+msgstr "Nome"
+
+#: ../rapidsvn_generated.cpp:499
 #, fuzzy
 msgid "&Name of the new repository:"
 msgstr "Criar Novo Repositório..."
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr "&Novo..."
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+#, fuzzy
+msgid "&Password"
+msgstr "Senha"
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr "&Permanentemente"
 
@@ -207,45 +223,50 @@ msgstr "&Permanentemente"
 msgid "&Properties...\tCTRL-P"
 msgstr "&Propriedades...\tCTRL-P"
 
-#: ../main_frame.cpp:343
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr "&Consulta"
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 #, fuzzy
 msgid "&Recent entries:"
 msgstr "Entradas recentes:"
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 #, fuzzy
 msgid "&Remove Bookmark"
 msgstr "&Remover Favorito..."
 
-#: ../main_frame.cpp:341
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr "&Repositório"
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+#, fuzzy
+msgid "&Revision"
+msgstr "Revisão"
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr "&Parar"
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr "&Trocar a URL do Repositório..."
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr "&Temporariamente"
 
-#: ../main_frame.cpp:348
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr "&Testes"
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:599
+#: ../rapidsvn_generated.cpp:473
 msgid "&Type:"
 msgstr ""
 
@@ -253,31 +274,41 @@ msgstr ""
 msgid "&Unlock"
 msgstr "&Desbloquear"
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr "&Atualizar...\tCTRL-U"
 
-#: ../log_dlg.cpp:360 ../main_frame.cpp:340
+#: ../rapidsvn_generated.cpp:89
+#, fuzzy
+msgid "&Username"
+msgstr "Renomear"
+
+#: ../rapidsvn_generated.cpp:904
+#, fuzzy
+msgid "&Value"
+msgstr "Valor"
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr "&Visualizar"
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr "&Visualizar..."
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr "- O certificado tem um erro desconhecido."
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr "- O certificado expirou."
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr "- O nome da máquina no certificado não confere."
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
@@ -285,9 +316,15 @@ msgstr ""
 "- O certificado não esta autenticado por uma autorizadora válida.\n"
 "  Use o fingerprint para validar o certificado manualmente!"
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
 msgstr "- O certificado ja não é mais válido."
+
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+#, fuzzy
+msgid "..."
+msgstr "&Novo..."
 
 #: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
 msgid "<None>"
@@ -301,30 +338,25 @@ msgstr ""
 msgid "A file of this name exists already"
 msgstr ""
 
-#: ../about_dlg.cpp:68
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr "ANSI"
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr "Sobre %s"
 
-#: ../log_dlg.cpp:242
-#, fuzzy
-msgid "Action"
-msgstr "Autenticação"
-
-#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listener.cpp:353
-#: ../main_frame.cpp:1398
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr "Adicionar"
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr "Adicionar &Repositório Existente..."
 
-#: ../rapidsvn_generated.cpp:642
+#: ../rapidsvn_generated.cpp:516
 msgid "Add a bookmark for the new repository"
 msgstr ""
 
@@ -332,40 +364,40 @@ msgstr ""
 msgid "Add r&ecursive"
 msgstr "Adicionar r&ecursivo"
 
-#: ../main_frame_helper.cpp:64
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr "Adicionar a seleção"
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr "Adicionar ao favoritos"
 
-#: ../listener.cpp:362 ../listener.cpp:369 ../main_frame.cpp:1407
-#: ../main_frame.cpp:1414
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr "Adicionado"
 
-#: ../main_frame.cpp:1904
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr "Adicionado o repositório ao favoritos '%s'"
 
-#: ../main_frame.cpp:1875
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr "Adicionada a cópia de trabalho ao favoritos '%s'"
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, fuzzy, c-format
 msgid "Adding file to repository: %s"
 msgstr "Repositório: %s"
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr ""
 
@@ -373,11 +405,11 @@ msgstr ""
 msgid "All files|*"
 msgstr "Todos os arquivos|*"
 
-#: ../main_frame.cpp:1271 ../main_frame.cpp:1290
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr ""
 
-#: ../main_frame.cpp:1258
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr ""
 
@@ -386,7 +418,7 @@ msgstr ""
 msgid "Annotate"
 msgstr "desatualizado"
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -398,11 +430,11 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../auth_dlg.cpp:117 ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: ../annotate_dlg.cpp:48 ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr "Autor"
 
@@ -410,11 +442,11 @@ msgstr "Autor"
 msgid "BASE"
 msgstr "BASE"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../rapidsvn_generated.cpp:477
 msgid "BerkeleyDB"
 msgstr ""
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr "Favorito"
 
@@ -422,17 +454,17 @@ msgstr "Favorito"
 msgid "Bookmarks"
 msgstr "Favoritos"
 
-#: ../main_frame_helper.cpp:85
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr "Traz as alterações do repositório para a cópia de trabalho"
 
-#: ../rapidsvn_generated.cpp:57 ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119 ../rapidsvn_generated.cpp:146
-#: ../rapidsvn_generated.cpp:620
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr ""
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -443,44 +475,44 @@ msgstr ""
 "wxWidgets %d.%d.%d (%s)\n"
 "Subversion %d.%d.%d\n"
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr "CR (MacOS)"
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr "CRLF (Windows)"
 
-#: ../auth_dlg.cpp:73 ../cert_dlg.cpp:138 ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57 ../destination_dlg.cpp:90 ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146 ../import_dlg.cpp:130 ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342 ../lock_dlg.cpp:61 ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195 ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409 ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564 ../rapidsvn_generated.cpp:708
-#: ../switch_dlg.cpp:139 ../unlock_dlg.cpp:58 ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+#, fuzzy
+msgid "Certificate information:"
 msgstr "Informações do Certificado:"
 
-#: ../main_frame.cpp:289
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr "Check&out...\tCTRL-O"
 
-#: ../checkout_action.cpp:40 ../checkout_dlg.cpp:250
+#: ../checkout_action.cpp:40
 msgid "Checkout"
 msgstr "Checkout"
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
 msgstr "Checkout de Nova Cópia de Trabalho..."
-
-#: ../main_frame.cpp:331
-msgid "Checkout Test"
-msgstr "Teste de Checkout"
 
 #: ../columns.cpp:58
 msgid "Checksum"
@@ -491,20 +523,25 @@ msgstr "Checksum"
 msgid "Checksum: %s"
 msgstr "Checksum: %s"
 
-#: ../cleanup_action.cpp:39 ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr "Limpar"
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+#, fuzzy
+msgid "Close"
+msgstr "Fechar"
+
+#: ../utils.cpp:297
 #, fuzzy
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr "Co&mmit...\tCTRL-M"
 
-#: ../main_frame.cpp:265
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr "Colunas"
 
-#: ../rapidsvn_generated.cpp:275 ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr ""
 
@@ -516,11 +553,11 @@ msgstr "Commit"
 msgid "Commit Log Message"
 msgstr "Mensagem de Registro do Commit"
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr ""
 
-#: ../main_frame_helper.cpp:94
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr "Commit da seleção"
 
@@ -528,9 +565,19 @@ msgstr "Commit da seleção"
 msgid "Committed revision"
 msgstr "Revisão gravada (commited)"
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
 msgstr "Comparar:"
+
+#: ../listener.cpp:496
+#, fuzzy, c-format
+msgid "Completed %s at revision %d"
+msgstr "Revisão gravada (commited)"
+
+#: ../listener.cpp:486
+#, fuzzy, c-format
+msgid "Completed at revision %d"
+msgstr "Revisão gravada (commited)"
 
 #: ../columns.cpp:64
 msgid "Conflict BASE"
@@ -564,6 +611,11 @@ msgstr "Trabalho Conflitante"
 msgid "Conflict Working File: %s"
 msgstr "Arquivo Conflitante: %s"
 
+#: ../listener.cpp:307
+#, fuzzy
+msgid "Conflicted"
+msgstr "conflitante"
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr "Copiado"
@@ -578,32 +630,22 @@ msgstr "Copiado da Rev: %ld"
 msgid "Copied From URL: %s"
 msgstr "Copiado da URL: %s"
 
-#: ../log_dlg.cpp:244
-#, fuzzy
-msgid "Copied from Path"
-msgstr "Copiado da URL: %s"
-
-#: ../log_dlg.cpp:245
-#, fuzzy
-msgid "Copied from Rev"
-msgstr "Copiado da Rev: %ld"
-
-#: ../dnd_dlg.cpp:108 ../listener.cpp:354 ../main_frame.cpp:1399
-#: ../move_action.cpp:44
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr "Cópia"
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 #, fuzzy
 msgid "Copy/Move"
 msgstr "Cópia"
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, fuzzy, c-format
 msgid "Copying file into working directory: %s"
 msgstr "Não é possível alterar a pasta de trabalho para %s"
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, fuzzy, c-format
 msgid "Copying file: %s"
 msgstr "Arquivo Conflitante: %s"
@@ -613,7 +655,7 @@ msgstr "Arquivo Conflitante: %s"
 msgid "Could not set working directory to %s"
 msgstr "Não é possível alterar a pasta de trabalho para %s"
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr "Criar Novo Repositório..."
 
@@ -622,59 +664,51 @@ msgstr "Criar Novo Repositório..."
 msgid "Create Repository"
 msgstr "Criar Novo Repositório..."
 
-#: ../rapidsvn_generated.cpp:611
+#: ../rapidsvn_generated.cpp:485
 #, fuzzy
 msgid "Create repository in &directory:"
 msgstr "Selecione uma pasta para destino"
 
-#: ../columns.cpp:54 ../log_dlg.cpp:165
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr "Data"
 
-#: ../rapidsvn_generated.cpp:265 ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr "Data:"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 #, fuzzy
 msgid "Default"
 msgstr "Excluir"
 
-#: ../delete_action.cpp:40 ../delete_dlg.cpp:79 ../listener.cpp:355
-#: ../main_frame.cpp:1400
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr "Excluir"
 
-#: ../main_frame_helper.cpp:75
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr "Excluir os arquivos e pastas do controle de versões"
 
-#: ../main_frame_helper.cpp:74
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr "Excluir a seleção"
 
-#: ../listener.cpp:361 ../listener.cpp:370 ../main_frame.cpp:1406
-#: ../main_frame.cpp:1415
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr "Excluido"
 
-#: ../checkout_dlg.cpp:72 ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
 msgstr "Pasta de Destino"
-
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr "Arquivo de Destino"
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
-msgstr "Caminho de Destino"
 
 #: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr "Diff"
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 #, fuzzy
 msgid "Diff Tool"
 msgstr "Ferramenta Diff:"
@@ -695,82 +729,97 @@ msgstr "Diff de outra revisão/data"
 msgid "Diff two revisions/dates"
 msgstr "Diff de duas revisões/datas"
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
 msgstr "Autenticações diferentes para cada favorito na lista dos favoritos"
+
+#: ../rapidsvn_generated.cpp:1296
+#, fuzzy
+msgid "Directory"
+msgstr "Pasta:"
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr "Pasta:"
 
-#: ../rapidsvn_generated.cpp:681
+#: ../rapidsvn_generated.cpp:554
 msgid "Disable automatic Log removal"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:685
+#: ../rapidsvn_generated.cpp:557
 msgid "Disable fsync when committing database transactions"
 msgstr ""
 
-#: ../main_frame_helper.cpp:195
+#: ../main_frame_helper.cpp:179
 #, fuzzy
 msgid "Display conflicted files/directories"
 msgstr "Deseja desbloquear os arquivos/pastas selecionado(a)s?"
 
-#: ../main_frame_helper.cpp:132
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr "Mostrar informações das entradas selecionadas"
 
-#: ../main_frame_helper.cpp:189
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:183
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:177
+#: ../main_frame_helper.cpp:161
 #, fuzzy
 msgid "Display unversioned files/directories"
 msgstr "Exibir os itens não versionados"
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr "Deseja remover os arquivos/pastas selecionado(a)s?"
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr "Deseja reverter as alterações locais?"
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr "Deseja desbloquear os arquivos/pastas selecionado(a)s?"
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr "Sai&r\tCTRL-Q"
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr "EOL:"
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr "Editar"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr "Editar o Favorito"
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr "Editar a Propriedade"
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "Edit..."
+msgstr "&Editar..."
+
+#: ../rapidsvn_generated.cpp:1306
+#, fuzzy
+msgid "End &log message"
+msgstr "Entre com a mensagem de registro"
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 #, fuzzy
 msgid "Enter &log message"
 msgstr "Entre com a mensagem de registro"
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr "Entre com um comentário para este bloqueio"
 
@@ -779,39 +828,19 @@ msgstr "Entre com um comentário para este bloqueio"
 msgid "Enter a name for the repository"
 msgstr "Entre com um comentário para este bloqueio"
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr "Entre com a mensagem de registro"
-
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr "Entre com o novo nome:"
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr ""
-"Entre com o caminho local aonde você deseja que o código seja exportado."
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
 msgstr "Entre com o caminho local aonde você deseja gravar o código."
 
-#: ../checkout_dlg.cpp:70 ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr "Entre com a URL do repositório (não o caminho local)."
 
-#: ../export_dlg.cpp:143
-msgid ""
-"Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
-"files."
-msgstr ""
-"Entre com o(s) símbolo(s) para serem EOL (fim de linha) nos arquivos "
-"exportados."
-
-#: ../import_dlg.cpp:178 ../import_dlg.cpp:191 ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494 ../log_dlg.cpp:530 ../main_frame.cpp:1865
-#: ../merge_dlg.cpp:52 ../merge_dlg.cpp:91 ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr "Erro"
 
@@ -823,11 +852,18 @@ msgstr "Erro lendo o status:"
 msgid "Error running svnadmin"
 msgstr ""
 
-#: ../property_dlg.cpp:120
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr "Erro alterando os valores da propriedade"
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, fuzzy, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr "Erro alterando os valores da propriedade"
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr "Erro validando o certificado do servidor para '%s':"
@@ -850,26 +886,26 @@ msgstr "Erro durante a preparação da ação."
 msgid "Error while preparing action: %s"
 msgstr "Erro durante a preparação da ação: %s"
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr "Erro durante a atualização da lista de arquivos (%s)"
 
-#: ../main_frame.cpp:907
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr "Erro durante a alteração da lista de arquivos"
 
-#: ../main_frame.cpp:894
+#: ../main_frame.cpp:917
 #, c-format
 msgid "Error while updating filelist (%s)"
 msgstr "Erro durante a alteração da lista de arquivos (%s)"
 
-#: ../main_frame.cpp:542
+#: ../main_frame.cpp:561
 #, fuzzy, c-format
 msgid "Error: %s\n"
 msgstr "Erro"
 
-#: ../main_frame.cpp:1799
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
 msgstr "Ocorreu uma exceção durante a alteração da lista de arquivos"
 
@@ -906,11 +942,11 @@ msgstr "Ferramenta diff: %s"
 msgid "Execute: %s"
 msgstr "Executar: %s"
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr "Gerenciar Arquivos...\tF2"
 
-#: ../export_action.cpp:40 ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr "Exportar"
 
@@ -918,52 +954,48 @@ msgstr "Exportar"
 msgid "Extension"
 msgstr "Extensão"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../listener.cpp:405
+#, fuzzy
+msgid "External"
+msgstr "externo"
+
+#: ../rapidsvn_generated.cpp:477
 msgid "FSFS"
 msgstr ""
 
-#: ../listener.cpp:376 ../main_frame.cpp:1421
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr "Falhou ao bloquear"
 
-#: ../listener.cpp:377 ../main_frame.cpp:1422
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr "Falhou ao desbloquear"
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr "Arquivo"
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr "É requerido um caminho durante a importação do arquivo!"
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr "Fingerprint:"
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr "É requerido o primeiro caminho ou URL para fundir (merge)!"
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr "Primeira cópia de trabalho ou URL"
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr "Para mais informações veja:"
 
-#: ../destination_dlg.cpp:80 ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr "Forçar"
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr "Forçar remoção"
 
-#: ../export_dlg.cpp:123
+#: ../export_dlg.cpp:75
 msgid ""
 "Force to execute even if destination directory not empty, causes overwriting "
 "of files with the same names."
@@ -971,11 +1003,11 @@ msgstr ""
 "Forçar a execução mesmo se a pasta destino não estiver vazia, causa a "
 "substituição de arquivos com os mesmos nomes."
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
 msgstr "Força o desbloqueio mesmo se você não for o dono do bloqueio"
 
-#: ../rapidsvn_generated.cpp:41 ../rapidsvn_generated.cpp:649
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr "Geral"
 
@@ -988,16 +1020,25 @@ msgstr "Baixar o arquivo %s rev. %s"
 msgid "HEAD"
 msgstr "HEAD"
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+#, fuzzy
+msgid "Help"
+msgstr "&Ajudar"
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr "Histórico: %d revisões"
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr "Nome da máquina:"
 
-#: ../checkout_dlg.cpp:88 ../export_dlg.cpp:91
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
 msgid ""
 "If not using the latest version of the files, specify which revision to use "
 "here."
@@ -1005,7 +1046,7 @@ msgstr ""
 "Se não estiver usando a última versão dos arquivos, especifique qual revisão "
 "deve ser utilizada."
 
-#: ../checkout_dlg.cpp:102 ../export_dlg.cpp:105
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
 msgid ""
 "If the files were renamed or moved some time, specify which peg revision to "
 "use here."
@@ -1018,20 +1059,24 @@ msgstr ""
 msgid "Ignore"
 msgstr "Informações"
 
-#: ../main_frame.cpp:275 ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr "Ignorar Externos"
 
-#: ../checkout_dlg.cpp:122 ../export_dlg.cpp:126 ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr "Ignorar externos"
 
-#: ../dnd_dlg.cpp:37 ../dnd_dlg.cpp:97 ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr "Importar"
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+#, fuzzy
+msgid "Import &Path"
+msgstr "Importar"
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr ""
@@ -1041,15 +1086,15 @@ msgstr ""
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr "&Propriedades...\tCTRL-P"
 
-#: ../main_frame.cpp:270
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr ""
 
-#: ../main_frame.cpp:1984
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr "Informações"
 
-#: ../main_frame_helper.cpp:131
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr "Informações da seleção"
 
@@ -1057,7 +1102,7 @@ msgstr "Informações da seleção"
 msgid "Internal Error: There is another action running"
 msgstr "Erro Interno: Existe outra ação sendo executada"
 
-#: ../main_frame.cpp:1542
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr "Erro Interno: sem dados do cliente para uma ação!"
 
@@ -1069,36 +1114,17 @@ msgstr "Erro Interno: sem contexto disponível"
 msgid "Invalid revision number detected"
 msgstr "Detectado um número inválido de revisão"
 
-#: ../log_dlg.cpp:478
+#: ../rapidsvn_generated.cpp:159
 #, fuzzy
-msgid ""
-"Invalid selection. At least one revisions is needed for diff and no more "
-"than two."
-msgstr ""
-"Seleção inválida. São necessário apenas duas revisões para a diferença "
-"(diff)."
-
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr ""
-"Seleção inválida. São necessário apenas duas revisões para fundir (merge)."
-
-#: ../log_dlg.cpp:529
-#, fuzzy
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr ""
-"Seleção inválida. São necessário apenas duas revisões para fundir (merge)."
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
+msgid "Issuer:"
 msgstr "Edição:"
 
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 #, fuzzy
 msgid "Keep Locks"
 msgstr "Manter bloqueios"
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr "LF (Unix)"
 
@@ -1120,20 +1146,16 @@ msgstr "Data da Última Alteração"
 msgid "Last Changed Rev: %ld"
 msgstr "Revisão Última Alteração: %ld"
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr ""
 
-#: ../main_frame.cpp:330
-msgid "Listener Test"
-msgstr "Teste de Escuta"
-
-#: ../filelist_ctrl.cpp:1058
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr "Listando entradas em '%s'"
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1146,19 +1168,7 @@ msgstr ""
 "Nome do Sistema: %s\n"
 "Nome Canônico: %s\n"
 
-#: ../rapidsvn_app.cpp:198 ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr "Localizar ajuda"
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr "Localizar dicas"
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr "Localizar arquivo de dicas"
-
-#: ../lock_action.cpp:40 ../lock_dlg.cpp:100
+#: ../lock_action.cpp:40
 msgid "Lock"
 msgstr "Bloquear"
 
@@ -1193,31 +1203,27 @@ msgstr "Dono do Bloqueio: %s"
 msgid "Lock Token: %s"
 msgstr "Sinal do Bloqueio: %s"
 
-#: ../listener.cpp:374 ../main_frame.cpp:1419
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr "Bloqueado"
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr "Registro"
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr "Histórico de Registros"
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr "Mensagem do Registro"
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr "Mensagem do Registro:"
-
-#: ../main_frame_helper.cpp:141
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr "Registro da seleção"
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr "Conectar..."
 
@@ -1242,40 +1248,41 @@ msgstr "Criar &pasta...\tF7"
 msgid "Make directory"
 msgstr "Criar pasta"
 
-#: ../merge_action.cpp:38 ../merge_action.cpp:44 ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr "Fundir (merge)"
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 #, fuzzy
 msgid "Merge Tool"
 msgstr "Fundir (merge)"
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
-msgstr "Fundir (merge) revisões"
-
-#: ../main_frame.cpp:294
+#: ../main_frame.cpp:303
 msgid "Merge..."
 msgstr "Fundir (merge)..."
+
+#: ../listener.cpp:308
+#, fuzzy
+msgid "Merged"
+msgstr "Fundir (merge)"
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr "Mkdir"
 
-#: ../listener.cpp:368 ../main_frame.cpp:1413
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr "Modificado"
 
-#: ../rapidsvn_generated.cpp:692
+#: ../rapidsvn_generated.cpp:563
 msgid "More options"
 msgstr ""
 
-#: ../dnd_dlg.cpp:104 ../move_action.cpp:42
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr "Mover"
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, fuzzy, c-format
 msgid "Moving file: %s"
 msgstr "Arquivo Conflitante: %s"
@@ -1284,8 +1291,16 @@ msgstr "Arquivo Conflitante: %s"
 msgid "Multiple Files"
 msgstr ""
 
-#: ../columns.cpp:45 ../listed_dlg.cpp:75 ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr "Nome"
 
@@ -1294,44 +1309,24 @@ msgstr "Nome"
 msgid "Name: %s"
 msgstr "Nome: %s"
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
 msgstr "Nova Propriedade"
-
-#: ../revert_dlg.cpp:57
-msgid "No"
-msgstr ""
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr ""
 
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Nenhum arquivo de ajuda foi encontrado, deseja \n"
-"ver esta pergunta na próxima execução?"
-
 #: ../userresolve_action.cpp:62
 msgid "No merge tool set in the preferences"
 msgstr ""
-
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Nenhum arquivo de dicas foi encontrado, deseja \n"
-"ver esta pergunta na próxima execução?"
 
 #: ../file_info.cpp:118
 #, c-format
 msgid "Node Kind: %s"
 msgstr "Tipo do Nó: %s"
 
-#: ../checkout_dlg.cpp:106 ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr "Não especificado"
 
@@ -1339,39 +1334,38 @@ msgstr "Não especificado"
 msgid "Not versioned"
 msgstr "Não versionado"
 
-#: ../about_dlg.cpp:114 ../annotate_dlg.cpp:42 ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126 ../delete_dlg.cpp:54 ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145 ../import_dlg.cpp:128 ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341 ../lock_dlg.cpp:60 ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191 ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405 ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560 ../rapidsvn_generated.cpp:704
-#: ../report_dlg.cpp:57 ../switch_dlg.cpp:137 ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr "OK"
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr "Abrir..."
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr "Sobrescrever"
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr "Senha"
-
-#: ../columns.cpp:46 ../import_dlg.cpp:80 ../log_dlg.cpp:243
+#: ../columns.cpp:46
 msgid "Path"
 msgstr "Caminho"
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+#, fuzzy
+msgid "Path &type"
 msgstr "Tipo do Caminho:"
 
-#: ../checkout_dlg.cpp:97 ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr "Etiqueta (Peg) de Revisão"
 
@@ -1379,28 +1373,28 @@ msgstr "Etiqueta (Peg) de Revisão"
 msgid "Preferences"
 msgstr "Preferências"
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr "Preferências..."
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 #, fuzzy
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr "Argumentos (%1=arq1, %2=arq2):"
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr "Argumentos (%1=arq1, %2=arq2):"
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr "Argumentos (%1=pasta selecionada):"
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr "Argumentos (%1=arquivo selecionado):"
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr "Programas"
 
@@ -1416,7 +1410,7 @@ msgstr "Estado Prop."
 msgid "Properties Last Updated"
 msgstr "Última Alteração de Propriedades"
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr "Propriedades:"
 
@@ -1428,22 +1422,21 @@ msgstr "Propriedade"
 msgid "Property Editor"
 msgstr "Editor de Propriedade"
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr "Remover arquivos temporários do programa ao sair"
 
-#: ../main_frame_helper.cpp:65
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr "Colocar os arquivos e pastas sob o controle de revisões"
 
-#: ../main_frame.cpp:509
-msgid "RapidSVN Error"
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
 msgstr ""
 
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
-msgstr "Ajuda do RapidSVN: %s"
+#: ../main_frame.cpp:528
+msgid "RapidSVN Error"
+msgstr ""
 
 #: ../utils.cpp:192
 msgid "Re&name...\tCTRL-N"
@@ -1457,52 +1450,52 @@ msgstr "Re&solver conflitos\tCTRL-S"
 msgid "Re&vert\tCTRL-V"
 msgstr "Re&verter\tCTRL-V"
 
-#: ../filelist_ctrl.cpp:1134
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr "Pronto"
 
-#: ../main_frame.cpp:1522 ../main_frame.cpp:1566
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr "Pronto\n"
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr "Entradas recentes:"
 
-#: ../checkout_dlg.cpp:111 ../export_dlg.cpp:114 ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201 ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547 ../revert_dlg.cpp:49 ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: ../main_frame_helper.cpp:206
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr "Recarregar"
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr "Recarregar\tCTRL-R"
 
-#: ../main_frame_helper.cpp:207
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr "Recarregar a lista de arquivos"
 
-#: ../main_frame.cpp:268
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr "Recarregar e Atualizar"
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 #, fuzzy
 msgid "Relocate"
 msgstr "Trocado"
 
-#: ../main_frame_helper.cpp:115
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
 msgstr ""
 "Remover o estado 'conflito' dos arquivos ou pastas na cópia de trabalho"
 
-#: ../main_frame.cpp:1918
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr "Favorito removido"
 
@@ -1514,7 +1507,7 @@ msgstr "Renomear"
 msgid "Rep. Rev."
 msgstr "Rev. Rep."
 
-#: ../listener.cpp:371 ../main_frame.cpp:1416
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr "Trocado"
 
@@ -1522,13 +1515,14 @@ msgstr "Trocado"
 msgid "Repository"
 msgstr "Repositório"
 
-#: ../import_dlg.cpp:67 ../main_frame.cpp:1890
+#: ../rapidsvn_generated.cpp:1268
+#, fuzzy
+msgid "Repository &URL for import"
+msgstr "É requerida a URL do repositório para a importação!"
+
+#: ../main_frame.cpp:2079
 msgid "Repository URL"
 msgstr "URL do Repositório"
-
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
-msgstr "É requerida a URL do repositório para a importação!"
 
 #: ../file_info.cpp:112
 #, c-format
@@ -1540,11 +1534,11 @@ msgstr "UUID do Repositório: %s"
 msgid "Repository: %s"
 msgstr "Repositório: %s"
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr "Resetar Colunas"
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr ""
 
@@ -1552,57 +1546,51 @@ msgstr ""
 msgid "Resolve"
 msgstr "Resolver"
 
-#: ../main_frame_helper.cpp:114
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr "Resolver a seleção"
 
-#: ../listener.cpp:359 ../main_frame.cpp:1404
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr "Resolvido"
 
-#: ../listener.cpp:356 ../main_frame.cpp:1401
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr "Restaurar"
 
-#: ../main_frame_helper.cpp:105
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
 msgstr "Restaura a cópia de trabalho original (desfaz todas as edições locais)"
 
-#: ../rapidsvn_generated.cpp:632
+#: ../rapidsvn_generated.cpp:506
 msgid "Resulting repository filename:"
 msgstr ""
 
-#: ../listener.cpp:357 ../main_frame.cpp:1402 ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr "Reverter"
 
-#: ../main_frame_helper.cpp:104
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr "Reverter a seleção"
 
-#: ../annotate_dlg.cpp:47 ../checkout_dlg.cpp:83 ../columns.cpp:47
-#: ../export_dlg.cpp:86 ../log_dlg.cpp:163 ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150 ../rapidsvn_generated.cpp:529 ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr "Revisão"
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr "A revisão deve ser um número não sinalizado!"
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 #, fuzzy
 msgid "Revision or date #1:"
 msgstr "Revisão ou data #&1:"
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 #, fuzzy
 msgid "Revision or date #2:"
 msgstr "Revisão ou data #&2:"
 
-#: ../rapidsvn_generated.cpp:250 ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr "Revisão:"
 
@@ -1616,10 +1604,6 @@ msgstr "Revisão: %ld"
 msgid "Running command %s:"
 msgstr ""
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr "Certificado SSL"
-
 #: ../columns.cpp:62
 msgid "Schedule"
 msgstr "Agenda"
@@ -1629,36 +1613,28 @@ msgstr "Agenda"
 msgid "Schedule: %s"
 msgstr "Agenda: %s"
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr "É requerido o segundo caminho ou URL para fundir (merge)!"
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr "Segunda URL ou cópia de trabalho"
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr "Selecione o Arquivo do Certificado"
 
-#: ../checkout_dlg.cpp:273 ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr "Selecione uma pasta para destino"
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr "Selecione a pasta para ser fundida (merge)"
 
 #: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
-#: ../main_frame.cpp:1845
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr "Selecione uma pasta"
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr "Selecione uma pasta para importar"
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr "Selecione um arquivo para importar"
 
@@ -1688,29 +1664,29 @@ msgstr "Selecione o editor padrão"
 msgid "Select standard file explorer executable"
 msgstr "Selecione o gerenciador de arquivos padrão"
 
-#: ../main_frame_helper.cpp:95
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr "Enviar as alterações de sua cópia de trabalho para o repositório"
 
-#: ../checkout_dlg.cpp:94 ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
 msgstr "Pegar as últimas versões dos arquivos no repositório."
 
-#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
 msgstr ""
 "Utilizar as etiquetas de revisões (peg revision) BASE/HEAD (atuais) dos "
 "arquivos."
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
 msgstr "Criar automaticamente um novo favorito da cópia de trabalho."
 
-#: ../checkout_dlg.cpp:114 ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
 msgstr "Incluir também todas as subpastas da URL."
 
-#: ../checkout_dlg.cpp:125 ../export_dlg.cpp:129
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
 msgid ""
 "Set to ignore external definitions and the external working copies managed "
 "by them."
@@ -1718,66 +1694,66 @@ msgstr ""
 "Ignorar definições externas e as cópias de trabalho externas gerenciadas por "
 "eles."
 
-#: ../main_frame.cpp:320
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr "Exibir Dicas ao Iniciar"
 
-#: ../main_frame.cpp:274 ../main_frame_helper.cpp:194
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 #, fuzzy
 msgid "Show conflicted entries"
 msgstr "Exibir os itens não versionados"
 
-#: ../main_frame_helper.cpp:171
+#: ../main_frame_helper.cpp:155
 #, fuzzy
 msgid "Show entries in subdirectories"
 msgstr "Exibir os itens não versionados"
 
-#: ../main_frame.cpp:276
+#: ../main_frame.cpp:285
 #, fuzzy
 msgid "Show ignored entries"
 msgstr "Exibir os itens não versionados"
 
-#: ../main_frame.cpp:273 ../main_frame_helper.cpp:188
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 #, fuzzy
 msgid "Show modified entries"
 msgstr "Exibir os itens não versionados"
 
-#: ../main_frame.cpp:269 ../main_frame_helper.cpp:170
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 #, fuzzy
 msgid "Show subdirectories"
 msgstr "Exibir os itens não versionados"
 
-#: ../main_frame_helper.cpp:142
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr "Exibir as mensagens de registro dos itens selecionados"
 
-#: ../main_frame.cpp:272 ../main_frame_helper.cpp:182
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 #, fuzzy
 msgid "Show unmodified entries"
 msgstr "Exibir os itens não versionados"
 
-#: ../main_frame.cpp:271 ../main_frame_helper.cpp:176
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr "Exibir os itens não versionados"
 
-#: ../listener.cpp:360 ../main_frame.cpp:1405
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr "Pular"
 
-#: ../main_frame.cpp:266
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr "Ordenar"
 
-#: ../main_frame.cpp:242
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr "Ordenar Ascendente"
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 #, fuzzy
 msgid "Standard Editor"
 msgstr "Editor padrão:"
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 #, fuzzy
 msgid "Standard Explorer"
 msgstr "Gerenciador de Arquivos padrão:"
@@ -1786,39 +1762,39 @@ msgstr "Gerenciador de Arquivos padrão:"
 msgid "Status"
 msgstr "Estado"
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr "Tomar o bloqueio caso ele pertença a outo usuário "
 
-#: ../main_frame_helper.cpp:219
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr "Parar"
 
-#: ../main_frame_helper.cpp:220
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr "Parar a ação atual"
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr "Guardar as credenciais de autenticação no HD"
 
-#: ../switch_action.cpp:50 ../switch_dlg.cpp:192
+#: ../switch_action.cpp:50
 msgid "Switch URL"
 msgstr "Trocar a URL"
 
-#: ../main_frame.cpp:295
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr "Trocar a URL...\tCTRL-S"
 
-#: ../main_frame.cpp:1352
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr "Teste de duração"
 
-#: ../main_frame.cpp:1348
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr "Teste terminado às"
 
-#: ../main_frame.cpp:1345
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr "Teste iniciado às"
 
@@ -1840,7 +1816,7 @@ msgstr ""
 msgid "The svnadmin command was not successful."
 msgstr ""
 
-#: ../cert_dlg.cpp:70
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
@@ -1848,13 +1824,13 @@ msgstr ""
 "Existem erros na validação no certificado do servidor.\n"
 "Deseja confiar neste certificado?"
 
-#: ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:418
 #, fuzzy
 msgid "This action has resulted in a commit - please enter a &log message"
 msgstr ""
 "Esta ação resultou em um Commit - favor entrar com uma mensagem de registro"
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1862,12 +1838,9 @@ msgid ""
 "Available online under:"
 msgstr ""
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr "Árvore"
-
-#: ../checkout_dlg.cpp:65 ../columns.cpp:59 ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521 ../switch_dlg.cpp:77 ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr "URL"
 
@@ -1880,11 +1853,11 @@ msgstr "URL: %s"
 msgid "UUID"
 msgstr "UUID"
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../main_frame.cpp:1494
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr "Ação não implementada!"
 
@@ -1893,11 +1866,11 @@ msgstr "Ação não implementada!"
 msgid "Unknown destination path"
 msgstr "Caminho de Destino"
 
-#: ../unlock_action.cpp:39 ../unlock_dlg.cpp:80
+#: ../unlock_action.cpp:39
 msgid "Unlock"
 msgstr "Desbloquear"
 
-#: ../listener.cpp:375 ../main_frame.cpp:1420
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr "Desbloqueado"
 
@@ -1905,50 +1878,50 @@ msgstr "Desbloqueado"
 msgid "Update"
 msgstr "Atualizar"
 
-#: ../main_frame_helper.cpp:84
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr "Atualizar a seleção"
 
-#: ../listener.cpp:363 ../main_frame.cpp:1408
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr "Atualizado"
 
-#: ../main_frame.cpp:1556 ../main_frame.cpp:1561
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr "Atualizando..."
 
-#: ../main_frame.cpp:241
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr "Use o Caminho para Ordenação"
 
-#: ../rapidsvn_generated.cpp:271 ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 #, fuzzy
 msgid "Use URL/path:"
 msgstr "Use URL/Caminho:"
 
-#: ../rapidsvn_generated.cpp:70 ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr "Use sempre"
 
-#: ../checkout_dlg.cpp:92 ../export_dlg.cpp:95 ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299 ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103 ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr "Use o mas recente"
 
-#: ../auth_dlg.cpp:54 ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr "Usuário"
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr "Válido de:"
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr "Válido até:"
 
-#: ../listed_dlg.cpp:80 ../listed_dlg.cpp:172 ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr "Valor"
 
@@ -1956,11 +1929,29 @@ msgstr "Valor"
 msgid "View"
 msgstr "Visualizar"
 
-#: ../rapidsvn_generated.cpp:696
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "View..."
+msgstr "&Visualizar..."
+
+#: ../rapidsvn_generated.cpp:567
 msgid "WARNING"
 msgstr ""
 
-#: ../dnd_dlg.cpp:69
+#: ../dnd_dlg.cpp:48
+#, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr ""
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -1973,32 +1964,28 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr ""
-
-#: ../main_frame.cpp:1863
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
 msgstr ""
 "Você não pode adicionar uma pasta administrativa do subversion aos favoritos!"
 
-#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1261
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr "adicionar"
 
-#: ../filelist_ctrl.cpp:1226 ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr "adicionado"
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr "conflitante"
 
-#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1264
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr "excluir"
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr "excluido"
 
@@ -2006,7 +1993,7 @@ msgstr "excluido"
 msgid "directory"
 msgstr "pasta"
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr "externo"
 
@@ -2014,63 +2001,67 @@ msgstr "externo"
 msgid "file"
 msgstr "arquivo"
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr ""
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr "incompleto"
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr "fundido"
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr "ausente"
 
-#: ../filelist_ctrl.cpp:1229 ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr "modificado"
 
-#: ../export_dlg.cpp:135 ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr "nativo"
 
-#: ../file_info.cpp:132 ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr "nada"
 
-#: ../file_info.cpp:146 ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr "normal"
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr "obstruido"
 
-#: ../filelist_ctrl.cpp:1294 ../filelist_ctrl.cpp:1308
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr "desatualizado"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.4"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.5"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.6"
 msgstr ""
 
-#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1267
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr "trocar"
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr "trocado"
 
@@ -2082,17 +2073,127 @@ msgstr ""
 msgid "unknown"
 msgstr "desconhecido"
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr "valor desconhecido"
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
 msgstr "sem versão"
 
-#: ../main_frame.cpp:329
-msgid "wxString Creation&Tracing Test"
-msgstr "wxString Creation&Tracing Test"
+#, fuzzy
+#~ msgid "Action"
+#~ msgstr "Autenticação"
+
+#~ msgid "Checkout Test"
+#~ msgstr "Teste de Checkout"
+
+#, fuzzy
+#~ msgid "Copied from Path"
+#~ msgstr "Copiado da URL: %s"
+
+#, fuzzy
+#~ msgid "Copied from Rev"
+#~ msgstr "Copiado da Rev: %ld"
+
+#~ msgid "Destination file"
+#~ msgstr "Arquivo de Destino"
+
+#~ msgid "Destination path"
+#~ msgstr "Caminho de Destino"
+
+#~ msgid "EOL:"
+#~ msgstr "EOL:"
+
+#~ msgid "Enter log message"
+#~ msgstr "Entre com a mensagem de registro"
+
+#~ msgid "Enter the local path where you want the code be exported."
+#~ msgstr ""
+#~ "Entre com o caminho local aonde você deseja que o código seja exportado."
+
+#~ msgid ""
+#~ "Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
+#~ "files."
+#~ msgstr ""
+#~ "Entre com o(s) símbolo(s) para serem EOL (fim de linha) nos arquivos "
+#~ "exportados."
+
+#~ msgid "File path required when importing a file!"
+#~ msgstr "É requerido um caminho durante a importação do arquivo!"
+
+#~ msgid "First path or URL is required for merge!"
+#~ msgstr "É requerido o primeiro caminho ou URL para fundir (merge)!"
+
+#, fuzzy
+#~ msgid ""
+#~ "Invalid selection. At least one revisions is needed for diff and no more "
+#~ "than two."
+#~ msgstr ""
+#~ "Seleção inválida. São necessário apenas duas revisões para a diferença "
+#~ "(diff)."
+
+#~ msgid "Invalid selection. Exactly two revisions needed for merge."
+#~ msgstr ""
+#~ "Seleção inválida. São necessário apenas duas revisões para fundir (merge)."
+
+#, fuzzy
+#~ msgid "Invalid selection. Only one revision may be selected for annotate"
+#~ msgstr ""
+#~ "Seleção inválida. São necessário apenas duas revisões para fundir (merge)."
+
+#~ msgid "Listener Test"
+#~ msgstr "Teste de Escuta"
+
+#~ msgid "Locate help"
+#~ msgstr "Localizar ajuda"
+
+#~ msgid "Locate tips"
+#~ msgstr "Localizar dicas"
+
+#~ msgid "Locate tips file"
+#~ msgstr "Localizar arquivo de dicas"
+
+#~ msgid "Log Message:"
+#~ msgstr "Mensagem do Registro:"
+
+#~ msgid "Merge revisions"
+#~ msgstr "Fundir (merge) revisões"
+
+#~ msgid ""
+#~ "No help file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Nenhum arquivo de ajuda foi encontrado, deseja \n"
+#~ "ver esta pergunta na próxima execução?"
+
+#~ msgid ""
+#~ "No tips file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Nenhum arquivo de dicas foi encontrado, deseja \n"
+#~ "ver esta pergunta na próxima execução?"
+
+#~ msgid "RapidSVN Help: %s"
+#~ msgstr "Ajuda do RapidSVN: %s"
+
+#~ msgid "Revision must be an unsigned number!"
+#~ msgstr "A revisão deve ser um número não sinalizado!"
+
+#~ msgid "SSL Certificate"
+#~ msgstr "Certificado SSL"
+
+#~ msgid "Second path or URL is required for merge!"
+#~ msgstr "É requerido o segundo caminho ou URL para fundir (merge)!"
+
+#~ msgid "Second working copy or URL"
+#~ msgstr "Segunda URL ou cópia de trabalho"
+
+#~ msgid "Tree"
+#~ msgstr "Árvore"
+
+#~ msgid "wxString Creation&Tracing Test"
+#~ msgstr "wxString Creation&Tracing Test"
 
 #~ msgid "Information"
 #~ msgstr "Informação"

--- a/librapidsvn/src/locale/rapidsvn.pot
+++ b/librapidsvn/src/locale/rapidsvn.pot
@@ -8,10 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-02 17:09+0100\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -21,22 +22,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr ""
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, c-format
 msgid "%s Version %s"
 msgstr ""
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, c-format
 msgid "%s Version %s Revision %d"
 msgstr ""
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr ""
 
-#: ../main_frame.cpp:323
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr ""
 
@@ -44,35 +45,31 @@ msgstr ""
 msgid "&Add\tINS"
 msgstr ""
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr ""
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr ""
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 msgid "&Annotate..."
 msgstr ""
 
-#: ../main_frame.cpp:344
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:676
+#: ../rapidsvn_generated.cpp:549
 msgid "&Browse"
 msgstr ""
 
-#: ../log_dlg.cpp:359
-msgid "&Close"
-msgstr ""
-
-#: ../rapidsvn_generated.cpp:655
+#: ../rapidsvn_generated.cpp:528
 msgid "&Compatible with:"
 msgstr ""
 
-#: ../main_frame.cpp:316
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr ""
 
@@ -80,7 +77,7 @@ msgstr ""
 msgid "&Copy...\tF5"
 msgstr ""
 
-#: ../main_frame.cpp:290
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr ""
 
@@ -88,11 +85,11 @@ msgstr ""
 msgid "&Delete\tDEL"
 msgstr ""
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr ""
 
-#: ../log_dlg.cpp:362 ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 msgid "&Diff"
 msgstr ""
 
@@ -104,43 +101,47 @@ msgstr ""
 msgid "&Diff to Head...\tCTRL+H"
 msgstr ""
 
+#: ../utils.cpp:220
+msgid "&Diff..."
+msgstr ""
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr ""
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr ""
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr ""
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr ""
 
-#: ../main_frame.cpp:288
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr ""
 
-#: ../main_frame.cpp:345
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr ""
 
-#: ../main_frame.cpp:339
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 msgid "&Files to commit"
 msgstr ""
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 msgid "&Get"
 msgstr ""
 
-#: ../main_frame.cpp:223 ../main_frame.cpp:346
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr ""
 
@@ -148,11 +149,11 @@ msgstr ""
 msgid "&Ignore\tCTRL-DEL"
 msgstr ""
 
-#: ../main_frame.cpp:287
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr ""
 
-#: ../main_frame.cpp:317
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr ""
 
@@ -160,7 +161,7 @@ msgstr ""
 msgid "&Info..."
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:540
 msgid "&Load configuration from directory (optional):"
 msgstr ""
 
@@ -168,27 +169,39 @@ msgstr ""
 msgid "&Lock..."
 msgstr ""
 
+#: ../utils.cpp:222
+msgid "&Log..."
+msgstr ""
+
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr ""
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 msgid "&Merge"
 msgstr ""
 
-#: ../main_frame.cpp:342
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:625
+#: ../rapidsvn_generated.cpp:897
+msgid "&Name"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:499
 msgid "&Name of the new repository:"
 msgstr ""
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr ""
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+msgid "&Password"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr ""
 
@@ -196,43 +209,47 @@ msgstr ""
 msgid "&Properties...\tCTRL-P"
 msgstr ""
 
-#: ../main_frame.cpp:343
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 msgid "&Recent entries:"
 msgstr ""
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 msgid "&Remove Bookmark"
 msgstr ""
 
-#: ../main_frame.cpp:341
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr ""
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+msgid "&Revision"
+msgstr ""
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr ""
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr ""
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr ""
 
-#: ../main_frame.cpp:348
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:599
+#: ../rapidsvn_generated.cpp:473
 msgid "&Type:"
 msgstr ""
 
@@ -240,38 +257,51 @@ msgstr ""
 msgid "&Unlock"
 msgstr ""
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr ""
 
-#: ../log_dlg.cpp:360 ../main_frame.cpp:340
+#: ../rapidsvn_generated.cpp:89
+msgid "&Username"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:904
+msgid "&Value"
+msgstr ""
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr ""
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr ""
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr ""
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr ""
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr ""
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
 msgstr ""
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+msgid "..."
 msgstr ""
 
 #: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
@@ -286,29 +316,25 @@ msgstr ""
 msgid "A file of this name exists already"
 msgstr ""
 
-#: ../about_dlg.cpp:68
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr ""
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr ""
 
-#: ../log_dlg.cpp:242
-msgid "Action"
-msgstr ""
-
-#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listener.cpp:353
-#: ../main_frame.cpp:1398
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr ""
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:642
+#: ../rapidsvn_generated.cpp:516
 msgid "Add a bookmark for the new repository"
 msgstr ""
 
@@ -316,40 +342,40 @@ msgstr ""
 msgid "Add r&ecursive"
 msgstr ""
 
-#: ../main_frame_helper.cpp:64
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr ""
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr ""
 
-#: ../listener.cpp:362 ../listener.cpp:369 ../main_frame.cpp:1407
-#: ../main_frame.cpp:1414
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr ""
 
-#: ../main_frame.cpp:1904
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr ""
 
-#: ../main_frame.cpp:1875
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, c-format
 msgid "Adding file to repository: %s"
 msgstr ""
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr ""
 
@@ -357,11 +383,11 @@ msgstr ""
 msgid "All files|*"
 msgstr ""
 
-#: ../main_frame.cpp:1271 ../main_frame.cpp:1290
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr ""
 
-#: ../main_frame.cpp:1258
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr ""
 
@@ -369,7 +395,7 @@ msgstr ""
 msgid "Annotate"
 msgstr ""
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -381,11 +407,11 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../auth_dlg.cpp:117 ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr ""
 
-#: ../annotate_dlg.cpp:48 ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr ""
 
@@ -393,11 +419,11 @@ msgstr ""
 msgid "BASE"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:603
+#: ../rapidsvn_generated.cpp:477
 msgid "BerkeleyDB"
 msgstr ""
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr ""
 
@@ -405,17 +431,17 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: ../main_frame_helper.cpp:85
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:57 ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119 ../rapidsvn_generated.cpp:146
-#: ../rapidsvn_generated.cpp:620
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr ""
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -423,43 +449,42 @@ msgid ""
 "Subversion %d.%d.%d\n"
 msgstr ""
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr ""
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr ""
 
-#: ../auth_dlg.cpp:73 ../cert_dlg.cpp:138 ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57 ../destination_dlg.cpp:90 ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146 ../import_dlg.cpp:130 ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342 ../lock_dlg.cpp:61 ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195 ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409 ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564 ../rapidsvn_generated.cpp:708
-#: ../switch_dlg.cpp:139 ../unlock_dlg.cpp:58 ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr ""
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+msgid "Certificate information:"
 msgstr ""
 
-#: ../main_frame.cpp:289
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr ""
 
-#: ../checkout_action.cpp:40 ../checkout_dlg.cpp:250
+#: ../checkout_action.cpp:40
 msgid "Checkout"
 msgstr ""
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
-msgstr ""
-
-#: ../main_frame.cpp:331
-msgid "Checkout Test"
 msgstr ""
 
 #: ../columns.cpp:58
@@ -471,19 +496,23 @@ msgstr ""
 msgid "Checksum: %s"
 msgstr ""
 
-#: ../cleanup_action.cpp:39 ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr ""
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+msgid "Close"
+msgstr ""
+
+#: ../utils.cpp:297
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr ""
 
-#: ../main_frame.cpp:265
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:275 ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr ""
 
@@ -495,11 +524,11 @@ msgstr ""
 msgid "Commit Log Message"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr ""
 
-#: ../main_frame_helper.cpp:94
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr ""
 
@@ -507,8 +536,18 @@ msgstr ""
 msgid "Committed revision"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
+msgstr ""
+
+#: ../listener.cpp:496
+#, c-format
+msgid "Completed %s at revision %d"
+msgstr ""
+
+#: ../listener.cpp:486
+#, c-format
+msgid "Completed at revision %d"
 msgstr ""
 
 #: ../columns.cpp:64
@@ -543,6 +582,10 @@ msgstr ""
 msgid "Conflict Working File: %s"
 msgstr ""
 
+#: ../listener.cpp:307
+msgid "Conflicted"
+msgstr ""
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr ""
@@ -557,29 +600,21 @@ msgstr ""
 msgid "Copied From URL: %s"
 msgstr ""
 
-#: ../log_dlg.cpp:244
-msgid "Copied from Path"
-msgstr ""
-
-#: ../log_dlg.cpp:245
-msgid "Copied from Rev"
-msgstr ""
-
-#: ../dnd_dlg.cpp:108 ../listener.cpp:354 ../main_frame.cpp:1399
-#: ../move_action.cpp:44
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr ""
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 msgid "Copy/Move"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, c-format
 msgid "Copying file into working directory: %s"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, c-format
 msgid "Copying file: %s"
 msgstr ""
@@ -589,7 +624,7 @@ msgstr ""
 msgid "Could not set working directory to %s"
 msgstr ""
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr ""
 
@@ -597,57 +632,49 @@ msgstr ""
 msgid "Create Repository"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:611
+#: ../rapidsvn_generated.cpp:485
 msgid "Create repository in &directory:"
 msgstr ""
 
-#: ../columns.cpp:54 ../log_dlg.cpp:165
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:265 ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "Default"
 msgstr ""
 
-#: ../delete_action.cpp:40 ../delete_dlg.cpp:79 ../listener.cpp:355
-#: ../main_frame.cpp:1400
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr ""
 
-#: ../main_frame_helper.cpp:75
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr ""
 
-#: ../main_frame_helper.cpp:74
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr ""
 
-#: ../listener.cpp:361 ../listener.cpp:370 ../main_frame.cpp:1406
-#: ../main_frame.cpp:1415
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr ""
 
-#: ../checkout_dlg.cpp:72 ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
-msgstr ""
-
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr ""
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
 msgstr ""
 
 #: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 msgid "Diff Tool"
 msgstr ""
 
@@ -667,79 +694,91 @@ msgstr ""
 msgid "Diff two revisions/dates"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:1296
+msgid "Directory"
 msgstr ""
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:681
+#: ../rapidsvn_generated.cpp:554
 msgid "Disable automatic Log removal"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:685
+#: ../rapidsvn_generated.cpp:557
 msgid "Disable fsync when committing database transactions"
 msgstr ""
 
-#: ../main_frame_helper.cpp:195
+#: ../main_frame_helper.cpp:179
 msgid "Display conflicted files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:132
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr ""
 
-#: ../main_frame_helper.cpp:189
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:183
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:177
+#: ../main_frame_helper.cpp:161
 msgid "Display unversioned files/directories"
 msgstr ""
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr ""
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr ""
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr ""
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr ""
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr ""
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr ""
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr ""
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+msgid "Edit..."
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:1306
+msgid "End &log message"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 msgid "Enter &log message"
 msgstr ""
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr ""
 
@@ -747,36 +786,19 @@ msgstr ""
 msgid "Enter a name for the repository"
 msgstr ""
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr ""
-
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr ""
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr ""
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
 msgstr ""
 
-#: ../checkout_dlg.cpp:70 ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr ""
 
-#: ../export_dlg.cpp:143
-msgid ""
-"Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
-"files."
-msgstr ""
-
-#: ../import_dlg.cpp:178 ../import_dlg.cpp:191 ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494 ../log_dlg.cpp:530 ../main_frame.cpp:1865
-#: ../merge_dlg.cpp:52 ../merge_dlg.cpp:91 ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr ""
 
@@ -788,11 +810,18 @@ msgstr ""
 msgid "Error running svnadmin"
 msgstr ""
 
-#: ../property_dlg.cpp:120
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr ""
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr ""
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr ""
@@ -815,26 +844,26 @@ msgstr ""
 msgid "Error while preparing action: %s"
 msgstr ""
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr ""
 
-#: ../main_frame.cpp:907
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr ""
 
-#: ../main_frame.cpp:894
+#: ../main_frame.cpp:917
 #, c-format
 msgid "Error while updating filelist (%s)"
 msgstr ""
 
-#: ../main_frame.cpp:542
+#: ../main_frame.cpp:561
 #, c-format
 msgid "Error: %s\n"
 msgstr ""
 
-#: ../main_frame.cpp:1799
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
 msgstr ""
 
@@ -871,11 +900,11 @@ msgstr ""
 msgid "Execute: %s"
 msgstr ""
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr ""
 
-#: ../export_action.cpp:40 ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr ""
 
@@ -883,62 +912,57 @@ msgstr ""
 msgid "Extension"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:603
+#: ../listener.cpp:405
+msgid "External"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:477
 msgid "FSFS"
 msgstr ""
 
-#: ../listener.cpp:376 ../main_frame.cpp:1421
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr ""
 
-#: ../listener.cpp:377 ../main_frame.cpp:1422
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr ""
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr ""
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr ""
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr ""
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr ""
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr ""
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr ""
 
-#: ../destination_dlg.cpp:80 ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr ""
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr ""
 
-#: ../export_dlg.cpp:123
+#: ../export_dlg.cpp:75
 msgid ""
 "Force to execute even if destination directory not empty, causes overwriting "
 "of files with the same names."
 msgstr ""
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:41 ../rapidsvn_generated.cpp:649
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr ""
 
@@ -951,22 +975,30 @@ msgstr ""
 msgid "HEAD"
 msgstr ""
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+msgid "Help"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr ""
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr ""
 
-#: ../checkout_dlg.cpp:88 ../export_dlg.cpp:91
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
 msgid ""
 "If not using the latest version of the files, specify which revision to use "
 "here."
 msgstr ""
 
-#: ../checkout_dlg.cpp:102 ../export_dlg.cpp:105
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
 msgid ""
 "If the files were renamed or moved some time, specify which peg revision to "
 "use here."
@@ -976,20 +1008,23 @@ msgstr ""
 msgid "Ignore"
 msgstr ""
 
-#: ../main_frame.cpp:275 ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr ""
 
-#: ../checkout_dlg.cpp:122 ../export_dlg.cpp:126 ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr ""
 
-#: ../dnd_dlg.cpp:37 ../dnd_dlg.cpp:97 ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+msgid "Import &Path"
+msgstr ""
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr ""
@@ -998,15 +1033,15 @@ msgstr ""
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr ""
 
-#: ../main_frame.cpp:270
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr ""
 
-#: ../main_frame.cpp:1984
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr ""
 
-#: ../main_frame_helper.cpp:131
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr ""
 
@@ -1014,7 +1049,7 @@ msgstr ""
 msgid "Internal Error: There is another action running"
 msgstr ""
 
-#: ../main_frame.cpp:1542
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr ""
 
@@ -1026,29 +1061,15 @@ msgstr ""
 msgid "Invalid revision number detected"
 msgstr ""
 
-#: ../log_dlg.cpp:478
-msgid ""
-"Invalid selection. At least one revisions is needed for diff and no more "
-"than two."
+#: ../rapidsvn_generated.cpp:159
+msgid "Issuer:"
 msgstr ""
 
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr ""
-
-#: ../log_dlg.cpp:529
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr ""
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
-msgstr ""
-
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 msgid "Keep Locks"
 msgstr ""
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr ""
 
@@ -1070,20 +1091,16 @@ msgstr ""
 msgid "Last Changed Rev: %ld"
 msgstr ""
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr ""
 
-#: ../main_frame.cpp:330
-msgid "Listener Test"
-msgstr ""
-
-#: ../filelist_ctrl.cpp:1058
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr ""
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1092,19 +1109,7 @@ msgid ""
 "Canonical Name: %s\n"
 msgstr ""
 
-#: ../rapidsvn_app.cpp:198 ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr ""
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr ""
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr ""
-
-#: ../lock_action.cpp:40 ../lock_dlg.cpp:100
+#: ../lock_action.cpp:40
 msgid "Lock"
 msgstr ""
 
@@ -1137,31 +1142,27 @@ msgstr ""
 msgid "Lock Token: %s"
 msgstr ""
 
-#: ../listener.cpp:374 ../main_frame.cpp:1419
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr ""
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr ""
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr ""
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr ""
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr ""
-
-#: ../main_frame_helper.cpp:141
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr ""
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr ""
 
@@ -1186,39 +1187,39 @@ msgstr ""
 msgid "Make directory"
 msgstr ""
 
-#: ../merge_action.cpp:38 ../merge_action.cpp:44 ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 msgid "Merge Tool"
 msgstr ""
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
+#: ../main_frame.cpp:303
+msgid "Merge..."
 msgstr ""
 
-#: ../main_frame.cpp:294
-msgid "Merge..."
+#: ../listener.cpp:308
+msgid "Merged"
 msgstr ""
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr ""
 
-#: ../listener.cpp:368 ../main_frame.cpp:1413
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:692
+#: ../rapidsvn_generated.cpp:563
 msgid "More options"
 msgstr ""
 
-#: ../dnd_dlg.cpp:104 ../move_action.cpp:42
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, c-format
 msgid "Moving file: %s"
 msgstr ""
@@ -1227,8 +1228,16 @@ msgstr ""
 msgid "Multiple Files"
 msgstr ""
 
-#: ../columns.cpp:45 ../listed_dlg.cpp:75 ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr ""
 
@@ -1237,32 +1246,16 @@ msgstr ""
 msgid "Name: %s"
 msgstr ""
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
-msgstr ""
-
-#: ../revert_dlg.cpp:57
-msgid "No"
 msgstr ""
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr ""
 
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-
 #: ../userresolve_action.cpp:62
 msgid "No merge tool set in the preferences"
-msgstr ""
-
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
 msgstr ""
 
 #: ../file_info.cpp:118
@@ -1270,7 +1263,7 @@ msgstr ""
 msgid "Node Kind: %s"
 msgstr ""
 
-#: ../checkout_dlg.cpp:106 ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr ""
 
@@ -1278,39 +1271,37 @@ msgstr ""
 msgid "Not versioned"
 msgstr ""
 
-#: ../about_dlg.cpp:114 ../annotate_dlg.cpp:42 ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126 ../delete_dlg.cpp:54 ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145 ../import_dlg.cpp:128 ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341 ../lock_dlg.cpp:60 ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191 ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405 ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560 ../rapidsvn_generated.cpp:704
-#: ../report_dlg.cpp:57 ../switch_dlg.cpp:137 ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr ""
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr ""
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr ""
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr ""
-
-#: ../columns.cpp:46 ../import_dlg.cpp:80 ../log_dlg.cpp:243
+#: ../columns.cpp:46
 msgid "Path"
 msgstr ""
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+msgid "Path &type"
 msgstr ""
 
-#: ../checkout_dlg.cpp:97 ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr ""
 
@@ -1318,27 +1309,27 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr ""
 
@@ -1354,7 +1345,7 @@ msgstr ""
 msgid "Properties Last Updated"
 msgstr ""
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr ""
 
@@ -1366,21 +1357,20 @@ msgstr ""
 msgid "Property Editor"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr ""
 
-#: ../main_frame_helper.cpp:65
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr ""
 
-#: ../main_frame.cpp:509
-msgid "RapidSVN Error"
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
 msgstr ""
 
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
+#: ../main_frame.cpp:528
+msgid "RapidSVN Error"
 msgstr ""
 
 #: ../utils.cpp:192
@@ -1395,50 +1385,50 @@ msgstr ""
 msgid "Re&vert\tCTRL-V"
 msgstr ""
 
-#: ../filelist_ctrl.cpp:1134
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr ""
 
-#: ../main_frame.cpp:1522 ../main_frame.cpp:1566
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr ""
 
-#: ../checkout_dlg.cpp:111 ../export_dlg.cpp:114 ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201 ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547 ../revert_dlg.cpp:49 ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr ""
 
-#: ../main_frame_helper.cpp:206
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr ""
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr ""
 
-#: ../main_frame_helper.cpp:207
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr ""
 
-#: ../main_frame.cpp:268
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr ""
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 msgid "Relocate"
 msgstr ""
 
-#: ../main_frame_helper.cpp:115
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
 msgstr ""
 
-#: ../main_frame.cpp:1918
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr ""
 
@@ -1450,7 +1440,7 @@ msgstr ""
 msgid "Rep. Rev."
 msgstr ""
 
-#: ../listener.cpp:371 ../main_frame.cpp:1416
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr ""
 
@@ -1458,12 +1448,12 @@ msgstr ""
 msgid "Repository"
 msgstr ""
 
-#: ../import_dlg.cpp:67 ../main_frame.cpp:1890
-msgid "Repository URL"
+#: ../rapidsvn_generated.cpp:1268
+msgid "Repository &URL for import"
 msgstr ""
 
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
+#: ../main_frame.cpp:2079
+msgid "Repository URL"
 msgstr ""
 
 #: ../file_info.cpp:112
@@ -1476,11 +1466,11 @@ msgstr ""
 msgid "Repository: %s"
 msgstr ""
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr ""
 
@@ -1488,55 +1478,49 @@ msgstr ""
 msgid "Resolve"
 msgstr ""
 
-#: ../main_frame_helper.cpp:114
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr ""
 
-#: ../listener.cpp:359 ../main_frame.cpp:1404
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr ""
 
-#: ../listener.cpp:356 ../main_frame.cpp:1401
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr ""
 
-#: ../main_frame_helper.cpp:105
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:632
+#: ../rapidsvn_generated.cpp:506
 msgid "Resulting repository filename:"
 msgstr ""
 
-#: ../listener.cpp:357 ../main_frame.cpp:1402 ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr ""
 
-#: ../main_frame_helper.cpp:104
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr ""
 
-#: ../annotate_dlg.cpp:47 ../checkout_dlg.cpp:83 ../columns.cpp:47
-#: ../export_dlg.cpp:86 ../log_dlg.cpp:163 ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150 ../rapidsvn_generated.cpp:529 ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr ""
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr ""
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 msgid "Revision or date #1:"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 msgid "Revision or date #2:"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:250 ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr ""
 
@@ -1550,10 +1534,6 @@ msgstr ""
 msgid "Running command %s:"
 msgstr ""
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr ""
-
 #: ../columns.cpp:62
 msgid "Schedule"
 msgstr ""
@@ -1563,36 +1543,28 @@ msgstr ""
 msgid "Schedule: %s"
 msgstr ""
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr ""
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr ""
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr ""
 
-#: ../checkout_dlg.cpp:273 ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr ""
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr ""
 
 #: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
-#: ../main_frame.cpp:1845
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr ""
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr ""
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr ""
 
@@ -1620,85 +1592,85 @@ msgstr ""
 msgid "Select standard file explorer executable"
 msgstr ""
 
-#: ../main_frame_helper.cpp:95
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr ""
 
-#: ../checkout_dlg.cpp:94 ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
 msgstr ""
 
-#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
 msgstr ""
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
 msgstr ""
 
-#: ../checkout_dlg.cpp:114 ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
 msgstr ""
 
-#: ../checkout_dlg.cpp:125 ../export_dlg.cpp:129
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
 msgid ""
 "Set to ignore external definitions and the external working copies managed "
 "by them."
 msgstr ""
 
-#: ../main_frame.cpp:320
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr ""
 
-#: ../main_frame.cpp:274 ../main_frame_helper.cpp:194
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 msgid "Show conflicted entries"
 msgstr ""
 
-#: ../main_frame_helper.cpp:171
+#: ../main_frame_helper.cpp:155
 msgid "Show entries in subdirectories"
 msgstr ""
 
-#: ../main_frame.cpp:276
+#: ../main_frame.cpp:285
 msgid "Show ignored entries"
 msgstr ""
 
-#: ../main_frame.cpp:273 ../main_frame_helper.cpp:188
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 msgid "Show modified entries"
 msgstr ""
 
-#: ../main_frame.cpp:269 ../main_frame_helper.cpp:170
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 msgid "Show subdirectories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:142
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr ""
 
-#: ../main_frame.cpp:272 ../main_frame_helper.cpp:182
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 msgid "Show unmodified entries"
 msgstr ""
 
-#: ../main_frame.cpp:271 ../main_frame_helper.cpp:176
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr ""
 
-#: ../listener.cpp:360 ../main_frame.cpp:1405
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr ""
 
-#: ../main_frame.cpp:266
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr ""
 
-#: ../main_frame.cpp:242
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 msgid "Standard Editor"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 msgid "Standard Explorer"
 msgstr ""
 
@@ -1706,39 +1678,39 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr ""
 
-#: ../main_frame_helper.cpp:219
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr ""
 
-#: ../main_frame_helper.cpp:220
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr ""
 
-#: ../switch_action.cpp:50 ../switch_dlg.cpp:192
+#: ../switch_action.cpp:50
 msgid "Switch URL"
 msgstr ""
 
-#: ../main_frame.cpp:295
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr ""
 
-#: ../main_frame.cpp:1352
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr ""
 
-#: ../main_frame.cpp:1348
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr ""
 
-#: ../main_frame.cpp:1345
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr ""
 
@@ -1758,17 +1730,17 @@ msgstr ""
 msgid "The svnadmin command was not successful."
 msgstr ""
 
-#: ../cert_dlg.cpp:70
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:418
 msgid "This action has resulted in a commit - please enter a &log message"
 msgstr ""
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1776,12 +1748,9 @@ msgid ""
 "Available online under:"
 msgstr ""
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr ""
-
-#: ../checkout_dlg.cpp:65 ../columns.cpp:59 ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521 ../switch_dlg.cpp:77 ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr ""
 
@@ -1794,11 +1763,11 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr ""
 
-#: ../main_frame.cpp:1494
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr ""
 
@@ -1806,11 +1775,11 @@ msgstr ""
 msgid "Unknown destination path"
 msgstr ""
 
-#: ../unlock_action.cpp:39 ../unlock_dlg.cpp:80
+#: ../unlock_action.cpp:39
 msgid "Unlock"
 msgstr ""
 
-#: ../listener.cpp:375 ../main_frame.cpp:1420
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr ""
 
@@ -1818,49 +1787,49 @@ msgstr ""
 msgid "Update"
 msgstr ""
 
-#: ../main_frame_helper.cpp:84
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr ""
 
-#: ../listener.cpp:363 ../main_frame.cpp:1408
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr ""
 
-#: ../main_frame.cpp:1556 ../main_frame.cpp:1561
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr ""
 
-#: ../main_frame.cpp:241
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:271 ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 msgid "Use URL/path:"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:70 ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr ""
 
-#: ../checkout_dlg.cpp:92 ../export_dlg.cpp:95 ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299 ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103 ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr ""
 
-#: ../auth_dlg.cpp:54 ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr ""
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr ""
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr ""
 
-#: ../listed_dlg.cpp:80 ../listed_dlg.cpp:172 ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr ""
 
@@ -1868,11 +1837,28 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:696
+#: ../listed_dlg.cpp:355
+msgid "View..."
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:567
 msgid "WARNING"
 msgstr ""
 
-#: ../dnd_dlg.cpp:69
+#: ../dnd_dlg.cpp:48
+#, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr ""
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -1885,31 +1871,27 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr ""
-
-#: ../main_frame.cpp:1863
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
 msgstr ""
 
-#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1261
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr ""
 
-#: ../filelist_ctrl.cpp:1226 ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr ""
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr ""
 
-#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1264
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr ""
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr ""
 
@@ -1917,7 +1899,7 @@ msgstr ""
 msgid "directory"
 msgstr ""
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr ""
 
@@ -1925,63 +1907,67 @@ msgstr ""
 msgid "file"
 msgstr ""
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr ""
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr ""
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr ""
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr ""
 
-#: ../filelist_ctrl.cpp:1229 ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr ""
 
-#: ../export_dlg.cpp:135 ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr ""
 
-#: ../file_info.cpp:132 ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr ""
 
-#: ../file_info.cpp:146 ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr ""
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr ""
 
-#: ../filelist_ctrl.cpp:1294 ../filelist_ctrl.cpp:1308
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.4"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.5"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.6"
 msgstr ""
 
-#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1267
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr ""
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr ""
 
@@ -1993,14 +1979,10 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr ""
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
-msgstr ""
-
-#: ../main_frame.cpp:329
-msgid "wxString Creation&Tracing Test"
 msgstr ""

--- a/librapidsvn/src/locale/ru/rapidsvn.po
+++ b/librapidsvn/src/locale/ru/rapidsvn.po
@@ -7,14 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RapidSVN 0.12.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-02 17:09+0100\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: 2012-09-11 23:20+0300\n"
 "Last-Translator: Alexey Reztsov <ariafan@mail.ru>\n"
 "Language-Team: RapidSVN Developers <dev@rapidsvn.tigris.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2\n"
+"Plural-Forms: n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n"
+"%100>=20) ? 1 : 2\n"
 "X-Poedit-Language: Russian\n"
 "X-Poedit-Country: RUSSIAN FEDERATION\n"
 
@@ -23,22 +25,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr "%s  код: %ld"
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, c-format
 msgid "%s Version %s"
 msgstr "%s версия %s"
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, c-format
 msgid "%s Version %s Revision %d"
 msgstr "%s версия %s ревизия %d"
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr "%x %X"
 
-#: ../rapidsvn_frame.cpp:329
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr "&О программе..."
 
@@ -46,27 +48,32 @@ msgstr "&О программе..."
 msgid "&Add\tINS"
 msgstr "&Добавить\tINS"
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr "&Добавить существующую рабочую копию..."
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr "&Авторство строк"
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 msgid "&Annotate..."
 msgstr "&Авторство строк..."
 
-#: ../rapidsvn_frame.cpp:350
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr "Зак&ладки"
 
-#: ../log_dlg.cpp:359
-msgid "&Close"
-msgstr "&Закрыть"
+#: ../rapidsvn_generated.cpp:549
+#, fuzzy
+msgid "&Browse"
+msgstr "Выбрать"
 
-#: ../rapidsvn_frame.cpp:322
+#: ../rapidsvn_generated.cpp:528
+msgid "&Compatible with:"
+msgstr ""
+
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr "&Содержание (в интернете)\tF1"
 
@@ -74,7 +81,7 @@ msgstr "&Содержание (в интернете)\tF1"
 msgid "&Copy...\tF5"
 msgstr "&Копировать...\tF5"
 
-#: ../rapidsvn_frame.cpp:296
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr "&Создать..."
 
@@ -82,12 +89,11 @@ msgstr "&Создать..."
 msgid "&Delete\tDEL"
 msgstr "&Удалить\tDEL"
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr "&Удалить..."
 
-#: ../log_dlg.cpp:362
-#: ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 msgid "&Diff"
 msgstr "&Сравнить"
 
@@ -99,44 +105,48 @@ msgstr "Сравнить с &Base...\tCTRL+B"
 msgid "&Diff to Head...\tCTRL+H"
 msgstr "Сравнить с &Head...\tCTRL+H"
 
+#: ../utils.cpp:220
+#, fuzzy
+msgid "&Diff..."
+msgstr "&Сравнить"
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr "&Сравнить...\tCTRL+D"
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr "&Изменить закладку..."
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr "&Изменить..."
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr "&Изменить...\tF3"
 
-#: ../rapidsvn_frame.cpp:294
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr "&Экспорт...\tCTRL-E"
 
-#: ../rapidsvn_frame.cpp:351
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr "&Прочее"
 
-#: ../rapidsvn_frame.cpp:345
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr "&Файл"
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 msgid "&Files to commit"
 msgstr "&Файлы для фиксации"
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 msgid "&Get"
 msgstr "&Получить"
 
-#: ../rapidsvn_frame.cpp:229
-#: ../rapidsvn_frame.cpp:352
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr "&Справка"
 
@@ -144,11 +154,11 @@ msgstr "&Справка"
 msgid "&Ignore\tCTRL-DEL"
 msgstr "&Игнорировать\tCTRL-DEL"
 
-#: ../rapidsvn_frame.cpp:293
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr "&Импорт...\tCTRL-I"
 
-#: ../rapidsvn_frame.cpp:323
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr "&Алфавитный указатель (в интернете) \tShift+F1"
 
@@ -156,27 +166,51 @@ msgstr "&Алфавитный указатель (в интернете) \tShift
 msgid "&Info..."
 msgstr "Ин&формация..."
 
+#: ../rapidsvn_generated.cpp:540
+msgid "&Load configuration from directory (optional):"
+msgstr ""
+
 #: ../utils.cpp:198
 msgid "&Lock..."
 msgstr "&Блокировать..."
+
+#: ../utils.cpp:222
+#, fuzzy
+msgid "&Log..."
+msgstr "&Журнал...\tCTRL-L"
 
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr "&Журнал...\tCTRL-L"
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 msgid "&Merge"
 msgstr "&Объединить"
 
-#: ../rapidsvn_frame.cpp:348
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr "&Операции"
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:897
+#, fuzzy
+msgid "&Name"
+msgstr "Имя"
+
+#: ../rapidsvn_generated.cpp:499
+#, fuzzy
+msgid "&Name of the new repository:"
+msgstr "Создать новый репозиторий..."
+
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr "&Новый..."
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+#, fuzzy
+msgid "&Password"
+msgstr "Пароль"
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr "&Постоянно"
 
@@ -184,72 +218,89 @@ msgstr "&Постоянно"
 msgid "&Properties...\tCTRL-P"
 msgstr "&Свойства...\tCTRL-P"
 
-#: ../rapidsvn_frame.cpp:349
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr "&Запросы"
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 msgid "&Recent entries:"
 msgstr "&Последние комментарии:"
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 msgid "&Remove Bookmark"
 msgstr "&Удалить закладку..."
 
-#: ../rapidsvn_frame.cpp:347
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr "&Репозиторий"
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+msgid "&Revision"
+msgstr "Ревизия"
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr "П&рервать"
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr "Изменить URL &репозитория..."
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr "&Временно"
 
-#: ../rapidsvn_frame.cpp:354
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr "Тест&ы"
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr "&Переключить"
+
+#: ../rapidsvn_generated.cpp:473
+msgid "&Type:"
+msgstr ""
 
 #: ../utils.cpp:199
 msgid "&Unlock"
 msgstr "Ра&зблокировать"
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr "&Обновить...\tCTRL-U"
 
-#: ../log_dlg.cpp:360
-#: ../rapidsvn_frame.cpp:346
+#: ../rapidsvn_generated.cpp:89
+#, fuzzy
+msgid "&Username"
+msgstr "Переименование"
+
+#: ../rapidsvn_generated.cpp:904
+#, fuzzy
+msgid "&Value"
+msgstr "Значение"
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr "&Просмотр"
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr "&Открыть..."
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr "- Сертификат содержит неизвестную ошибку."
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr "- Сертификат просрочен."
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr "- Имя узла не соответствует сертификату."
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
@@ -257,80 +308,88 @@ msgstr ""
 "- Сертификат выдан непроверенным центром сертификации.\n"
 "  Для проверки сертификата вручную используйте отпечаток ключа!"
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
 msgstr "- Сертификат недействителен."
 
-#: ../file_info.cpp:102
-#: ../file_info.cpp:110
-#: ../file_info.cpp:195
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+#, fuzzy
+msgid "..."
+msgstr "&Новый..."
+
+#: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
 msgid "<None>"
 msgstr "<нет>"
 
-#: ../about_dlg.cpp:68
+#: ../create_repos_dlg.cpp:131
+msgid "A directory of this name exists already"
+msgstr ""
+
+#: ../create_repos_dlg.cpp:136
+msgid "A file of this name exists already"
+msgstr ""
+
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr "ANSI"
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr "О программе %s"
 
-#: ../log_dlg.cpp:242
-msgid "Action"
-msgstr "Операция"
-
-#: ../add_action.cpp:37
-#: ../add_recursive_action.cpp:37
-#: ../listener.cpp:353
-#: ../rapidsvn_frame.cpp:1627
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr "Добавление"
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr "Добавить &существующий репозиторий..."
+
+#: ../rapidsvn_generated.cpp:516
+msgid "Add a bookmark for the new repository"
+msgstr ""
 
 #: ../utils.cpp:173
 msgid "Add r&ecursive"
 msgstr "Добавить р&екурсивно"
 
-#: ../rapidsvn_frame.cpp:553
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr "Добавить выбранные"
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr "Добавить в закладки"
 
-#: ../listener.cpp:362
-#: ../listener.cpp:369
-#: ../rapidsvn_frame.cpp:1636
-#: ../rapidsvn_frame.cpp:1643
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr "Добавлено"
 
-#: ../rapidsvn_frame.cpp:2146
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr "Репозиторий '%s' добавлен в закладки"
 
-#: ../rapidsvn_frame.cpp:2117
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr "Рабочая копия '%s' добавлена в закладки"
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr "Добавление каталога в репозиторий: %s"
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, c-format
 msgid "Adding file to repository: %s"
 msgstr "Добавление файла в репозиторий: %s"
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr "Файлы/каталоги"
 
@@ -338,21 +397,19 @@ msgstr "Файлы/каталоги"
 msgid "All files|*"
 msgstr "Все файлы|*"
 
-#: ../rapidsvn_frame.cpp:1501
-#: ../rapidsvn_frame.cpp:1520
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr "Возникла ошибка при запуске интернет-обозревателя"
 
-#: ../rapidsvn_frame.cpp:1488
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr "Возникла ошибка при проверке допустимых операций"
 
-#: ../annotate_action.cpp:80
-#: ../annotate_action.cpp:81
+#: ../annotate_action.cpp:80 ../annotate_action.cpp:81
 msgid "Annotate"
 msgstr "Авторство строк"
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -371,13 +428,11 @@ msgstr ""
 "\n"
 "  %s?"
 
-#: ../auth_dlg.cpp:117
-#: ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr "Аутентификация"
 
-#: ../annotate_dlg.cpp:48
-#: ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr "Автор"
 
@@ -385,7 +440,11 @@ msgstr "Автор"
 msgid "BASE"
 msgstr "BASE"
 
-#: ../rapidsvn_frame.cpp:2183
+#: ../rapidsvn_generated.cpp:477
+msgid "BerkeleyDB"
+msgstr ""
+
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr "Закладка"
 
@@ -393,18 +452,17 @@ msgstr "Закладка"
 msgid "Bookmarks"
 msgstr "Закладки"
 
-#: ../rapidsvn_frame.cpp:574
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr "Внести в рабочую копию изменения из репозитория"
 
-#: ../rapidsvn_generated.cpp:57
-#: ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119
-#: ../rapidsvn_generated.cpp:146
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr "Выбрать"
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -415,57 +473,44 @@ msgstr ""
 "wxWidgets %d.%d.%d (%s)\n"
 "Subversion %d.%d.%d\n"
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr "CR (MacOS)"
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr "CRLF (Windows)"
 
-#: ../auth_dlg.cpp:73
-#: ../cert_dlg.cpp:138
-#: ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57
-#: ../destination_dlg.cpp:90
-#: ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146
-#: ../import_dlg.cpp:130
-#: ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342
-#: ../lock_dlg.cpp:61
-#: ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195
-#: ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409
-#: ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564
-#: ../switch_dlg.cpp:139
-#: ../unlock_dlg.cpp:58
-#: ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+#, fuzzy
+msgid "Certificate information:"
 msgstr "Информация о сертификате:"
 
-#: ../rapidsvn_frame.cpp:295
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr "Создать &рабочую копию...\tCTRL-O"
 
 #: ../checkout_action.cpp:40
-#: ../checkout_dlg.cpp:250
 msgid "Checkout"
 msgstr "Создание рабочей копии"
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
 msgstr "Создать новую рабочую копию..."
-
-#: ../rapidsvn_frame.cpp:337
-msgid "Checkout Test"
-msgstr "Тест создания рабочей копии"
 
 #: ../columns.cpp:58
 msgid "Checksum"
@@ -476,26 +521,28 @@ msgstr "Контрольная сумма"
 msgid "Checksum: %s"
 msgstr "Контрольная сумма: %s"
 
-#: ../cleanup_action.cpp:39
-#: ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr "Уборка"
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+#, fuzzy
+msgid "Close"
+msgstr "&Закрыть"
+
+#: ../utils.cpp:297
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr "&Фиксировать изменения...\tCTRL-ENTER"
 
-#: ../rapidsvn_frame.cpp:271
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr "Столбцы"
 
-#: ../rapidsvn_generated.cpp:275
-#: ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr "Комбо!"
 
-#: ../commit_action.cpp:42
-#: ../commit_dlg.cpp:45
+#: ../commit_action.cpp:42 ../commit_dlg.cpp:45
 msgid "Commit"
 msgstr "Фиксация изменений"
 
@@ -503,11 +550,11 @@ msgstr "Фиксация изменений"
 msgid "Commit Log Message"
 msgstr "Комментарий фиксации"
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr "Комментарий фиксации: по умолчанию - самый последний"
 
-#: ../rapidsvn_frame.cpp:583
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr "Зафиксировать выбранные"
 
@@ -515,9 +562,19 @@ msgstr "Зафиксировать выбранные"
 msgid "Committed revision"
 msgstr "Зафиксирована ревизия"
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
 msgstr "Сравнить:"
+
+#: ../listener.cpp:496
+#, fuzzy, c-format
+msgid "Completed %s at revision %d"
+msgstr "Зафиксирована ревизия"
+
+#: ../listener.cpp:486
+#, fuzzy, c-format
+msgid "Completed at revision %d"
+msgstr "Зафиксирована ревизия"
 
 #: ../columns.cpp:64
 msgid "Conflict BASE"
@@ -551,6 +608,11 @@ msgstr "Конфликт: рабочий ф-л"
 msgid "Conflict Working File: %s"
 msgstr "Рабочий файл конфликта: %s"
 
+#: ../listener.cpp:307
+#, fuzzy
+msgid "Conflicted"
+msgstr "конфликт"
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr "Скопировано"
@@ -565,31 +627,21 @@ msgstr "Скопировано из ревизии: %ld"
 msgid "Copied From URL: %s"
 msgstr "Скопировано из URL: %s"
 
-#: ../log_dlg.cpp:244
-msgid "Copied from Path"
-msgstr "Скопировано из пути"
-
-#: ../log_dlg.cpp:245
-msgid "Copied from Rev"
-msgstr "Скопировано из ревизии"
-
-#: ../dnd_dlg.cpp:108
-#: ../listener.cpp:354
-#: ../move_action.cpp:44
-#: ../rapidsvn_frame.cpp:1628
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr "Копирование"
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 msgid "Copy/Move"
 msgstr "Копирование/Перемещение"
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, c-format
 msgid "Copying file into working directory: %s"
 msgstr "Копирование файла в рабочий каталог: %s"
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, c-format
 msgid "Copying file: %s"
 msgstr "Копирование файла: %s"
@@ -599,62 +651,59 @@ msgstr "Копирование файла: %s"
 msgid "Could not set working directory to %s"
 msgstr "Невозможно установить рабочим каталогом %s"
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr "Создать новый репозиторий..."
 
-#: ../columns.cpp:54
-#: ../log_dlg.cpp:165
+#: ../create_repos_action.cpp:37
+#, fuzzy
+msgid "Create Repository"
+msgstr "Создать новый репозиторий..."
+
+#: ../rapidsvn_generated.cpp:485
+#, fuzzy
+msgid "Create repository in &directory:"
+msgstr "Выберите целевой каталог"
+
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr "Дата"
 
-#: ../rapidsvn_generated.cpp:265
-#: ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr "Дата:"
 
-#: ../delete_action.cpp:40
-#: ../delete_dlg.cpp:79
-#: ../listener.cpp:355
-#: ../rapidsvn_frame.cpp:1629
+#: ../rapidsvn_generated.cpp:532
+msgid "Default"
+msgstr ""
+
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr "Удаление"
 
-#: ../rapidsvn_frame.cpp:564
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr "Прекратить контроль версий для файлов и каталогов"
 
-#: ../rapidsvn_frame.cpp:563
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr "Удалить выбранные"
 
-#: ../listener.cpp:361
-#: ../listener.cpp:370
-#: ../rapidsvn_frame.cpp:1635
-#: ../rapidsvn_frame.cpp:1644
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr "Удалён"
 
-#: ../checkout_dlg.cpp:72
-#: ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
 msgstr "Целевой каталог"
 
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr "Целевой файл"
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
-msgstr "Целевой путь"
-
-#: ../diff_action.cpp:191
-#: ../diff_action.cpp:197
-#: ../diff_dlg.cpp:179
+#: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr "Сравнение"
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 msgid "Diff Tool"
 msgstr "Программа для сравнения"
 
@@ -674,109 +723,115 @@ msgstr "Сравнить с другой ревизией/датой"
 msgid "Diff two revisions/dates"
 msgstr "Сравнить две ревизии/даты"
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
 msgstr "Отдельный вход с паролем для каждой закладки из списка"
+
+#: ../rapidsvn_generated.cpp:1296
+#, fuzzy
+msgid "Directory"
+msgstr "Каталог:"
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr "Каталог:"
 
-#: ../rapidsvn_frame.cpp:507
+#: ../rapidsvn_generated.cpp:554
+msgid "Disable automatic Log removal"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:557
+msgid "Disable fsync when committing database transactions"
+msgstr ""
+
+#: ../main_frame_helper.cpp:179
 msgid "Display conflicted files/directories"
 msgstr "Показывать файлы/каталоги в состоянии конфликта"
 
-#: ../rapidsvn_frame.cpp:620
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr "Отобразить информацию о выбранных файлах/каталогах"
 
-#: ../rapidsvn_frame.cpp:501
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr "Показывать измененные файлы/каталоги"
 
-#: ../rapidsvn_frame.cpp:495
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr "Показывать неизменённые файлы/каталоги"
 
-#: ../rapidsvn_frame.cpp:489
+#: ../main_frame_helper.cpp:161
 msgid "Display unversioned files/directories"
 msgstr "Показывать файлы/каталоги без версионного контроля"
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr "Подтверждаете удаление выбранных файлов/каталогов?"
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr "Подтверждаете отмену локальных изменений?"
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr "Подтверждаете разблокировку выбранных файлов/каталогов?"
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr "В&ыход\tCTRL-Q"
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr "Символ(ы) конца строки (EOL):"
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr "Изменение"
 
-#: ../rapidsvn_frame.cpp:2183
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr "Изменить закладку"
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr "Изменить свойство"
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "Edit..."
+msgstr "&Изменить..."
+
+#: ../rapidsvn_generated.cpp:1306
+#, fuzzy
+msgid "End &log message"
+msgstr "Введите &комментарий"
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 msgid "Enter &log message"
 msgstr "Введите &комментарий"
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr "Введите комментарий для блокировки"
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr "Введите комментарий"
+#: ../create_repos_dlg.cpp:126
+#, fuzzy
+msgid "Enter a name for the repository"
+msgstr "Введите комментарий для блокировки"
 
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr "Укажите новое имя:"
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr "Введите локальный путь, куда следует произвести экспорт файлов."
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
 msgstr "Введите локальный путь, где вы хотите создать рабочую копию."
 
-#: ../checkout_dlg.cpp:70
-#: ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr "Введите тут URL репозитория (не локальный путь)."
 
-#: ../export_dlg.cpp:143
-msgid "Enter what kind of symbol(s) do you want as EOL (end of line) in exported files."
-msgstr "Укажите, какой символ(ы) следует использовать в качестве EOL (конца строки) в экспортированных файлах."
-
-#: ../import_dlg.cpp:178
-#: ../import_dlg.cpp:191
-#: ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494
-#: ../log_dlg.cpp:530
-#: ../merge_dlg.cpp:52
-#: ../merge_dlg.cpp:91
-#: ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
-#: ../rapidsvn_frame.cpp:2107
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr "Ошибка"
 
@@ -784,57 +839,64 @@ msgstr "Ошибка"
 msgid "Error retrieving status:"
 msgstr "Ошибка получения статуса:"
 
-#: ../property_dlg.cpp:120
+#: ../create_repos_action.cpp:111
+msgid "Error running svnadmin"
+msgstr ""
+
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr "Ошибка установки значений свойств"
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, fuzzy, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr "Ошибка установки значений свойств"
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr "Ошибка проверки подлинности сертификата сервера для '%s':"
 
-#: ../simple_worker.cpp:216
-#: ../threaded_worker.cpp:178
+#: ../simple_worker.cpp:216 ../threaded_worker.cpp:178
 msgid "Error while performing action."
 msgstr "Ошибка при выполнении операции."
 
-#: ../simple_worker.cpp:206
-#: ../threaded_worker.cpp:165
+#: ../simple_worker.cpp:206 ../threaded_worker.cpp:165
 #, c-format
 msgid "Error while performing action: %s"
 msgstr "Ошибка при выполнении операции: %s"
 
-#: ../simple_worker.cpp:167
-#: ../threaded_worker.cpp:286
+#: ../simple_worker.cpp:167 ../threaded_worker.cpp:286
 msgid "Error while preparing action."
 msgstr "Ошибка при подготовке операции."
 
-#: ../simple_worker.cpp:161
-#: ../threaded_worker.cpp:276
+#: ../simple_worker.cpp:161 ../threaded_worker.cpp:276
 #, c-format
 msgid "Error while preparing action: %s"
 msgstr "Ошибка при подготовке операции: %s"
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr "Ошибка при обновлении списка файлов (%s)"
 
-#: ../rapidsvn_frame.cpp:1137
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr "Ошибка при обновлении списка файлов"
 
-#: ../rapidsvn_frame.cpp:1124
+#: ../main_frame.cpp:917
 #, c-format
 msgid "Error while updating filelist (%s)"
 msgstr "Ошибка при обновлении списка файлов (%s)"
 
-#: ../rapidsvn_frame.cpp:723
+#: ../main_frame.cpp:561
 #, c-format
 msgid "Error: %s\n"
 msgstr "Ошибка: %s\n"
 
-#: ../rapidsvn_frame.cpp:2041
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
 msgstr "Возникла исключительная ситуация во время обновления списка файлов"
 
@@ -851,8 +913,7 @@ msgstr "Выполнить"
 msgid "Execute diff tool: %s"
 msgstr "Запуск программы сравнения: %s"
 
-#: ../external_program_action.cpp:140
-#: ../view_action.cpp:121
+#: ../external_program_action.cpp:140 ../view_action.cpp:121
 #, c-format
 msgid "Execute editor: %s"
 msgstr "Запуск редактора: %s"
@@ -867,18 +928,16 @@ msgstr "Запуск обозревателя файлов: %s"
 msgid "Execute merge tool: %s"
 msgstr "Запуск программы объединения: %s"
 
-#: ../simple_worker.cpp:175
-#: ../threaded_worker.cpp:143
+#: ../simple_worker.cpp:175 ../threaded_worker.cpp:143
 #, c-format
 msgid "Execute: %s"
 msgstr "Выполнение: %s"
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr "Открыть...\tF2"
 
-#: ../export_action.cpp:40
-#: ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr "Экспорт"
 
@@ -886,59 +945,61 @@ msgstr "Экспорт"
 msgid "Extension"
 msgstr "Расширение"
 
-#: ../listener.cpp:376
-#: ../rapidsvn_frame.cpp:1650
+#: ../listener.cpp:405
+#, fuzzy
+msgid "External"
+msgstr "внешний"
+
+#: ../rapidsvn_generated.cpp:477
+msgid "FSFS"
+msgstr ""
+
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr "Попытка блокировки не удалась"
 
-#: ../listener.cpp:377
-#: ../rapidsvn_frame.cpp:1651
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr "Попытка разблокировки не удалась"
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr "Файл"
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr "Для выполнения импорта файла необходим его путь!"
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr "Отпечаток ключа:"
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr "Для объединения необходим первый путь или URL!"
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr "Первая рабочая копия или URL"
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr "Более подробная информация:"
 
-#: ../destination_dlg.cpp:80
-#: ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr "Принудительно"
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr "Принудительное удаление"
 
-#: ../export_dlg.cpp:123
-msgid "Force to execute even if destination directory not empty, causes overwriting of files with the same names."
-msgstr "Выполнить операцию, перезаписывая поверх существующих файлов в целевом каталоге. ВНИМАНИЕ! Может привести к потере данных!"
+#: ../export_dlg.cpp:75
+msgid ""
+"Force to execute even if destination directory not empty, causes overwriting "
+"of files with the same names."
+msgstr ""
+"Выполнить операцию, перезаписывая поверх существующих файлов в целевом "
+"каталоге. ВНИМАНИЕ! Может привести к потере данных!"
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
-msgstr "Принудительная разблокировка, даже если заблокировано другим пользователем"
+msgstr ""
+"Принудительная разблокировка, даже если заблокировано другим пользователем"
 
-#: ../rapidsvn_generated.cpp:41
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr "Общие"
 
@@ -951,48 +1012,59 @@ msgstr "Чтение файла %s ревизии %s"
 msgid "HEAD"
 msgstr "HEAD"
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+msgid "Help"
+msgstr "Справка"
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr "История: %d ревизий"
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr "Имя узла:"
 
-#: ../checkout_dlg.cpp:88
-#: ../export_dlg.cpp:91
-msgid "If not using the latest version of the files, specify which revision to use here."
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
+msgid ""
+"If not using the latest version of the files, specify which revision to use "
+"here."
 msgstr "Если нужна не последняя версия файлов, введите тут номер ревизии."
 
-#: ../checkout_dlg.cpp:102
-#: ../export_dlg.cpp:105
-msgid "If the files were renamed or moved some time, specify which peg revision to use here."
-msgstr "Если файлы когда-либо переименовывались или перемещались, укажите от какой ревизии их отслеживать."
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
+msgid ""
+"If the files were renamed or moved some time, specify which peg revision to "
+"use here."
+msgstr ""
+"Если файлы когда-либо переименовывались или перемещались, укажите от какой "
+"ревизии их отслеживать."
 
 #: ../ignore_action.cpp:40
 msgid "Ignore"
 msgstr "Игнорировать"
 
-#: ../rapidsvn_frame.cpp:281
-#: ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr "Игнорировать внешние зависимости"
 
-#: ../checkout_dlg.cpp:122
-#: ../export_dlg.cpp:126
-#: ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr "Игнорировать внешние зависимости"
 
-#: ../dnd_dlg.cpp:37
-#: ../dnd_dlg.cpp:97
-#: ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr "Импорт"
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+#, fuzzy
+msgid "Import &Path"
+msgstr "Импорт"
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr "Импорт файла в репозиторий: %s"
@@ -1001,27 +1073,23 @@ msgstr "Импорт файла в репозиторий: %s"
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr "Интерактивное разре&шение...\tCTRL-T"
 
-#: ../rapidsvn_frame.cpp:276
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr "Выделять изменённые дочерние"
 
-#: ../rapidsvn_frame.cpp:2226
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr "Информация"
 
-#: ../rapidsvn_frame.cpp:619
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr "Информация о выбранных"
-
-#: ../rapidsvn_frame.cpp:1716
-msgid "Information"
-msgstr "Информация"
 
 #: ../threaded_worker.cpp:245
 msgid "Internal Error: There is another action running"
 msgstr "Внутренняя ошибка: выполняется другая операция"
 
-#: ../rapidsvn_frame.cpp:1784
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr "Внутренняя ошибка: отсутствуют данные клиента для операции!"
 
@@ -1033,27 +1101,16 @@ msgstr "Внутренняя ошибка: контекст не доступе�
 msgid "Invalid revision number detected"
 msgstr "Обнаружен неправильный номер ревизии"
 
-#: ../log_dlg.cpp:478
-msgid "Invalid selection. At least one revisions is needed for diff and no more than two."
-msgstr "Неправильный выбор. Для сравнения необходимо выбрать одну или две ревизии."
-
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr "Неправильный выбор. Для операции слияния необходимо ровно две ревизии."
-
-#: ../log_dlg.cpp:529
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr "Неправильный выбор. Для просмотра авторства строк можно выбрать только одну ревизию."
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
+#: ../rapidsvn_generated.cpp:159
+#, fuzzy
+msgid "Issuer:"
 msgstr "Выдан:"
 
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 msgid "Keep Locks"
 msgstr "Сохранить блокировки"
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr "LF (Unix)"
 
@@ -1075,20 +1132,16 @@ msgstr "Дата последнего изменения"
 msgid "Last Changed Rev: %ld"
 msgstr "Последняя ревизия: %ld"
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr "Строка"
 
-#: ../rapidsvn_frame.cpp:336
-msgid "Listener Test"
-msgstr "Тест Слушателя"
-
-#: ../filelist_ctrl.cpp:1018
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr "Вывод содержимого в '%s'"
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1101,21 +1154,7 @@ msgstr ""
 "Системное имя: %s\n"
 "Имя по стандарту: %s\n"
 
-#: ../rapidsvn_app.cpp:198
-#: ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr "Найти справку"
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr "Найти подсказки"
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr "Найти файл подсказок"
-
 #: ../lock_action.cpp:40
-#: ../lock_dlg.cpp:100
 msgid "Lock"
 msgstr "Блокировка"
 
@@ -1150,32 +1189,27 @@ msgstr "Обладатель блокировки: %s"
 msgid "Lock Token: %s"
 msgstr "Ключ блокировки: %s"
 
-#: ../listener.cpp:374
-#: ../rapidsvn_frame.cpp:1648
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr "Заблокировано"
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr "Журнал"
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr "Журнал правок"
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr "Комментарий"
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr "Комментарий:"
-
-#: ../rapidsvn_frame.cpp:629
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr "Журнал файла/каталога"
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr "Войти..."
 
@@ -1200,39 +1234,40 @@ msgstr "Создать &каталог...\tF7"
 msgid "Make directory"
 msgstr "Создание каталога"
 
-#: ../merge_action.cpp:38
-#: ../merge_action.cpp:44
-#: ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr "Объединить"
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 msgid "Merge Tool"
 msgstr "Программа объединения"
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
-msgstr "Объединить ревизии"
-
-#: ../rapidsvn_frame.cpp:300
+#: ../main_frame.cpp:303
 msgid "Merge..."
 msgstr "Объединить изменения..."
+
+#: ../listener.cpp:308
+#, fuzzy
+msgid "Merged"
+msgstr "Объединить"
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr "Создание каталога"
 
-#: ../listener.cpp:368
-#: ../rapidsvn_frame.cpp:1642
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr "Изменено"
 
-#: ../dnd_dlg.cpp:104
-#: ../move_action.cpp:42
+#: ../rapidsvn_generated.cpp:563
+msgid "More options"
+msgstr ""
+
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr "Перемещение"
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, c-format
 msgid "Moving file: %s"
 msgstr "Перемещение файла: %s"
@@ -1241,10 +1276,16 @@ msgstr "Перемещение файла: %s"
 msgid "Multiple Files"
 msgstr "Составные файлы"
 
-#: ../columns.cpp:45
-#: ../listed_dlg.cpp:75
-#: ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr "Имя"
 
@@ -1253,45 +1294,24 @@ msgstr "Имя"
 msgid "Name: %s"
 msgstr "Имя: %s"
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
 msgstr "Новое свойство"
-
-#: ../revert_dlg.cpp:57
-msgid "No"
-msgstr "Нет"
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr "Не установлена программа сравнения в настройках"
 
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Файл справки не был указан, повторить \n"
-"вопрос при следующем старте?"
-
 #: ../userresolve_action.cpp:62
 msgid "No merge tool set in the preferences"
 msgstr "Не установлена программа объединения в настройках"
-
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Местонахождение файла подсказок не указано, \n"
-"спросить при следующем старте?"
 
 #: ../file_info.cpp:118
 #, c-format
 msgid "Node Kind: %s"
 msgstr "Тип узла: %s"
 
-#: ../checkout_dlg.cpp:106
-#: ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr "Не указано"
 
@@ -1299,103 +1319,66 @@ msgstr "Не указано"
 msgid "Not versioned"
 msgstr "Объект не версионирован"
 
-#: ../about_dlg.cpp:114
-#: ../annotate_dlg.cpp:42
-#: ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126
-#: ../delete_dlg.cpp:54
-#: ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145
-#: ../import_dlg.cpp:128
-#: ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341
-#: ../lock_dlg.cpp:60
-#: ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191
-#: ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405
-#: ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560
-#: ../report_dlg.cpp:57
-#: ../switch_dlg.cpp:137
-#: ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr "OK"
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr "Открыть..."
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr "Перезапись"
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr "Пароль"
-
 #: ../columns.cpp:46
-#: ../import_dlg.cpp:80
-#: ../log_dlg.cpp:243
 msgid "Path"
 msgstr "Путь"
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+#, fuzzy
+msgid "Path &type"
 msgstr "Тип пути:"
 
-#: ../checkout_dlg.cpp:97
-#: ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr "Стержневая ревизия"
-
-#: ../rapidsvn_frame.cpp:1709
-msgid ""
-"Please use the command line utility 'svnadmin'\n"
-"to create a new repository.\n"
-"\n"
-"This command line utility is not part of the\n"
-"RapidSVN distribution.\n"
-"\n"
-"More information about subversion:\n"
-"http://svnbook.red-bean.com/\n"
-"http://subversion.tigris.org"
-msgstr ""
-"Пожалуйста, используйте утилиту командной строки 'svnadmin'\n"
-"для создания нового репозитория.\n"
-"\n"
-"Эта утилита не поставляется вместе с дистрибутивом RapidSVN.\n"
-"\n"
-"Более подробная информация о программе subversion:\n"
-"http://svnbook.red-bean.com/\n"
-"http://subversion.tigris.org"
 
 #: ../preferences_dlg.cpp:48
 msgid "Preferences"
 msgstr "Настройки"
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr "Настройки..."
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr "Аргументы программы (%1=базовый, %2=их, %3=мой, %4=результат):"
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr "Аргументы программы (%1=файл1, %2=файл2):"
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr "Аргументы программы (%1=выбранный каталог):"
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr "Аргументы программы (%1=выбранный файл):"
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr "Программы"
 
@@ -1411,7 +1394,7 @@ msgstr "Статус св-в"
 msgid "Properties Last Updated"
 msgstr "Последнее обновление свойств"
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr "Свойства:"
 
@@ -1423,22 +1406,21 @@ msgstr "Свойство"
 msgid "Property Editor"
 msgstr "Редактор свойств"
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr "Очищать временные файлы при выходе из программы"
 
-#: ../rapidsvn_frame.cpp:554
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr "Ввести у файлов и каталогов контроль версий"
 
-#: ../rapidsvn_frame.cpp:690
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
+msgstr ""
+
+#: ../main_frame.cpp:528
 msgid "RapidSVN Error"
 msgstr "Ошибка RapidSVN"
-
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
-msgstr "Справка RapidSVN: %s"
 
 #: ../utils.cpp:192
 msgid "Re&name...\tCTRL-N"
@@ -1452,56 +1434,50 @@ msgstr "Ра&зрешить конфликты\tCTRL-S"
 msgid "Re&vert\tCTRL-V"
 msgstr "&Отменить изменения\tCTRL-V"
 
-#: ../filelist_ctrl.cpp:1088
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr "Готово"
 
-#: ../rapidsvn_frame.cpp:1764
-#: ../rapidsvn_frame.cpp:1808
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr "Готово\n"
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr "Последние комментарии:"
 
-#: ../checkout_dlg.cpp:111
-#: ../export_dlg.cpp:114
-#: ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201
-#: ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547
-#: ../revert_dlg.cpp:49
-#: ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr "Рекурсивно"
 
-#: ../rapidsvn_frame.cpp:518
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr "Обновить"
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr "Обновить список файлов\tCTRL-R"
 
-#: ../rapidsvn_frame.cpp:519
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr "Обновить список файлов"
 
-#: ../rapidsvn_frame.cpp:274
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr "Обновлять из репозитория"
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 msgid "Relocate"
 msgstr "Перемещение"
 
-#: ../rapidsvn_frame.cpp:604
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
 msgstr "Убрать состояние 'конфликтует' с файлов или каталогов рабочей копии"
 
-#: ../rapidsvn_frame.cpp:2160
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr "Закладка удалена"
 
@@ -1513,8 +1489,7 @@ msgstr "Переименование"
 msgid "Rep. Rev."
 msgstr "Рев. реп."
 
-#: ../listener.cpp:371
-#: ../rapidsvn_frame.cpp:1645
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr "Заменено"
 
@@ -1522,14 +1497,14 @@ msgstr "Заменено"
 msgid "Repository"
 msgstr "Репозиторий"
 
-#: ../import_dlg.cpp:67
-#: ../rapidsvn_frame.cpp:2132
+#: ../rapidsvn_generated.cpp:1268
+#, fuzzy
+msgid "Repository &URL for import"
+msgstr "Для импорта необходим URL репозитория!"
+
+#: ../main_frame.cpp:2079
 msgid "Repository URL"
 msgstr "URL репозитория"
-
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
-msgstr "Для импорта необходим URL репозитория!"
 
 #: ../file_info.cpp:112
 #, c-format
@@ -1541,75 +1516,63 @@ msgstr "UUID репозитория: %s"
 msgid "Repository: %s"
 msgstr "Репозиторий: %s"
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr "Сброс столбцов"
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr "Сбрасывать плоский режим при каждом запуске программы"
 
-#: ../resolve_action.cpp:37
-#: ../userresolve_action.cpp:44
+#: ../resolve_action.cpp:37 ../userresolve_action.cpp:44
 msgid "Resolve"
 msgstr "Разрешение конфликтов"
 
-#: ../rapidsvn_frame.cpp:603
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr "Разрешить конфликты у выбранных"
 
-#: ../listener.cpp:359
-#: ../rapidsvn_frame.cpp:1633
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr "Конфликт урегулирован"
 
-#: ../listener.cpp:356
-#: ../rapidsvn_frame.cpp:1630
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr "Восстановление"
 
-#: ../rapidsvn_frame.cpp:594
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
-msgstr "Восстановить первоначальную рабочую копию файла (отменить все локальные изменения)"
+msgstr ""
+"Восстановить первоначальную рабочую копию файла (отменить все локальные "
+"изменения)"
 
-#: ../listener.cpp:357
-#: ../rapidsvn_frame.cpp:1631
-#: ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../rapidsvn_generated.cpp:506
+msgid "Resulting repository filename:"
+msgstr ""
+
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr "Откат изменений"
 
-#: ../rapidsvn_frame.cpp:593
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr "Откатить изменения"
 
-#: ../annotate_dlg.cpp:47
-#: ../checkout_dlg.cpp:83
-#: ../columns.cpp:47
-#: ../export_dlg.cpp:86
-#: ../log_dlg.cpp:163
-#: ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150
-#: ../rapidsvn_generated.cpp:529
-#: ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr "Ревизия"
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr "Номер ревизии должен быть неотрицательным числом!"
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 msgid "Revision or date #1:"
 msgstr "Ревизия или дата #1:"
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 msgid "Revision or date #2:"
 msgstr "Ревизия или дата #2:"
 
-#: ../rapidsvn_generated.cpp:250
-#: ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr "Ревизия:"
 
@@ -1618,9 +1581,10 @@ msgstr "Ревизия:"
 msgid "Revision: %ld"
 msgstr "Правка: %ld"
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr "Сертификат SSL"
+#: ../create_repos_action.cpp:104
+#, c-format
+msgid "Running command %s:"
+msgstr ""
 
 #: ../columns.cpp:62
 msgid "Schedule"
@@ -1631,38 +1595,35 @@ msgstr "Планируется"
 msgid "Schedule: %s"
 msgstr "Планируется: %s"
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr "Для объединения необходим второй путь или URL!"
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr "Вторая рабочая копия или URL"
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr "Выберите файл сертификата"
 
-#: ../checkout_dlg.cpp:273
-#: ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr "Выберите целевой каталог"
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr "Укажите целевой каталог для объединения"
 
-#: ../rapidsvn_frame.cpp:2087
+#: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr "Выберите каталог"
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr "Выберите каталог для импорта"
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr "Выберите файл для импорта"
+
+#: ../create_repos_dlg.cpp:121
+#, fuzzy
+msgid "Select an existing directory for the repository"
+msgstr "Добавление каталога в репозиторий: %s"
 
 #: ../move_action.cpp:63
 msgid "Select destination:"
@@ -1684,93 +1645,95 @@ msgstr "Выберите стандартный редактор"
 msgid "Select standard file explorer executable"
 msgstr "Выберите стандартный обозреватель файлов"
 
-#: ../rapidsvn_frame.cpp:584
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr "Отправить изменения из рабочей копии в репозиторий"
 
-#: ../checkout_dlg.cpp:94
-#: ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
-msgstr "Установите этот флажок, чтобы получить последнюю версию файлов из репозитория."
+msgstr ""
+"Установите этот флажок, чтобы получить последнюю версию файлов из "
+"репозитория."
 
-#: ../checkout_dlg.cpp:108
-#: ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
-msgstr "Установите этот флажок, чтобы использовать BASE/HEAD (текущую) стержневую ревизию файлов."
+msgstr ""
+"Установите этот флажок, чтобы использовать BASE/HEAD (текущую) стержневую "
+"ревизию файлов."
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
-msgstr "Установите этот флажок для автоматического создания закладки для новой рабочей копии."
+msgstr ""
+"Установите этот флажок для автоматического создания закладки для новой "
+"рабочей копии."
 
-#: ../checkout_dlg.cpp:114
-#: ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
-msgstr "Установите этот флажок, чтобы также получить рекурсивно все подкаталоги из URL."
+msgstr ""
+"Установите этот флажок, чтобы также получить рекурсивно все подкаталоги из "
+"URL."
 
-#: ../checkout_dlg.cpp:125
-#: ../export_dlg.cpp:129
-msgid "Set to ignore external definitions and the external working copies managed by them."
-msgstr "Установите этот параметр для игнорирования внешних определений и внешних рабочих копий, ими управляемых."
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
+msgid ""
+"Set to ignore external definitions and the external working copies managed "
+"by them."
+msgstr ""
+"Установите этот параметр для игнорирования внешних определений и внешних "
+"рабочих копий, ими управляемых."
 
-#: ../rapidsvn_frame.cpp:326
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr "Показывать полезные подсказки при запуске"
 
-#: ../rapidsvn_frame.cpp:280
-#: ../rapidsvn_frame.cpp:506
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 msgid "Show conflicted entries"
 msgstr "Показывать файлы/каталоги в состоянии конфликта"
 
-#: ../rapidsvn_frame.cpp:483
+#: ../main_frame_helper.cpp:155
 msgid "Show entries in subdirectories"
 msgstr "Показывать файлы/каталоги в подкаталогах"
 
-#: ../rapidsvn_frame.cpp:282
+#: ../main_frame.cpp:285
 msgid "Show ignored entries"
 msgstr "Показывать игнорируемые файлы/каталоги"
 
-#: ../rapidsvn_frame.cpp:279
-#: ../rapidsvn_frame.cpp:500
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 msgid "Show modified entries"
 msgstr "Показывать изменённые файлы/каталоги"
 
-#: ../rapidsvn_frame.cpp:275
-#: ../rapidsvn_frame.cpp:482
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 msgid "Show subdirectories"
 msgstr "Показывать подкаталоги"
 
-#: ../rapidsvn_frame.cpp:630
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr "Показывать комментарии для выбранных файлов/каталогов"
 
-#: ../rapidsvn_frame.cpp:278
-#: ../rapidsvn_frame.cpp:494
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 msgid "Show unmodified entries"
 msgstr "Показывать неизменённые файлы и каталоги"
 
-#: ../rapidsvn_frame.cpp:277
-#: ../rapidsvn_frame.cpp:488
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr "Показывать неотслеживаемые файлы"
 
-#: ../listener.cpp:360
-#: ../rapidsvn_frame.cpp:1634
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr "Пропуск"
 
-#: ../rapidsvn_frame.cpp:272
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr "Сортировка"
 
-#: ../rapidsvn_frame.cpp:248
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr "по возрастанию"
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 msgid "Standard Editor"
 msgstr "Стандартный редактор"
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 msgid "Standard Explorer"
 msgstr "Стандартная программа обзора"
 
@@ -1778,40 +1741,39 @@ msgstr "Стандартная программа обзора"
 msgid "Status"
 msgstr "Статус"
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr "Перехватить блокировку, если она установлена другим пользователем"
 
-#: ../rapidsvn_frame.cpp:531
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr "Остановить"
 
-#: ../rapidsvn_frame.cpp:532
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr "Остановить текущую операцию"
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr "Хранить аутентификационное удостоверение на диске"
 
 #: ../switch_action.cpp:50
-#: ../switch_dlg.cpp:192
 msgid "Switch URL"
 msgstr "Смена URL"
 
-#: ../rapidsvn_frame.cpp:301
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr "Изменить URL...\tCTRL-S"
 
-#: ../rapidsvn_frame.cpp:1581
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr "Длительность теста"
 
-#: ../rapidsvn_frame.cpp:1577
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr "Тест закончен в"
 
-#: ../rapidsvn_frame.cpp:1574
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr "Тест начат в"
 
@@ -1821,9 +1783,19 @@ msgstr "Последнее обновление текста"
 
 #: ../view_action.cpp:96
 msgid "The Editor is not configured. Please check Edit->Preferences>Programs"
-msgstr "Не выбран редактор. Чтобы его установить, следуйте Просмотр->Настройки->Программы"
+msgstr ""
+"Не выбран редактор. Чтобы его установить, следуйте Просмотр->Настройки-"
+">Программы"
 
-#: ../cert_dlg.cpp:70
+#: ../create_repos_dlg.cpp:141
+msgid "The configuration directory does not exist"
+msgstr ""
+
+#: ../create_repos_action.cpp:121
+msgid "The svnadmin command was not successful."
+msgstr ""
+
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
@@ -1831,11 +1803,12 @@ msgstr ""
 "Обнаружены ошибки во время проверки сертификата сервера.\n"
 "Принять этот сертификат?"
 
-#: ../rapidsvn_generated.cpp:384
-msgid "This action has resulted in a commit - please enter a log message"
+#: ../rapidsvn_generated.cpp:418
+#, fuzzy
+msgid "This action has resulted in a commit - please enter a &log message"
 msgstr "Эта операция привела к фиксации - введите комментарий для журнала"
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1847,16 +1820,9 @@ msgstr ""
 "\n"
 "Она доступна по адресу:"
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr "Дерево"
-
-#: ../checkout_dlg.cpp:65
-#: ../columns.cpp:59
-#: ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521
-#: ../switch_dlg.cpp:77
-#: ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr "URL"
 
@@ -1869,11 +1835,11 @@ msgstr "URL: %s"
 msgid "UUID"
 msgstr "UUID"
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr "Юникод"
 
-#: ../rapidsvn_frame.cpp:1736
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr "Неподдерживаемая операция!"
 
@@ -1882,75 +1848,60 @@ msgid "Unknown destination path"
 msgstr "Неизвестный целевой путь"
 
 #: ../unlock_action.cpp:39
-#: ../unlock_dlg.cpp:80
 msgid "Unlock"
 msgstr "Разблокировка"
 
-#: ../listener.cpp:375
-#: ../rapidsvn_frame.cpp:1649
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr "Разблокировано"
 
-#: ../get_action.cpp:38
-#: ../update_action.cpp:39
-#: ../update_action.cpp:51
+#: ../get_action.cpp:38 ../update_action.cpp:39 ../update_action.cpp:51
 msgid "Update"
 msgstr "Обновление"
 
-#: ../rapidsvn_frame.cpp:573
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr "Обновить выбранные"
 
-#: ../listener.cpp:363
-#: ../rapidsvn_frame.cpp:1637
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr "Обновлено"
 
-#: ../rapidsvn_frame.cpp:1798
-#: ../rapidsvn_frame.cpp:1803
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr "Обновление..."
 
-#: ../rapidsvn_frame.cpp:247
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr "Использовать путь для сортировки"
 
-#: ../rapidsvn_generated.cpp:271
-#: ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 msgid "Use URL/path:"
 msgstr "Использовать URL/путь:"
 
-#: ../rapidsvn_generated.cpp:70
-#: ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr "Использовать всегда"
 
-#: ../checkout_dlg.cpp:92
-#: ../export_dlg.cpp:95
-#: ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299
-#: ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103
-#: ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr "Использовать последнюю"
 
-#: ../auth_dlg.cpp:54
-#: ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr "Пользователь"
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr "Действителен с:"
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr "Действителен по:"
 
-#: ../listed_dlg.cpp:80
-#: ../listed_dlg.cpp:172
-#: ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr "Значение"
 
@@ -1958,7 +1909,37 @@ msgstr "Значение"
 msgid "View"
 msgstr "Просмотр"
 
-#: ../dnd_dlg.cpp:69
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "View..."
+msgstr "&Открыть..."
+
+#: ../rapidsvn_generated.cpp:567
+msgid "WARNING"
+msgstr ""
+
+#: ../dnd_dlg.cpp:48
+#, fuzzy, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr ""
+"Хотите переместить или скопировать\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"в\n"
+"\n"
+"  %s?"
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -1979,33 +1960,27 @@ msgstr ""
 "\n"
 "  %s?"
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr "Да"
-
-#: ../rapidsvn_frame.cpp:2105
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
 msgstr "Нельзя добавить в закладки административный каталог subversion!"
 
-#: ../file_info.cpp:150
-#: ../filelist_ctrl.cpp:1196
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr "добавить"
 
-#: ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr "добавлен"
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr "конфликт"
 
-#: ../file_info.cpp:154
-#: ../filelist_ctrl.cpp:1199
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr "удалить"
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr "удалён"
 
@@ -2013,7 +1988,7 @@ msgstr "удалён"
 msgid "directory"
 msgstr "каталог"
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr "внешний"
 
@@ -2021,134 +1996,301 @@ msgstr "внешний"
 msgid "file"
 msgstr "файл"
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr "проигнорирован"
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr "повреждён"
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr "объединён"
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr "отсутствует"
 
-#: ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr "изменён"
 
-#: ../export_dlg.cpp:135
-#: ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr "(формат операционной системы)"
 
-#: ../file_info.cpp:132
-#: ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr "нет"
 
-#: ../file_info.cpp:146
-#: ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr "нормальный"
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr "заслоняет другой файл"
 
-#: ../filelist_ctrl.cpp:1229
-#: ../filelist_ctrl.cpp:1243
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr "устарел"
 
-#: ../file_info.cpp:158
-#: ../filelist_ctrl.cpp:1202
+#: ../rapidsvn_generated.cpp:532
+#, fuzzy
+msgid "pre Subversion 1.4"
+msgstr "Subversion %d.%d.%d"
+
+#: ../rapidsvn_generated.cpp:532
+#, fuzzy
+msgid "pre Subversion 1.5"
+msgstr "Subversion %d.%d.%d"
+
+#: ../rapidsvn_generated.cpp:532
+#, fuzzy
+msgid "pre Subversion 1.6"
+msgstr "Subversion %d.%d.%d"
+
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr "заменить"
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr "заменён"
 
-#: ../file_info.cpp:137
-#: ../file_info.cpp:162
+#: ../create_repos_dlg.cpp:116
+msgid "svnadmin could not be found"
+msgstr ""
+
+#: ../file_info.cpp:137 ../file_info.cpp:162
 msgid "unknown"
 msgstr "неизвестный"
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr "неизвестное значение"
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
 msgstr "не отслеживается"
 
-#: ../rapidsvn_frame.cpp:335
-msgid "wxString Creation&Tracing Test"
-msgstr "Тест создания и трассировки wxString"
+#~ msgid "Action"
+#~ msgstr "Операция"
+
+#~ msgid "Checkout Test"
+#~ msgstr "Тест создания рабочей копии"
+
+#~ msgid "Copied from Path"
+#~ msgstr "Скопировано из пути"
+
+#~ msgid "Copied from Rev"
+#~ msgstr "Скопировано из ревизии"
+
+#~ msgid "Destination file"
+#~ msgstr "Целевой файл"
+
+#~ msgid "Destination path"
+#~ msgstr "Целевой путь"
+
+#~ msgid "EOL:"
+#~ msgstr "Символ(ы) конца строки (EOL):"
+
+#~ msgid "Enter log message"
+#~ msgstr "Введите комментарий"
+
+#~ msgid "Enter the local path where you want the code be exported."
+#~ msgstr "Введите локальный путь, куда следует произвести экспорт файлов."
+
+#~ msgid ""
+#~ "Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
+#~ "files."
+#~ msgstr ""
+#~ "Укажите, какой символ(ы) следует использовать в качестве EOL (конца "
+#~ "строки) в экспортированных файлах."
+
+#~ msgid "File path required when importing a file!"
+#~ msgstr "Для выполнения импорта файла необходим его путь!"
+
+#~ msgid "First path or URL is required for merge!"
+#~ msgstr "Для объединения необходим первый путь или URL!"
+
+#~ msgid "Information"
+#~ msgstr "Информация"
+
+#~ msgid ""
+#~ "Invalid selection. At least one revisions is needed for diff and no more "
+#~ "than two."
+#~ msgstr ""
+#~ "Неправильный выбор. Для сравнения необходимо выбрать одну или две ревизии."
+
+#~ msgid "Invalid selection. Exactly two revisions needed for merge."
+#~ msgstr ""
+#~ "Неправильный выбор. Для операции слияния необходимо ровно две ревизии."
+
+#~ msgid "Invalid selection. Only one revision may be selected for annotate"
+#~ msgstr ""
+#~ "Неправильный выбор. Для просмотра авторства строк можно выбрать только "
+#~ "одну ревизию."
+
+#~ msgid "Listener Test"
+#~ msgstr "Тест Слушателя"
+
+#~ msgid "Locate help"
+#~ msgstr "Найти справку"
+
+#~ msgid "Locate tips"
+#~ msgstr "Найти подсказки"
+
+#~ msgid "Locate tips file"
+#~ msgstr "Найти файл подсказок"
+
+#~ msgid "Log Message:"
+#~ msgstr "Комментарий:"
+
+#~ msgid "Merge revisions"
+#~ msgstr "Объединить ревизии"
+
+#~ msgid "No"
+#~ msgstr "Нет"
+
+#~ msgid ""
+#~ "No help file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Файл справки не был указан, повторить \n"
+#~ "вопрос при следующем старте?"
+
+#~ msgid ""
+#~ "No tips file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Местонахождение файла подсказок не указано, \n"
+#~ "спросить при следующем старте?"
+
+#~ msgid ""
+#~ "Please use the command line utility 'svnadmin'\n"
+#~ "to create a new repository.\n"
+#~ "\n"
+#~ "This command line utility is not part of the\n"
+#~ "RapidSVN distribution.\n"
+#~ "\n"
+#~ "More information about subversion:\n"
+#~ "http://svnbook.red-bean.com/\n"
+#~ "http://subversion.tigris.org"
+#~ msgstr ""
+#~ "Пожалуйста, используйте утилиту командной строки 'svnadmin'\n"
+#~ "для создания нового репозитория.\n"
+#~ "\n"
+#~ "Эта утилита не поставляется вместе с дистрибутивом RapidSVN.\n"
+#~ "\n"
+#~ "Более подробная информация о программе subversion:\n"
+#~ "http://svnbook.red-bean.com/\n"
+#~ "http://subversion.tigris.org"
+
+#~ msgid "RapidSVN Help: %s"
+#~ msgstr "Справка RapidSVN: %s"
+
+#~ msgid "Revision must be an unsigned number!"
+#~ msgstr "Номер ревизии должен быть неотрицательным числом!"
+
+#~ msgid "SSL Certificate"
+#~ msgstr "Сертификат SSL"
+
+#~ msgid "Second path or URL is required for merge!"
+#~ msgstr "Для объединения необходим второй путь или URL!"
+
+#~ msgid "Second working copy or URL"
+#~ msgstr "Вторая рабочая копия или URL"
+
+#~ msgid "Tree"
+#~ msgstr "Дерево"
+
+#~ msgid "Yes"
+#~ msgstr "Да"
+
+#~ msgid "wxString Creation&Tracing Test"
+#~ msgstr "Тест создания и трассировки wxString"
 
 #~ msgid "Flat Mode"
 #~ msgstr "Развернутый режим (flat mode)"
+
 #~ msgid "&Add\tCTRL-A"
 #~ msgstr "&Добавить\tCTRL-A"
+
 #~ msgid "Nothing selected."
 #~ msgstr "Ничего не выбрано."
+
 #~ msgid "Please select only one file or directory."
 #~ msgstr "Выберите один файл или каталог."
+
 #~ msgid "Skipped: %s"
 #~ msgstr "Пропущено: %s"
+
 #~ msgid "&Author"
 #~ msgstr "Автор"
+
 #~ msgid "&Date"
 #~ msgstr "Дата"
+
 #~ msgid "&Last Changed"
 #~ msgstr "Последнее изменение"
+
 #~ msgid "&Prop Status"
 #~ msgstr "Статус свойств"
-#~ msgid "&Revision"
-#~ msgstr "Ревизия"
+
 #~ msgid "&Status"
 #~ msgstr "Статус"
+
 #~ msgid "Deleting unversioned file: %s"
 #~ msgstr "Удаляю неверсионированный файл: %s"
+
 #~ msgid "E&xtension"
 #~ msgstr "Расширение"
+
 #~ msgid "Pr&op Date"
 #~ msgstr "Дата изм. св-в"
+
 #~ msgid "R&ep. Rev."
 #~ msgstr "Рев. Реп."
+
 #~ msgid "Milestone: %s"
 #~ msgstr "Milestone: %s"
+
 #~ msgid "CR"
 #~ msgstr "CR"
+
 #~ msgid "CRLF"
 #~ msgstr "CRLF"
+
 #~ msgid "LF"
 #~ msgstr "LF"
 
 #, fuzzy
 #~ msgid "Conflict Previous Base File: %s"
 #~ msgstr "Conflict Previous Base File: %s"
+
 #~ msgid "Ansi"
 #~ msgstr "Ansi"
+
 #~ msgid "Url"
 #~ msgstr "Url"
-#~ msgid "Subversion %d.%d.%d"
-#~ msgstr "Subversion %d.%d.%d"
+
 #~ msgid "wxWidgets %d.%d.%d"
 #~ msgstr "wxWidgets %d.%d.%d"
+
 #~ msgid "Built with:"
 #~ msgstr "Собрано с использованием:"
+
 #~ msgid "Supported URL schemas: "
 #~ msgstr "Поддерживаемые схемы URL:"
+
 #~ msgid "Locale Information:"
 #~ msgstr "Информация о кодировке:"
+
 #~ msgid "Language:"
 #~ msgstr "Язык:"
-#~ msgid "Help"
-#~ msgstr "Справка"
-

--- a/librapidsvn/src/locale/uk/rapidsvn.po
+++ b/librapidsvn/src/locale/uk/rapidsvn.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RapidSVN 0.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-02 17:09+0100\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: 2006-05-15 11:14+0100\n"
 "Last-Translator: Olha <sleepy@adam-i-eva.com>\n"
 "Language-Team: RapidSVN Developers <dev@rapidsvn.tigris.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -20,22 +21,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr "%s  код: %ld"
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, fuzzy, c-format
 msgid "%s Version %s"
 msgstr "%s версія %d.%d.%d"
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, fuzzy, c-format
 msgid "%s Version %s Revision %d"
 msgstr "%s версія %d.%d.%d"
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr ""
 
-#: ../main_frame.cpp:323
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr "Про програму..."
 
@@ -43,38 +44,33 @@ msgstr "Про програму..."
 msgid "&Add\tINS"
 msgstr ""
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr "Додати існуючу робочу копію..."
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr ""
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 #, fuzzy
 msgid "&Annotate..."
 msgstr "Про програму..."
 
-#: ../main_frame.cpp:344
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr "Закладки"
 
-#: ../rapidsvn_generated.cpp:676
+#: ../rapidsvn_generated.cpp:549
 #, fuzzy
 msgid "&Browse"
 msgstr "Закрити"
 
-#: ../log_dlg.cpp:359
-#, fuzzy
-msgid "&Close"
-msgstr "Закрити"
-
-#: ../rapidsvn_generated.cpp:655
+#: ../rapidsvn_generated.cpp:528
 msgid "&Compatible with:"
 msgstr ""
 
-#: ../main_frame.cpp:316
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr "Зміст\tF1"
 
@@ -82,7 +78,7 @@ msgstr "Зміст\tF1"
 msgid "&Copy...\tF5"
 msgstr "Копіювати...\tF5"
 
-#: ../main_frame.cpp:290
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr "Створити..."
 
@@ -90,11 +86,11 @@ msgstr "Створити..."
 msgid "&Delete\tDEL"
 msgstr "Видалити\tDEL"
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr "Видалити..."
 
-#: ../log_dlg.cpp:362 ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 #, fuzzy
 msgid "&Diff"
 msgstr "Порівняти"
@@ -107,45 +103,50 @@ msgstr "Порівняти з Base...\tCTRL+B"
 msgid "&Diff to Head...\tCTRL+H"
 msgstr "Порівняти з Head...\tCTRL+H"
 
+#: ../utils.cpp:220
+#, fuzzy
+msgid "&Diff..."
+msgstr "Порівняти"
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr "Порівняти...\tCTRL+D"
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr "Редагувати закладку..."
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr "Редагування..."
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr "Редагувати...\tF3"
 
-#: ../main_frame.cpp:288
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr "Експорт...\tCTRL-E"
 
-#: ../main_frame.cpp:345
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr "Екстра"
 
-#: ../main_frame.cpp:339
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr "Файл"
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 #, fuzzy
 msgid "&Files to commit"
 msgstr "Спроба блокування не вдалася"
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 #, fuzzy
 msgid "&Get"
 msgstr "Отримати"
 
-#: ../main_frame.cpp:223 ../main_frame.cpp:346
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr "Допомога"
 
@@ -154,11 +155,11 @@ msgstr "Допомога"
 msgid "&Ignore\tCTRL-DEL"
 msgstr "Експорт...\tCTRL-E"
 
-#: ../main_frame.cpp:287
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr "Імпорт...\tCTRL-I"
 
-#: ../main_frame.cpp:317
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr "Індекс\tShift+F1"
 
@@ -166,7 +167,7 @@ msgstr "Індекс\tShift+F1"
 msgid "&Info..."
 msgstr "Інфо..."
 
-#: ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:540
 msgid "&Load configuration from directory (optional):"
 msgstr ""
 
@@ -174,29 +175,44 @@ msgstr ""
 msgid "&Lock..."
 msgstr "Заблокувати..."
 
+#: ../utils.cpp:222
+#, fuzzy
+msgid "&Log..."
+msgstr "Журнал...\tCTRL-L"
+
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr "Журнал...\tCTRL-L"
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 #, fuzzy
 msgid "&Merge"
 msgstr "Об'єднати"
 
-#: ../main_frame.cpp:342
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr "Операції"
 
-#: ../rapidsvn_generated.cpp:625
+#: ../rapidsvn_generated.cpp:897
+#, fuzzy
+msgid "&Name"
+msgstr "Ім'я"
+
+#: ../rapidsvn_generated.cpp:499
 #, fuzzy
 msgid "&Name of the new repository:"
 msgstr "Створити новий репозиторій..."
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr "Новий..."
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+#, fuzzy
+msgid "&Password"
+msgstr "Пароль"
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr "Постійно"
 
@@ -204,45 +220,49 @@ msgstr "Постійно"
 msgid "&Properties...\tCTRL-P"
 msgstr "Властивості...\tCTRL-P"
 
-#: ../main_frame.cpp:343
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr "Запити"
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 #, fuzzy
 msgid "&Recent entries:"
 msgstr "Нещодавні записи:"
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 #, fuzzy
 msgid "&Remove Bookmark"
 msgstr "Видалити закладку..."
 
-#: ../main_frame.cpp:341
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr "Репозиторій"
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+msgid "&Revision"
+msgstr "Ревізія"
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr "Стоп"
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr "Перемкнути URL репозиторію..."
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr "Тимчасово"
 
-#: ../main_frame.cpp:348
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr "Тести"
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:599
+#: ../rapidsvn_generated.cpp:473
 msgid "&Type:"
 msgstr ""
 
@@ -250,31 +270,41 @@ msgstr ""
 msgid "&Unlock"
 msgstr "Розблокувати"
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr "Актуалізація (update)...\tCTRL-U"
 
-#: ../log_dlg.cpp:360 ../main_frame.cpp:340
+#: ../rapidsvn_generated.cpp:89
+#, fuzzy
+msgid "&Username"
+msgstr "Перейменування"
+
+#: ../rapidsvn_generated.cpp:904
+#, fuzzy
+msgid "&Value"
+msgstr "Значення"
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr "Вигляд"
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr "Перегляд..."
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr "- Сертифікат містить невідому помилку."
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr "- Сертифікат прострочений."
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr "- Ім'я вузла не відповідає сертифікату."
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
@@ -282,9 +312,15 @@ msgstr ""
 "- Сертифікат видано неофіційним центром сертифікації.\n"
 "  Для перевірки сертифіката вручну використовуйте відбиток ключа!"
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
 msgstr "- Сертифікат ще не дійсний."
+
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+#, fuzzy
+msgid "..."
+msgstr "Новий..."
 
 #: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
 msgid "<None>"
@@ -298,30 +334,25 @@ msgstr ""
 msgid "A file of this name exists already"
 msgstr ""
 
-#: ../about_dlg.cpp:68
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr "ANSI"
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr "Про програму %s"
 
-#: ../log_dlg.cpp:242
-#, fuzzy
-msgid "Action"
-msgstr "Аутентифікація"
-
-#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listener.cpp:353
-#: ../main_frame.cpp:1398
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr "Додати"
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr "Додати існуючий репозиторій..."
 
-#: ../rapidsvn_generated.cpp:642
+#: ../rapidsvn_generated.cpp:516
 msgid "Add a bookmark for the new repository"
 msgstr ""
 
@@ -329,40 +360,40 @@ msgstr ""
 msgid "Add r&ecursive"
 msgstr "Додати рекурсивно"
 
-#: ../main_frame_helper.cpp:64
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr "Додати вибране"
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr "Додати до закладок"
 
-#: ../listener.cpp:362 ../listener.cpp:369 ../main_frame.cpp:1407
-#: ../main_frame.cpp:1414
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr "Додано"
 
-#: ../main_frame.cpp:1904
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr "Репозиторій '%s' додано до закладок"
 
-#: ../main_frame.cpp:1875
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr "Робочу копію '%s' додано до закладок"
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, fuzzy, c-format
 msgid "Adding file to repository: %s"
 msgstr "Репозиторій: %s"
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr ""
 
@@ -370,11 +401,11 @@ msgstr ""
 msgid "All files|*"
 msgstr "Всі файли|*"
 
-#: ../main_frame.cpp:1271 ../main_frame.cpp:1290
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr ""
 
-#: ../main_frame.cpp:1258
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr ""
 
@@ -383,7 +414,7 @@ msgstr ""
 msgid "Annotate"
 msgstr "застарів"
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -395,11 +426,11 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../auth_dlg.cpp:117 ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr "Аутентифікація"
 
-#: ../annotate_dlg.cpp:48 ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr "Автор"
 
@@ -407,11 +438,11 @@ msgstr "Автор"
 msgid "BASE"
 msgstr "BASE"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../rapidsvn_generated.cpp:477
 msgid "BerkeleyDB"
 msgstr ""
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr "Закладка"
 
@@ -419,17 +450,17 @@ msgstr "Закладка"
 msgid "Bookmarks"
 msgstr "Закладки"
 
-#: ../main_frame_helper.cpp:85
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr "Занести в робочу копію зміни, знайдені у репозиторії."
 
-#: ../rapidsvn_generated.cpp:57 ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119 ../rapidsvn_generated.cpp:146
-#: ../rapidsvn_generated.cpp:620
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr ""
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -440,44 +471,44 @@ msgstr ""
 "wxWidgets %d.%d.%d (%s)\n"
 "Subversion %d.%d.%d\n"
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr "CR (MacOS)"
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr "CRLF (Windows)"
 
-#: ../auth_dlg.cpp:73 ../cert_dlg.cpp:138 ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57 ../destination_dlg.cpp:90 ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146 ../import_dlg.cpp:130 ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342 ../lock_dlg.cpp:61 ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195 ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409 ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564 ../rapidsvn_generated.cpp:708
-#: ../switch_dlg.cpp:139 ../unlock_dlg.cpp:58 ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+#, fuzzy
+msgid "Certificate information:"
 msgstr "Інформація про сертифікат:"
 
-#: ../main_frame.cpp:289
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr "Створити локальну копію (check&out)...\tCTRL-O"
 
-#: ../checkout_action.cpp:40 ../checkout_dlg.cpp:250
+#: ../checkout_action.cpp:40
 msgid "Checkout"
 msgstr "Створення копії"
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
 msgstr "Створити нову робочу копію..."
-
-#: ../main_frame.cpp:331
-msgid "Checkout Test"
-msgstr "Тест Checkout"
 
 #: ../columns.cpp:58
 msgid "Checksum"
@@ -488,20 +519,25 @@ msgstr "Контрольна сума"
 msgid "Checksum: %s"
 msgstr "Контрольна сума: %s"
 
-#: ../cleanup_action.cpp:39 ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr "Прибирання"
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+#, fuzzy
+msgid "Close"
+msgstr "Закрити"
+
+#: ../utils.cpp:297
 #, fuzzy
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr "Фіксувати зміни (co&mmit)...\tCTRL-M"
 
-#: ../main_frame.cpp:265
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr "Стовпці"
 
-#: ../rapidsvn_generated.cpp:275 ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr ""
 
@@ -513,11 +549,11 @@ msgstr "Фіксація змін"
 msgid "Commit Log Message"
 msgstr "Повідомлення журналу"
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr ""
 
-#: ../main_frame_helper.cpp:94
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr "Зафіксувати вибране (commit)"
 
@@ -525,9 +561,19 @@ msgstr "Зафіксувати вибране (commit)"
 msgid "Committed revision"
 msgstr "Зафіксовано ревізію"
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
 msgstr "Порівняти:"
+
+#: ../listener.cpp:496
+#, fuzzy, c-format
+msgid "Completed %s at revision %d"
+msgstr "Зафіксовано ревізію"
+
+#: ../listener.cpp:486
+#, fuzzy, c-format
+msgid "Completed at revision %d"
+msgstr "Зафіксовано ревізію"
 
 #: ../columns.cpp:64
 msgid "Conflict BASE"
@@ -561,6 +607,11 @@ msgstr "Конфлікт: робочий ф-л"
 msgid "Conflict Working File: %s"
 msgstr "Робочий файл конфлікту: %s"
 
+#: ../listener.cpp:307
+#, fuzzy
+msgid "Conflicted"
+msgstr "конфліктує"
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr "Скопійовано"
@@ -575,32 +626,22 @@ msgstr "Скопійовано з ревізії: %ld"
 msgid "Copied From URL: %s"
 msgstr "Скопійовано з URL: %s"
 
-#: ../log_dlg.cpp:244
-#, fuzzy
-msgid "Copied from Path"
-msgstr "Скопійовано з URL: %s"
-
-#: ../log_dlg.cpp:245
-#, fuzzy
-msgid "Copied from Rev"
-msgstr "Скопійовано з ревізії: %ld"
-
-#: ../dnd_dlg.cpp:108 ../listener.cpp:354 ../main_frame.cpp:1399
-#: ../move_action.cpp:44
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr "Копіювати"
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 #, fuzzy
 msgid "Copy/Move"
 msgstr "Копіювати"
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, fuzzy, c-format
 msgid "Copying file into working directory: %s"
 msgstr "Неможливо встановити робочий шлях %s"
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, fuzzy, c-format
 msgid "Copying file: %s"
 msgstr "Робочий файл конфлікту: %s"
@@ -610,7 +651,7 @@ msgstr "Робочий файл конфлікту: %s"
 msgid "Could not set working directory to %s"
 msgstr "Неможливо встановити робочий шлях %s"
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr "Створити новий репозиторій..."
 
@@ -619,59 +660,51 @@ msgstr "Створити новий репозиторій..."
 msgid "Create Repository"
 msgstr "Створити новий репозиторій..."
 
-#: ../rapidsvn_generated.cpp:611
+#: ../rapidsvn_generated.cpp:485
 #, fuzzy
 msgid "Create repository in &directory:"
 msgstr "Оберіть цільовий каталог"
 
-#: ../columns.cpp:54 ../log_dlg.cpp:165
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr "Дата"
 
-#: ../rapidsvn_generated.cpp:265 ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr "Дата:"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 #, fuzzy
 msgid "Default"
 msgstr "Видалення"
 
-#: ../delete_action.cpp:40 ../delete_dlg.cpp:79 ../listener.cpp:355
-#: ../main_frame.cpp:1400
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr "Видалення"
 
-#: ../main_frame_helper.cpp:75
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr "Винести файли та каталоги з-під контролю версій"
 
-#: ../main_frame_helper.cpp:74
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr "Видалити вибране"
 
-#: ../listener.cpp:361 ../listener.cpp:370 ../main_frame.cpp:1406
-#: ../main_frame.cpp:1415
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr "Видалено"
 
-#: ../checkout_dlg.cpp:72 ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
 msgstr "Цільовий каталог"
-
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr "Цільовий файл"
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
-msgstr "Цільовий шлях"
 
 #: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr "Порівняти"
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 #, fuzzy
 msgid "Diff Tool"
 msgstr "Програма для порівняння (diff):"
@@ -692,82 +725,97 @@ msgstr "Порівняти з іншою ревізією/датою"
 msgid "Diff two revisions/dates"
 msgstr "Порівняти дві ревізії/дати"
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
 msgstr "Окремий вхід за паролем у кожену закладку вибраного"
+
+#: ../rapidsvn_generated.cpp:1296
+#, fuzzy
+msgid "Directory"
+msgstr "Ім'я каталогу:"
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr "Ім'я каталогу:"
 
-#: ../rapidsvn_generated.cpp:681
+#: ../rapidsvn_generated.cpp:554
 msgid "Disable automatic Log removal"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:685
+#: ../rapidsvn_generated.cpp:557
 msgid "Disable fsync when committing database transactions"
 msgstr ""
 
-#: ../main_frame_helper.cpp:195
+#: ../main_frame_helper.cpp:179
 #, fuzzy
 msgid "Display conflicted files/directories"
 msgstr "Ви згодні розблокувати вибрані файли/каталоги?"
 
-#: ../main_frame_helper.cpp:132
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr "Відобразити інформацію про вибрані елементи"
 
-#: ../main_frame_helper.cpp:189
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:183
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:177
+#: ../main_frame_helper.cpp:161
 #, fuzzy
 msgid "Display unversioned files/directories"
 msgstr "Пропускаю невідстежуваний каталог: %s"
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr "Ви згодні видалити вибрані файли/каталоги?"
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr "Підтверджуєте скасування локальних змін?"
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr "Ви згодні розблокувати вибрані файли/каталоги?"
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr "Вихід\tCTRL-Q"
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr "EOL:"
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr "Редагування"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr "Редагувати закладку"
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr "Редагувати властивість"
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "Edit..."
+msgstr "Редагування..."
+
+#: ../rapidsvn_generated.cpp:1306
+#, fuzzy
+msgid "End &log message"
+msgstr "Введіть повідомлення для журналу"
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 #, fuzzy
 msgid "Enter &log message"
 msgstr "Введіть повідомлення для журналу"
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr "Введіть коментар для блокування"
 
@@ -776,38 +824,19 @@ msgstr "Введіть коментар для блокування"
 msgid "Enter a name for the repository"
 msgstr "Введіть коментар для блокування"
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr "Введіть повідомлення для журналу"
-
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr "Оберіть нове ім'я:"
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr "Введіть шлях, куди слід експортувати файли."
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
 msgstr "Введіть шлях, де Ви бажаєте створити локальну копію."
 
-#: ../checkout_dlg.cpp:70 ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr "Введіть тут URL репозиторію (не локальний шлях)."
 
-#: ../export_dlg.cpp:143
-msgid ""
-"Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
-"files."
-msgstr ""
-"Вкажіть, які символи слід використувувати в якості EOL-маркера в "
-"експортованих файлах. EOL - End Of Line, тобто кінець рядка."
-
-#: ../import_dlg.cpp:178 ../import_dlg.cpp:191 ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494 ../log_dlg.cpp:530 ../main_frame.cpp:1865
-#: ../merge_dlg.cpp:52 ../merge_dlg.cpp:91 ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr "Помилка"
 
@@ -819,11 +848,18 @@ msgstr "Помилка при поверненні статусу:"
 msgid "Error running svnadmin"
 msgstr ""
 
-#: ../property_dlg.cpp:120
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr "Помилка при встановленні значень властивостей"
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, fuzzy, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr "Помилка при встановленні значень властивостей"
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr "Помилка при перевірці сертифіката сервера для '%s':"
@@ -846,26 +882,26 @@ msgstr "Помилка під час підготовки до виконанн�
 msgid "Error while preparing action: %s"
 msgstr "Помилка під час підготовки до виконання операції: %s"
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr "Помилка під час оновлення переліку файлів (%s)"
 
-#: ../main_frame.cpp:907
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr "Помилка під час оновлення переліку файлів"
 
-#: ../main_frame.cpp:894
+#: ../main_frame.cpp:917
 #, c-format
 msgid "Error while updating filelist (%s)"
 msgstr "Помилка під час оновлення переліку файлів (%s)"
 
-#: ../main_frame.cpp:542
+#: ../main_frame.cpp:561
 #, fuzzy, c-format
 msgid "Error: %s\n"
 msgstr "Помилка"
 
-#: ../main_frame.cpp:1799
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
 msgstr "Виявлена виняткова ситуація під час оновлення переліку файлів"
 
@@ -902,11 +938,11 @@ msgstr "Виконання програми порівняння: %s"
 msgid "Execute: %s"
 msgstr "Виконати: %s"
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr "Перегляд...\tF2"
 
-#: ../export_action.cpp:40 ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr "Експорт"
 
@@ -914,52 +950,48 @@ msgstr "Експорт"
 msgid "Extension"
 msgstr "Розширення"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../listener.cpp:405
+#, fuzzy
+msgid "External"
+msgstr "зовнішній"
+
+#: ../rapidsvn_generated.cpp:477
 msgid "FSFS"
 msgstr ""
 
-#: ../listener.cpp:376 ../main_frame.cpp:1421
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr "Спроба блокування не вдалася"
 
-#: ../listener.cpp:377 ../main_frame.cpp:1422
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr "Спроба розблокування не вдалася"
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr "Файл"
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr "Для імпорту файла потрібно вказати його шлях!"
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr "Відбиток ключа:"
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr "Для операції об'єднання потрібен перший шлях або URL!"
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr "Перша робоча копія або URL"
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr "Подальша інформація:"
 
-#: ../destination_dlg.cpp:80 ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr "Примусово"
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr "Примусове видалення"
 
-#: ../export_dlg.cpp:123
+#: ../export_dlg.cpp:75
 msgid ""
 "Force to execute even if destination directory not empty, causes overwriting "
 "of files with the same names."
@@ -967,12 +999,12 @@ msgstr ""
 "Виконати операцію, перезаписуючи поверх існуючі файли у цільовому шляху. "
 "УВАГА! Може призвести до втрати даних!"
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
 msgstr ""
 "Розблокувати примусово, навіть якщо файл було заблоковано іншим користувачем."
 
-#: ../rapidsvn_generated.cpp:41 ../rapidsvn_generated.cpp:649
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr "Загальні"
 
@@ -985,22 +1017,30 @@ msgstr "Читання файлу %s рев. %s"
 msgid "HEAD"
 msgstr "HEAD"
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+msgid "Help"
+msgstr "Допомога"
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr "Історія: %d ревізій"
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr "Назва вузла:"
 
-#: ../checkout_dlg.cpp:88 ../export_dlg.cpp:91
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
 msgid ""
 "If not using the latest version of the files, specify which revision to use "
 "here."
 msgstr "Якщо потрібна не остання версія файлів, введіть тут номер ревізії."
 
-#: ../checkout_dlg.cpp:102 ../export_dlg.cpp:105
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
 msgid ""
 "If the files were renamed or moved some time, specify which peg revision to "
 "use here."
@@ -1013,20 +1053,24 @@ msgstr ""
 msgid "Ignore"
 msgstr "Інформація"
 
-#: ../main_frame.cpp:275 ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr "Ігнорувати зовнішні залежності"
 
-#: ../checkout_dlg.cpp:122 ../export_dlg.cpp:126 ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr "Ігнорувати зовнішні залежності"
 
-#: ../dnd_dlg.cpp:37 ../dnd_dlg.cpp:97 ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr "Імортувати"
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+#, fuzzy
+msgid "Import &Path"
+msgstr "Імортувати"
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr ""
@@ -1036,15 +1080,15 @@ msgstr ""
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr "Властивості...\tCTRL-P"
 
-#: ../main_frame.cpp:270
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr ""
 
-#: ../main_frame.cpp:1984
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr "Інформація"
 
-#: ../main_frame_helper.cpp:131
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr "Інформація про файл"
 
@@ -1052,7 +1096,7 @@ msgstr "Інформація про файл"
 msgid "Internal Error: There is another action running"
 msgstr "Внутрішня помилка: зараз виконується інша операція"
 
-#: ../main_frame.cpp:1542
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr "Внутрішня помилка: відсутні дані клієнта для операції!"
 
@@ -1064,32 +1108,17 @@ msgstr "Внутрішня помилка: не знайдений контек�
 msgid "Invalid revision number detected"
 msgstr "Помічений неправильний номер ревізії"
 
-#: ../log_dlg.cpp:478
+#: ../rapidsvn_generated.cpp:159
 #, fuzzy
-msgid ""
-"Invalid selection. At least one revisions is needed for diff and no more "
-"than two."
-msgstr "Хибний вибір. Для операції порівняння необхідні рівно дві ревізії."
-
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr "Хибний вибір. Для операції об'єднання необхідні рівно дві ревізії."
-
-#: ../log_dlg.cpp:529
-#, fuzzy
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr "Хибний вибір. Для операції об'єднання необхідні рівно дві ревізії."
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
+msgid "Issuer:"
 msgstr "Виданий:"
 
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 #, fuzzy
 msgid "Keep Locks"
 msgstr "Зберігати блокування"
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr "LF (Unix)"
 
@@ -1111,20 +1140,16 @@ msgstr "Дата останньої зміни"
 msgid "Last Changed Rev: %ld"
 msgstr "Ревізія останньої зміни: %ld"
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr ""
 
-#: ../main_frame.cpp:330
-msgid "Listener Test"
-msgstr "Тестування Listener"
-
-#: ../filelist_ctrl.cpp:1058
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr "Відображається зміст '%s'"
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1137,19 +1162,7 @@ msgstr ""
 "System Name: %s\n"
 "Canonical Name: %s\n"
 
-#: ../rapidsvn_app.cpp:198 ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr "Встановити файл допомоги"
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr "Встановити підказки"
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr "Встановити файл підказок"
-
-#: ../lock_action.cpp:40 ../lock_dlg.cpp:100
+#: ../lock_action.cpp:40
 msgid "Lock"
 msgstr "Блокування"
 
@@ -1184,31 +1197,27 @@ msgstr "Власник блокування: %s"
 msgid "Lock Token: %s"
 msgstr "Ключ блокування: %s"
 
-#: ../listener.cpp:374 ../main_frame.cpp:1419
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr "Заблоковано"
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr "Журнал"
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr "Журнал повідомлень"
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr "Повідомлення журналу"
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr "Повідомлення журналу:"
-
-#: ../main_frame_helper.cpp:141
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr "Журнал файлу"
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr "Вхід (login)..."
 
@@ -1233,40 +1242,41 @@ msgstr "Створити каталог...\tF7"
 msgid "Make directory"
 msgstr "Створення каталога"
 
-#: ../merge_action.cpp:38 ../merge_action.cpp:44 ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr "Об'єднати"
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 #, fuzzy
 msgid "Merge Tool"
 msgstr "Об'єднати"
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
-msgstr "Об'єднати ревізії"
-
-#: ../main_frame.cpp:294
+#: ../main_frame.cpp:303
 msgid "Merge..."
 msgstr "Об'єднати..."
+
+#: ../listener.cpp:308
+#, fuzzy
+msgid "Merged"
+msgstr "Об'єднати"
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr "Створення каталога"
 
-#: ../listener.cpp:368 ../main_frame.cpp:1413
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr "Змінено"
 
-#: ../rapidsvn_generated.cpp:692
+#: ../rapidsvn_generated.cpp:563
 msgid "More options"
 msgstr ""
 
-#: ../dnd_dlg.cpp:104 ../move_action.cpp:42
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr "Переміщення"
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, fuzzy, c-format
 msgid "Moving file: %s"
 msgstr "Робочий файл конфлікту: %s"
@@ -1275,8 +1285,16 @@ msgstr "Робочий файл конфлікту: %s"
 msgid "Multiple Files"
 msgstr ""
 
-#: ../columns.cpp:45 ../listed_dlg.cpp:75 ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr "Ім'я"
 
@@ -1285,44 +1303,24 @@ msgstr "Ім'я"
 msgid "Name: %s"
 msgstr "Ім'я: %s"
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
 msgstr "Нова властивість"
-
-#: ../revert_dlg.cpp:57
-msgid "No"
-msgstr ""
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr ""
 
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Файл допомоги не вказано, повторити\n"
-"запитання при наступному старті?"
-
 #: ../userresolve_action.cpp:62
 msgid "No merge tool set in the preferences"
 msgstr ""
-
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"Файл підказок не вказано, повторити\n"
-"запитання при наступному старті?"
 
 #: ../file_info.cpp:118
 #, c-format
 msgid "Node Kind: %s"
 msgstr "Тип: %s"
 
-#: ../checkout_dlg.cpp:106 ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr "Не вказана"
 
@@ -1330,39 +1328,38 @@ msgstr "Не вказана"
 msgid "Not versioned"
 msgstr "невідстежуваний"
 
-#: ../about_dlg.cpp:114 ../annotate_dlg.cpp:42 ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126 ../delete_dlg.cpp:54 ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145 ../import_dlg.cpp:128 ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341 ../lock_dlg.cpp:60 ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191 ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405 ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560 ../rapidsvn_generated.cpp:704
-#: ../report_dlg.cpp:57 ../switch_dlg.cpp:137 ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr "OK"
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr "Відкрити..."
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr "Перезапис"
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr "Пароль"
-
-#: ../columns.cpp:46 ../import_dlg.cpp:80 ../log_dlg.cpp:243
+#: ../columns.cpp:46
 msgid "Path"
 msgstr "Шлях"
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+#, fuzzy
+msgid "Path &type"
 msgstr "Цільовий шлях:"
 
-#: ../checkout_dlg.cpp:97 ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr "Пег-ревізія"
 
@@ -1370,28 +1367,28 @@ msgstr "Пег-ревізія"
 msgid "Preferences"
 msgstr "Налаштування"
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr "Налаштування..."
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 #, fuzzy
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr "Аргументи програми (%1=файл1, %2=файл2):"
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr "Аргументи програми (%1=файл1, %2=файл2):"
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr "Аргументи програми (%1=вибраний каталог):"
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr "Аргументи програми (%1=вибраний файл):"
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr "Програми"
 
@@ -1407,7 +1404,7 @@ msgstr "Статус власт."
 msgid "Properties Last Updated"
 msgstr "Останнє оновлення властивостей"
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr "Властивості:"
 
@@ -1419,22 +1416,21 @@ msgstr "Властивість"
 msgid "Property Editor"
 msgstr "Редактор властивостей"
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr "Спорожнити тимчасові файли при виході з програми"
 
-#: ../main_frame_helper.cpp:65
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr "Занести файли та каталоги під контроль версій"
 
-#: ../main_frame.cpp:509
-msgid "RapidSVN Error"
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
 msgstr ""
 
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
-msgstr "Допомога RapidSVN: %s"
+#: ../main_frame.cpp:528
+msgid "RapidSVN Error"
+msgstr ""
 
 #: ../utils.cpp:192
 msgid "Re&name...\tCTRL-N"
@@ -1448,51 +1444,51 @@ msgstr "Вирішити конфлікти\tCTRL-S"
 msgid "Re&vert\tCTRL-V"
 msgstr "Скасування локальних змін\tCTRL-V"
 
-#: ../filelist_ctrl.cpp:1134
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr "Готово"
 
-#: ../main_frame.cpp:1522 ../main_frame.cpp:1566
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr "Готово\n"
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr "Нещодавні записи:"
 
-#: ../checkout_dlg.cpp:111 ../export_dlg.cpp:114 ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201 ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547 ../revert_dlg.cpp:49 ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr "Рекурсивно"
 
-#: ../main_frame_helper.cpp:206
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr "Оновити"
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr "Оновити зображення\tCTRL-R"
 
-#: ../main_frame_helper.cpp:207
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr "Оновити перелік файлів"
 
-#: ../main_frame.cpp:268
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr "Оновлювати повністю"
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 #, fuzzy
 msgid "Relocate"
 msgstr "Замінено"
 
-#: ../main_frame_helper.cpp:115
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
 msgstr "Зняти позначку 'конфліктує' з файлів чи каталогів робочої копії"
 
-#: ../main_frame.cpp:1918
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr "Закладку видалено"
 
@@ -1504,7 +1500,7 @@ msgstr "Перейменування"
 msgid "Rep. Rev."
 msgstr "Рев. реп."
 
-#: ../listener.cpp:371 ../main_frame.cpp:1416
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr "Замінено"
 
@@ -1512,13 +1508,14 @@ msgstr "Замінено"
 msgid "Repository"
 msgstr "Репозиторій"
 
-#: ../import_dlg.cpp:67 ../main_frame.cpp:1890
+#: ../rapidsvn_generated.cpp:1268
+#, fuzzy
+msgid "Repository &URL for import"
+msgstr "Для імпорту необхідний URL репозиторію!"
+
+#: ../main_frame.cpp:2079
 msgid "Repository URL"
 msgstr "URL репозиторію"
-
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
-msgstr "Для імпорту необхідний URL репозиторію!"
 
 #: ../file_info.cpp:112
 #, c-format
@@ -1530,11 +1527,11 @@ msgstr "UUID репозиторію: %s"
 msgid "Repository: %s"
 msgstr "Репозиторій: %s"
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr "У початковий стан"
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr ""
 
@@ -1542,57 +1539,51 @@ msgstr ""
 msgid "Resolve"
 msgstr "Вирішення конфліктів"
 
-#: ../main_frame_helper.cpp:114
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr "Вирішити конфлікти"
 
-#: ../listener.cpp:359 ../main_frame.cpp:1404
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr "Конфлікт вирішено"
 
-#: ../listener.cpp:356 ../main_frame.cpp:1401
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr "Відновити"
 
-#: ../main_frame_helper.cpp:105
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
 msgstr "Відновити початкову робочу копію файла (скасувати всі локальні зміни)"
 
-#: ../rapidsvn_generated.cpp:632
+#: ../rapidsvn_generated.cpp:506
 msgid "Resulting repository filename:"
 msgstr ""
 
-#: ../listener.cpp:357 ../main_frame.cpp:1402 ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr "Скасування змін"
 
-#: ../main_frame_helper.cpp:104
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr "Скасування змін"
 
-#: ../annotate_dlg.cpp:47 ../checkout_dlg.cpp:83 ../columns.cpp:47
-#: ../export_dlg.cpp:86 ../log_dlg.cpp:163 ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150 ../rapidsvn_generated.cpp:529 ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr "Ревізія"
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr "Номер ревізії являє собою невід'ємне число!"
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 #, fuzzy
 msgid "Revision or date #1:"
 msgstr "Ревізія або дата #&1:"
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 #, fuzzy
 msgid "Revision or date #2:"
 msgstr "Ревізія або дата #&2:"
 
-#: ../rapidsvn_generated.cpp:250 ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr "Ревізія:"
 
@@ -1606,10 +1597,6 @@ msgstr "Ревізія: %ld"
 msgid "Running command %s:"
 msgstr ""
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr "Сертифікат SSL"
-
 #: ../columns.cpp:62
 msgid "Schedule"
 msgstr "Заплановано"
@@ -1619,36 +1606,28 @@ msgstr "Заплановано"
 msgid "Schedule: %s"
 msgstr "Заплановано: %s"
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr "Для операції об'єднання потрібен другий шлях або URL!"
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr "Друга робоча копія або URL"
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr "Оберіть файл сертифіката"
 
-#: ../checkout_dlg.cpp:273 ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr "Оберіть цільовий каталог"
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr "Вкажіть цільовий каталог для об'єднання"
 
 #: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
-#: ../main_frame.cpp:1845
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr "Вкажіть каталог"
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr "Оберіть каталог для імпорту."
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr "Оберіть файл для імпорту"
 
@@ -1678,32 +1657,32 @@ msgstr "Оберіть стандартний редактор (виконува
 msgid "Select standard file explorer executable"
 msgstr "Оберіть програму перегляду (файл для виконання)"
 
-#: ../main_frame_helper.cpp:95
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr "Відіслати зміни у локальнії копії до репозиторію."
 
-#: ../checkout_dlg.cpp:94 ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
 msgstr "Виберіть цей пункт, аби отримати останню версію файлів з репозиторію."
 
-#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
 msgstr ""
 "Виберіть цей пункт, аби використовувати останню (BASE/HEAD) пег-ревізію "
 "файлів."
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
 msgstr ""
 "Встановіть цей прапорець для автоматичного створення лінка на нову робочу "
 "копію."
 
-#: ../checkout_dlg.cpp:114 ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
 msgstr ""
 "Виберіть цей пункт, щоб отримати також рекурсивно всі підкаталоги цього URL."
 
-#: ../checkout_dlg.cpp:125 ../export_dlg.cpp:129
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
 msgid ""
 "Set to ignore external definitions and the external working copies managed "
 "by them."
@@ -1711,66 +1690,66 @@ msgstr ""
 "Встановіть для ігнорування зовнішніх означень та ними керованих зовнішніх "
 "робочих копій."
 
-#: ../main_frame.cpp:320
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr "Показувати корисні підказки на старті"
 
-#: ../main_frame.cpp:274 ../main_frame_helper.cpp:194
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 #, fuzzy
 msgid "Show conflicted entries"
 msgstr "Показувати невідстежувані файли"
 
-#: ../main_frame_helper.cpp:171
+#: ../main_frame_helper.cpp:155
 #, fuzzy
 msgid "Show entries in subdirectories"
 msgstr "Показувати невідстежувані файли"
 
-#: ../main_frame.cpp:276
+#: ../main_frame.cpp:285
 #, fuzzy
 msgid "Show ignored entries"
 msgstr "Показувати невідстежувані файли"
 
-#: ../main_frame.cpp:273 ../main_frame_helper.cpp:188
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 #, fuzzy
 msgid "Show modified entries"
 msgstr "Показувати невідстежувані файли"
 
-#: ../main_frame.cpp:269 ../main_frame_helper.cpp:170
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 #, fuzzy
 msgid "Show subdirectories"
 msgstr "Показувати невідстежувані файли"
 
-#: ../main_frame_helper.cpp:142
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr "Показати повідомлення журналу для вибраних файлів"
 
-#: ../main_frame.cpp:272 ../main_frame_helper.cpp:182
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 #, fuzzy
 msgid "Show unmodified entries"
 msgstr "Показувати невідстежувані файли"
 
-#: ../main_frame.cpp:271 ../main_frame_helper.cpp:176
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr "Показувати невідстежувані файли"
 
-#: ../listener.cpp:360 ../main_frame.cpp:1405
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr "Пропуск"
 
-#: ../main_frame.cpp:266
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr "Сортування"
 
-#: ../main_frame.cpp:242
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr "за зростанням"
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 #, fuzzy
 msgid "Standard Editor"
 msgstr "Стандартний редактор:"
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 #, fuzzy
 msgid "Standard Explorer"
 msgstr "Стандартна програма перегляду:"
@@ -1779,39 +1758,39 @@ msgstr "Стандартна програма перегляду:"
 msgid "Status"
 msgstr "Статус"
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr "Перехопити блокування, якщо воно належить іншому користувачеві"
 
-#: ../main_frame_helper.cpp:219
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr "Зупинити"
 
-#: ../main_frame_helper.cpp:220
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr "Зупинити поточну операцію"
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr "Зберігати аутентифікаційне посвідчення на диску"
 
-#: ../switch_action.cpp:50 ../switch_dlg.cpp:192
+#: ../switch_action.cpp:50
 msgid "Switch URL"
 msgstr "Перемикання URL"
 
-#: ../main_frame.cpp:295
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr "Перемкнути URL...\tCTRL-S"
 
-#: ../main_frame.cpp:1352
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr "Тривалість тесту"
 
-#: ../main_frame.cpp:1348
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr "Тест закінчено о"
 
-#: ../main_frame.cpp:1345
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr "Тест розпочато о"
 
@@ -1833,7 +1812,7 @@ msgstr ""
 msgid "The svnadmin command was not successful."
 msgstr ""
 
-#: ../cert_dlg.cpp:70
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
@@ -1841,14 +1820,14 @@ msgstr ""
 "Знайдено помилки під час перевірки сертифіката.\n"
 "Прийняти цей сертифікат?"
 
-#: ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:418
 #, fuzzy
 msgid "This action has resulted in a commit - please enter a &log message"
 msgstr ""
 "Ця операція призвела до фіксації змін (Commit). Введіть повідомлення для "
 "журналу."
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1856,12 +1835,9 @@ msgid ""
 "Available online under:"
 msgstr ""
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr "Дерево"
-
-#: ../checkout_dlg.cpp:65 ../columns.cpp:59 ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521 ../switch_dlg.cpp:77 ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr "URL"
 
@@ -1874,11 +1850,11 @@ msgstr "URL: %s"
 msgid "UUID"
 msgstr "UUID"
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../main_frame.cpp:1494
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr "Непідтримувана операція!"
 
@@ -1887,11 +1863,11 @@ msgstr "Непідтримувана операція!"
 msgid "Unknown destination path"
 msgstr "Цільовий шлях"
 
-#: ../unlock_action.cpp:39 ../unlock_dlg.cpp:80
+#: ../unlock_action.cpp:39
 msgid "Unlock"
 msgstr "Розблокування"
 
-#: ../listener.cpp:375 ../main_frame.cpp:1420
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr "Розблоковано"
 
@@ -1899,50 +1875,50 @@ msgstr "Розблоковано"
 msgid "Update"
 msgstr "Оновлення"
 
-#: ../main_frame_helper.cpp:84
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr "Оновити вибране повністю"
 
-#: ../listener.cpp:363 ../main_frame.cpp:1408
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr "Оновлено"
 
-#: ../main_frame.cpp:1556 ../main_frame.cpp:1561
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr "Оновлення..."
 
-#: ../main_frame.cpp:241
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr "Використовувати шлях"
 
-#: ../rapidsvn_generated.cpp:271 ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 #, fuzzy
 msgid "Use URL/path:"
 msgstr "Використовувати URL/шлях:"
 
-#: ../rapidsvn_generated.cpp:70 ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr "Використовувати завжди"
 
-#: ../checkout_dlg.cpp:92 ../export_dlg.cpp:95 ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299 ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103 ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr "Використовувати останню версію"
 
-#: ../auth_dlg.cpp:54 ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr "Користувач"
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr "Дійсний з:"
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr "Дійсний до:"
 
-#: ../listed_dlg.cpp:80 ../listed_dlg.cpp:172 ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr "Значення"
 
@@ -1950,11 +1926,29 @@ msgstr "Значення"
 msgid "View"
 msgstr "Перегляд"
 
-#: ../rapidsvn_generated.cpp:696
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "View..."
+msgstr "Перегляд..."
+
+#: ../rapidsvn_generated.cpp:567
 msgid "WARNING"
 msgstr ""
 
-#: ../dnd_dlg.cpp:69
+#: ../dnd_dlg.cpp:48
+#, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr ""
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -1967,31 +1961,27 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr ""
-
-#: ../main_frame.cpp:1863
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
 msgstr "Не можна додати до закладок адміністративний каталог subversion!"
 
-#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1261
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr "додати"
 
-#: ../filelist_ctrl.cpp:1226 ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr "доданий"
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr "конфліктує"
 
-#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1264
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr "видалити"
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr "видалений"
 
@@ -1999,7 +1989,7 @@ msgstr "видалений"
 msgid "directory"
 msgstr "каталог"
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr "зовнішній"
 
@@ -2007,66 +1997,70 @@ msgstr "зовнішній"
 msgid "file"
 msgstr "файл"
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr ""
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr "пошкоджений"
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr "об'єднаний"
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr "відсутній"
 
-#: ../filelist_ctrl.cpp:1229 ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr "змінений"
 
-#: ../export_dlg.cpp:135 ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr "власний формат для ОС"
 
-#: ../file_info.cpp:132 ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr "немає"
 
-#: ../file_info.cpp:146 ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr "нормальний"
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr "затуляє інший файл"
 
-#: ../filelist_ctrl.cpp:1294 ../filelist_ctrl.cpp:1308
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr "застарів"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 #, fuzzy
 msgid "pre Subversion 1.4"
 msgstr "Subversion %d.%d.%d"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 #, fuzzy
 msgid "pre Subversion 1.5"
 msgstr "Subversion %d.%d.%d"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 #, fuzzy
 msgid "pre Subversion 1.6"
 msgstr "Subversion %d.%d.%d"
 
-#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1267
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr "замінити"
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr "заміщений"
 
@@ -2078,17 +2072,122 @@ msgstr ""
 msgid "unknown"
 msgstr "невідомо"
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr "невідоме значення"
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
 msgstr "невідстежуваний"
 
-#: ../main_frame.cpp:329
-msgid "wxString Creation&Tracing Test"
-msgstr "Тест зі створення та журналювання wxString"
+#, fuzzy
+#~ msgid "Action"
+#~ msgstr "Аутентифікація"
+
+#~ msgid "Checkout Test"
+#~ msgstr "Тест Checkout"
+
+#, fuzzy
+#~ msgid "Copied from Path"
+#~ msgstr "Скопійовано з URL: %s"
+
+#, fuzzy
+#~ msgid "Copied from Rev"
+#~ msgstr "Скопійовано з ревізії: %ld"
+
+#~ msgid "Destination file"
+#~ msgstr "Цільовий файл"
+
+#~ msgid "Destination path"
+#~ msgstr "Цільовий шлях"
+
+#~ msgid "EOL:"
+#~ msgstr "EOL:"
+
+#~ msgid "Enter log message"
+#~ msgstr "Введіть повідомлення для журналу"
+
+#~ msgid "Enter the local path where you want the code be exported."
+#~ msgstr "Введіть шлях, куди слід експортувати файли."
+
+#~ msgid ""
+#~ "Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
+#~ "files."
+#~ msgstr ""
+#~ "Вкажіть, які символи слід використувувати в якості EOL-маркера в "
+#~ "експортованих файлах. EOL - End Of Line, тобто кінець рядка."
+
+#~ msgid "File path required when importing a file!"
+#~ msgstr "Для імпорту файла потрібно вказати його шлях!"
+
+#~ msgid "First path or URL is required for merge!"
+#~ msgstr "Для операції об'єднання потрібен перший шлях або URL!"
+
+#, fuzzy
+#~ msgid ""
+#~ "Invalid selection. At least one revisions is needed for diff and no more "
+#~ "than two."
+#~ msgstr "Хибний вибір. Для операції порівняння необхідні рівно дві ревізії."
+
+#~ msgid "Invalid selection. Exactly two revisions needed for merge."
+#~ msgstr "Хибний вибір. Для операції об'єднання необхідні рівно дві ревізії."
+
+#, fuzzy
+#~ msgid "Invalid selection. Only one revision may be selected for annotate"
+#~ msgstr "Хибний вибір. Для операції об'єднання необхідні рівно дві ревізії."
+
+#~ msgid "Listener Test"
+#~ msgstr "Тестування Listener"
+
+#~ msgid "Locate help"
+#~ msgstr "Встановити файл допомоги"
+
+#~ msgid "Locate tips"
+#~ msgstr "Встановити підказки"
+
+#~ msgid "Locate tips file"
+#~ msgstr "Встановити файл підказок"
+
+#~ msgid "Log Message:"
+#~ msgstr "Повідомлення журналу:"
+
+#~ msgid "Merge revisions"
+#~ msgstr "Об'єднати ревізії"
+
+#~ msgid ""
+#~ "No help file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Файл допомоги не вказано, повторити\n"
+#~ "запитання при наступному старті?"
+
+#~ msgid ""
+#~ "No tips file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "Файл підказок не вказано, повторити\n"
+#~ "запитання при наступному старті?"
+
+#~ msgid "RapidSVN Help: %s"
+#~ msgstr "Допомога RapidSVN: %s"
+
+#~ msgid "Revision must be an unsigned number!"
+#~ msgstr "Номер ревізії являє собою невід'ємне число!"
+
+#~ msgid "SSL Certificate"
+#~ msgstr "Сертифікат SSL"
+
+#~ msgid "Second path or URL is required for merge!"
+#~ msgstr "Для операції об'єднання потрібен другий шлях або URL!"
+
+#~ msgid "Second working copy or URL"
+#~ msgstr "Друга робоча копія або URL"
+
+#~ msgid "Tree"
+#~ msgstr "Дерево"
+
+#~ msgid "wxString Creation&Tracing Test"
+#~ msgstr "Тест зі створення та журналювання wxString"
 
 #~ msgid "Information"
 #~ msgstr "Інформація"
@@ -2141,9 +2240,6 @@ msgstr "Тест зі створення та журналювання wxString"
 #~ msgid "&Prop Status"
 #~ msgstr "Статус власт."
 
-#~ msgid "&Revision"
-#~ msgstr "Ревізія"
-
 #~ msgid "&Status"
 #~ msgstr "Статус"
 
@@ -2194,6 +2290,3 @@ msgstr "Тест зі створення та журналювання wxString"
 
 #~ msgid "Language:"
 #~ msgstr "Мова:"
-
-#~ msgid "Help"
-#~ msgstr "Допомога"

--- a/librapidsvn/src/locale/zh_CN/rapidsvn.po
+++ b/librapidsvn/src/locale/zh_CN/rapidsvn.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RapidSVN 0.9.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-11-02 17:09+0100\n"
+"POT-Creation-Date: 2017-01-26 15:12+0000\n"
 "PO-Revision-Date: 2011-11-07 09:56+0800\n"
 "Last-Translator: highbing <caohaibing@gmail.com>\n"
 "Language-Team: RapidSVN i18n\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -24,22 +25,22 @@ msgstr ""
 msgid "%s  code: %ld"
 msgstr "%s  代码:%ld"
 
-#: ../about_dlg.cpp:50
+#: ../about_dlg.cpp:47
 #, fuzzy, c-format
 msgid "%s Version %s"
 msgstr "%s 版本 %d.%d.%d"
 
-#: ../about_dlg.cpp:55
+#: ../about_dlg.cpp:52
 #, fuzzy, c-format
 msgid "%s Version %s Revision %d"
 msgstr "%s 版本 %d.%d.%d"
 
-#: ../utils.cpp:360
+#: ../utils.cpp:370
 #, c-format
 msgid "%x %X"
 msgstr ""
 
-#: ../main_frame.cpp:323
+#: ../main_frame.cpp:332
 msgid "&About..."
 msgstr "关于(&A)..."
 
@@ -47,36 +48,32 @@ msgstr "关于(&A)..."
 msgid "&Add\tINS"
 msgstr "添加(&D)\tINS"
 
-#: ../utils.cpp:249
+#: ../utils.cpp:258
 msgid "&Add Existing Working Copy..."
 msgstr "添加已存在的工作副本(&A)..."
 
-#: ../log_dlg.cpp:364
+#: ../rapidsvn_generated.cpp:1188
 msgid "&Annotate"
 msgstr "评注(&A)"
 
-#: ../utils.cpp:213
+#: ../utils.cpp:213 ../utils.cpp:223
 msgid "&Annotate..."
 msgstr "评注(&A)..."
 
-#: ../main_frame.cpp:344
+#: ../main_frame.cpp:363
 msgid "&Bookmarks"
 msgstr "书签(&B)"
 
-#: ../rapidsvn_generated.cpp:676
+#: ../rapidsvn_generated.cpp:549
 #, fuzzy
 msgid "&Browse"
 msgstr "关闭(&C)"
 
-#: ../log_dlg.cpp:359
-msgid "&Close"
-msgstr "关闭(&C)"
-
-#: ../rapidsvn_generated.cpp:655
+#: ../rapidsvn_generated.cpp:528
 msgid "&Compatible with:"
 msgstr ""
 
-#: ../main_frame.cpp:316
+#: ../main_frame.cpp:325
 msgid "&Contents\tF1"
 msgstr "目录(&C)\tF1"
 
@@ -84,7 +81,7 @@ msgstr "目录(&C)\tF1"
 msgid "&Copy...\tF5"
 msgstr "复制(&C)...\tF5"
 
-#: ../main_frame.cpp:290
+#: ../main_frame.cpp:299
 msgid "&Create..."
 msgstr "创建(&C)..."
 
@@ -92,12 +89,11 @@ msgstr "创建(&C)..."
 msgid "&Delete\tDEL"
 msgstr "删除(&D)\tDEL"
 
-#: ../listed_dlg.cpp:60
+#: ../rapidsvn_generated.cpp:1074
 msgid "&Delete..."
 msgstr "删除(&D)..."
 
-#: ../log_dlg.cpp:362
-#: ../rapidsvn_generated.cpp:463
+#: ../rapidsvn_generated.cpp:364 ../rapidsvn_generated.cpp:1182
 msgid "&Diff"
 msgstr "比较(&D)"
 
@@ -109,45 +105,49 @@ msgstr "与基准版本(BASE)比较(&D)...\tCTRL+B"
 msgid "&Diff to Head...\tCTRL+H"
 msgstr "与最新版本(HEAD)比较(&D)...\tCTRL+H"
 
+#: ../utils.cpp:220
+#, fuzzy
+msgid "&Diff..."
+msgstr "比较(&D)"
+
 #: ../utils.cpp:205
 msgid "&Diff...\tCTRL+D"
 msgstr "比较(&D)...\tCTRL+D"
 
-#: ../utils.cpp:267
+#: ../utils.cpp:276
 msgid "&Edit Bookmark..."
 msgstr "编辑书签(&E)..."
 
-#: ../listed_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1071
 msgid "&Edit..."
 msgstr "编辑(&E)..."
 
-#: ../utils.cpp:245
+#: ../utils.cpp:254
 msgid "&Edit...\tF3"
 msgstr "编辑(&E)...\tF3"
 
-#: ../main_frame.cpp:288
+#: ../main_frame.cpp:297
 msgid "&Export...\tCTRL-E"
 msgstr "导出(&E)...\tCTRL-E"
 
-#: ../main_frame.cpp:345
+#: ../main_frame.cpp:364
 msgid "&Extras"
 msgstr "扩展功能(&E)"
 
-#: ../main_frame.cpp:339
+#: ../main_frame.cpp:358
 msgid "&File"
 msgstr "文件(&F)"
 
-#: ../rapidsvn_generated.cpp:451
+#: ../rapidsvn_generated.cpp:352
 #, fuzzy
 msgid "&Files to commit"
 msgstr "锁定失败"
 
-#: ../log_dlg.cpp:361
+#: ../rapidsvn_generated.cpp:1179
 msgid "&Get"
 msgstr "获取(&G)"
 
-#: ../main_frame.cpp:223
-#: ../main_frame.cpp:346
+#: ../main_frame.cpp:232 ../main_frame.cpp:365
 msgid "&Help"
 msgstr "帮助(&H)"
 
@@ -155,11 +155,11 @@ msgstr "帮助(&H)"
 msgid "&Ignore\tCTRL-DEL"
 msgstr "忽略(&I)...\tCTRL-DEL"
 
-#: ../main_frame.cpp:287
+#: ../main_frame.cpp:296
 msgid "&Import...\tCTRL-I"
 msgstr "导入(&I)...\tCTRL-I"
 
-#: ../main_frame.cpp:317
+#: ../main_frame.cpp:326
 msgid "&Index\tShift+F1"
 msgstr "索引(&I)\tShift+F1"
 
@@ -167,7 +167,7 @@ msgstr "索引(&I)\tShift+F1"
 msgid "&Info..."
 msgstr "信息(&I)..."
 
-#: ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:540
 msgid "&Load configuration from directory (optional):"
 msgstr ""
 
@@ -175,28 +175,43 @@ msgstr ""
 msgid "&Lock..."
 msgstr "锁定(&L)..."
 
+#: ../utils.cpp:222
+#, fuzzy
+msgid "&Log..."
+msgstr "历史记录(&L)...\tCTRL-L"
+
 #: ../utils.cpp:209
 msgid "&Log...\tCTRL-L"
 msgstr "历史记录(&L)...\tCTRL-L"
 
-#: ../log_dlg.cpp:363
+#: ../rapidsvn_generated.cpp:1185
 msgid "&Merge"
 msgstr "合并(&M)"
 
-#: ../main_frame.cpp:342
+#: ../main_frame.cpp:361
 msgid "&Modify"
 msgstr "修改(&M)"
 
-#: ../rapidsvn_generated.cpp:625
+#: ../rapidsvn_generated.cpp:897
+#, fuzzy
+msgid "&Name"
+msgstr "文件名"
+
+#: ../rapidsvn_generated.cpp:499
 #, fuzzy
 msgid "&Name of the new repository:"
 msgstr "新建文档库..."
 
-#: ../listed_dlg.cpp:59
+#: ../rapidsvn_generated.cpp:1068
 msgid "&New..."
 msgstr "新建(&N)..."
 
-#: ../cert_dlg.cpp:134
+#: ../rapidsvn_generated.cpp:96
+#, fuzzy
+msgid "&Password"
+msgstr "密码"
+
+#: ../rapidsvn_generated.cpp:198
 msgid "&Permanently"
 msgstr "永久的(&P)"
 
@@ -204,44 +219,49 @@ msgstr "永久的(&P)"
 msgid "&Properties...\tCTRL-P"
 msgstr "属性(&P)...\tCTRL-P"
 
-#: ../main_frame.cpp:343
+#: ../main_frame.cpp:362
 msgid "&Query"
 msgstr "查询(&Q)"
 
-#: ../rapidsvn_generated.cpp:442
+#: ../rapidsvn_generated.cpp:343
 #, fuzzy
 msgid "&Recent entries:"
 msgstr "最近条目:"
 
-#: ../utils.cpp:262
+#: ../utils.cpp:271
 msgid "&Remove Bookmark"
 msgstr "移除书签(&R)..."
 
-#: ../main_frame.cpp:341
+#: ../main_frame.cpp:360
 msgid "&Repository"
 msgstr "文档库(&R)"
 
-#: ../utils.cpp:314
+#: ../rapidsvn_generated.cpp:1437 ../rapidsvn_generated.cpp:1463
+#, fuzzy
+msgid "&Revision"
+msgstr "版本"
+
+#: ../utils.cpp:323
 msgid "&Stop"
 msgstr "停止(&S)"
 
-#: ../utils.cpp:258
+#: ../utils.cpp:267
 msgid "&Switch Repository URL..."
 msgstr "修改文档库 URL(&S)..."
 
-#: ../cert_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:201
 msgid "&Temporarily"
 msgstr "临时的(&T)"
 
-#: ../main_frame.cpp:348
+#: ../main_frame.cpp:367
 msgid "&Tests"
 msgstr "测试(&T)"
 
-#: ../rapidsvn_generated.cpp:460
+#: ../rapidsvn_generated.cpp:361
 msgid "&Toggle"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:599
+#: ../rapidsvn_generated.cpp:473
 msgid "&Type:"
 msgstr ""
 
@@ -249,32 +269,41 @@ msgstr ""
 msgid "&Unlock"
 msgstr "解除锁定(&U)"
 
-#: ../utils.cpp:283
+#: ../utils.cpp:292
 msgid "&Update...\tCTRL-U"
 msgstr "更新(&U)...\tCTRL-U"
 
-#: ../log_dlg.cpp:360
-#: ../main_frame.cpp:340
+#: ../rapidsvn_generated.cpp:89
+#, fuzzy
+msgid "&Username"
+msgstr "重命名"
+
+#: ../rapidsvn_generated.cpp:904
+#, fuzzy
+msgid "&Value"
+msgstr "值"
+
+#: ../main_frame.cpp:359 ../rapidsvn_generated.cpp:1176
 msgid "&View"
 msgstr "查看(&V)"
 
-#: ../listed_dlg.cpp:58
+#: ../utils.cpp:221
 msgid "&View..."
 msgstr "查看(&V)..."
 
-#: ../cert_dlg.cpp:80
+#: ../cert_dlg.cpp:51
 msgid "- The certificate has an unknown error."
 msgstr "- 此证书包含一个未知错误."
 
-#: ../cert_dlg.cpp:79
+#: ../cert_dlg.cpp:50
 msgid "- The certificate has expired."
 msgstr "- 此证书已过期."
 
-#: ../cert_dlg.cpp:77
+#: ../cert_dlg.cpp:48
 msgid "- The certificate hostname does not match."
 msgstr "- 此证书的主机名不匹配."
 
-#: ../cert_dlg.cpp:76
+#: ../cert_dlg.cpp:47
 msgid ""
 "- The certificate is not issued by a trusted authority.\n"
 "  Use the fingerprint to validate the certificate manually!"
@@ -282,13 +311,17 @@ msgstr ""
 "- 此证书不是由可信赖的机构颁发的.\n"
 "  请使用指纹(Fingerprint)手工验证此证书的有效性!"
 
-#: ../cert_dlg.cpp:78
+#: ../cert_dlg.cpp:49
 msgid "- The certificate is not yet valid."
 msgstr "- 此证书尚未生效."
 
-#: ../file_info.cpp:102
-#: ../file_info.cpp:110
-#: ../file_info.cpp:195
+#: ../rapidsvn_generated.cpp:246 ../rapidsvn_generated.cpp:958
+#: ../rapidsvn_generated.cpp:1284 ../rapidsvn_generated.cpp:1483
+#, fuzzy
+msgid "..."
+msgstr "新建(&N)..."
+
+#: ../file_info.cpp:102 ../file_info.cpp:110 ../file_info.cpp:195
 msgid "<None>"
 msgstr "<无>"
 
@@ -300,31 +333,25 @@ msgstr ""
 msgid "A file of this name exists already"
 msgstr ""
 
-#: ../about_dlg.cpp:68
+#: ../about_dlg.cpp:65
 msgid "ANSI"
 msgstr "ANSI"
 
-#: ../about_dlg.cpp:42
+#: ../about_dlg.cpp:39
 #, c-format
 msgid "About %s"
 msgstr "关于 %s"
 
-#: ../log_dlg.cpp:242
-msgid "Action"
-msgstr "动作"
-
-#: ../add_action.cpp:37
-#: ../add_recursive_action.cpp:37
-#: ../listener.cpp:353
-#: ../main_frame.cpp:1398
+#: ../add_action.cpp:37 ../add_recursive_action.cpp:37 ../listed_dlg.cpp:183
+#: ../listener.cpp:393 ../main_frame.cpp:1420
 msgid "Add"
 msgstr "添加"
 
-#: ../utils.cpp:254
+#: ../utils.cpp:263
 msgid "Add Existing &Repository..."
 msgstr "添加已存在的文档库(&R)..."
 
-#: ../rapidsvn_generated.cpp:642
+#: ../rapidsvn_generated.cpp:516
 msgid "Add a bookmark for the new repository"
 msgstr ""
 
@@ -332,42 +359,40 @@ msgstr ""
 msgid "Add r&ecursive"
 msgstr "递归添加(&e)..."
 
-#: ../main_frame_helper.cpp:64
+#: ../main_frame_helper.cpp:62
 msgid "Add selected"
 msgstr "添加选定项目"
 
-#: ../checkout_dlg.cpp:116
+#: ../rapidsvn_generated.cpp:276
 msgid "Add to bookmarks"
 msgstr "添加到书签"
 
-#: ../listener.cpp:362
-#: ../listener.cpp:369
-#: ../main_frame.cpp:1407
-#: ../main_frame.cpp:1414
+#: ../listener.cpp:309 ../listener.cpp:402 ../listener.cpp:409
+#: ../main_frame.cpp:1429 ../main_frame.cpp:1436
 msgid "Added"
 msgstr "已添加"
 
-#: ../main_frame.cpp:1904
+#: ../main_frame.cpp:2093
 #, c-format
 msgid "Added repository to bookmarks '%s'"
 msgstr "已添加文档库到书签 '%s'"
 
-#: ../main_frame.cpp:1875
+#: ../main_frame.cpp:2063
 #, c-format
 msgid "Added working copy to bookmarks '%s'"
 msgstr "已添加工作副本到书签 '%s'"
 
-#: ../drag_n_drop_action.cpp:319
+#: ../drag_n_drop_action.cpp:327
 #, c-format
 msgid "Adding directory to repository: %s"
 msgstr ""
 
-#: ../drag_n_drop_action.cpp:332
+#: ../drag_n_drop_action.cpp:340
 #, fuzzy, c-format
 msgid "Adding file to repository: %s"
 msgstr "文档库: %s"
 
-#: ../log_dlg.cpp:357
+#: ../rapidsvn_generated.cpp:1222
 msgid "Affected Files/Dirs"
 msgstr "受影响的文件/目录"
 
@@ -375,21 +400,19 @@ msgstr "受影响的文件/目录"
 msgid "All files|*"
 msgstr "所有文件|*"
 
-#: ../main_frame.cpp:1271
-#: ../main_frame.cpp:1290
+#: ../main_frame.cpp:1294 ../main_frame.cpp:1313
 msgid "An error occured while launching the browser"
 msgstr ""
 
-#: ../main_frame.cpp:1258
+#: ../main_frame.cpp:1281
 msgid "An error occurred while checking valid actions"
 msgstr ""
 
-#: ../annotate_action.cpp:80
-#: ../annotate_action.cpp:81
+#: ../annotate_action.cpp:80 ../annotate_action.cpp:81
 msgid "Annotate"
 msgstr "评注"
 
-#: ../dnd_dlg.cpp:56
+#: ../dnd_dlg.cpp:31
 #, c-format
 msgid ""
 "Are you sure that you want to import\n"
@@ -401,13 +424,11 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../auth_dlg.cpp:117
-#: ../rapidsvn_generated.cpp:184
+#: ../rapidsvn_generated.cpp:1697
 msgid "Authentication"
 msgstr "身份验证"
 
-#: ../annotate_dlg.cpp:48
-#: ../columns.cpp:49
+#: ../annotate_dlg.cpp:35 ../columns.cpp:49
 msgid "Author"
 msgstr "作者"
 
@@ -415,11 +436,11 @@ msgstr "作者"
 msgid "BASE"
 msgstr "基准(BASE)"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../rapidsvn_generated.cpp:477
 msgid "BerkeleyDB"
 msgstr ""
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Bookmark"
 msgstr "书签"
 
@@ -427,19 +448,17 @@ msgstr "书签"
 msgid "Bookmarks"
 msgstr "书签"
 
-#: ../main_frame_helper.cpp:85
+#: ../main_frame_helper.cpp:79
 msgid "Bring changes from the repository into the working copy"
 msgstr "将文档库的修改带入工作副本"
 
-#: ../rapidsvn_generated.cpp:57
-#: ../rapidsvn_generated.cpp:88
-#: ../rapidsvn_generated.cpp:119
-#: ../rapidsvn_generated.cpp:146
-#: ../rapidsvn_generated.cpp:620
+#: ../rapidsvn_generated.cpp:494 ../rapidsvn_generated.cpp:1574
+#: ../rapidsvn_generated.cpp:1604 ../rapidsvn_generated.cpp:1634
+#: ../rapidsvn_generated.cpp:1661
 msgid "Browse"
 msgstr ""
 
-#: ../about_dlg.cpp:83
+#: ../about_dlg.cpp:80
 #, c-format
 msgid ""
 "Built with:\n"
@@ -450,58 +469,44 @@ msgstr ""
 "wxWidgets %d.%d.%d (%s)\n"
 "Subversion %d.%d.%d\n"
 
-#: ../export_dlg.cpp:138
+#: ../rapidsvn_generated.cpp:992
 msgid "CR (MacOS)"
 msgstr "CR (MacOS)"
 
-#: ../export_dlg.cpp:136
+#: ../rapidsvn_generated.cpp:992
 msgid "CRLF (Windows)"
 msgstr "CRLF (Windows)"
 
-#: ../auth_dlg.cpp:73
-#: ../cert_dlg.cpp:138
-#: ../checkout_dlg.cpp:127
-#: ../delete_dlg.cpp:57
-#: ../destination_dlg.cpp:90
-#: ../dnd_dlg.cpp:112
-#: ../export_dlg.cpp:146
-#: ../import_dlg.cpp:130
-#: ../listed_dlg.cpp:186
-#: ../listed_dlg.cpp:342
-#: ../lock_dlg.cpp:61
-#: ../merge_dlg.cpp:215
-#: ../rapidsvn_generated.cpp:195
-#: ../rapidsvn_generated.cpp:329
-#: ../rapidsvn_generated.cpp:409
-#: ../rapidsvn_generated.cpp:485
-#: ../rapidsvn_generated.cpp:564
-#: ../rapidsvn_generated.cpp:708
-#: ../switch_dlg.cpp:139
-#: ../unlock_dlg.cpp:58
-#: ../update_dlg.cpp:135
+#: ../rapidsvn_generated.cpp:111 ../rapidsvn_generated.cpp:204
+#: ../rapidsvn_generated.cpp:293 ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:443 ../rapidsvn_generated.cpp:579
+#: ../rapidsvn_generated.cpp:630 ../rapidsvn_generated.cpp:667
+#: ../rapidsvn_generated.cpp:789 ../rapidsvn_generated.cpp:860
+#: ../rapidsvn_generated.cpp:919 ../rapidsvn_generated.cpp:1020
+#: ../rapidsvn_generated.cpp:1083 ../rapidsvn_generated.cpp:1129
+#: ../rapidsvn_generated.cpp:1322 ../rapidsvn_generated.cpp:1506
+#: ../rapidsvn_generated.cpp:1708 ../rapidsvn_generated.cpp:1781
+#: ../rapidsvn_generated.cpp:1837 ../rapidsvn_generated.cpp:1880
+#: ../rapidsvn_generated.cpp:1935
 msgid "Cancel"
 msgstr "取消"
 
-#: ../cert_dlg.cpp:128
-msgid "Certificate Information:"
+#: ../rapidsvn_generated.cpp:144
+#, fuzzy
+msgid "Certificate information:"
 msgstr "证书信息:"
 
-#: ../main_frame.cpp:289
+#: ../main_frame.cpp:298
 msgid "Check&out...\tCTRL-O"
 msgstr "签出(&o)...\tCTRL-O"
 
 #: ../checkout_action.cpp:40
-#: ../checkout_dlg.cpp:250
 msgid "Checkout"
 msgstr "签出"
 
-#: ../utils.cpp:275
+#: ../utils.cpp:284
 msgid "Checkout New Working Copy..."
 msgstr "签出新的工作副本..."
-
-#: ../main_frame.cpp:331
-msgid "Checkout Test"
-msgstr "签出测试"
 
 #: ../columns.cpp:58
 msgid "Checksum"
@@ -512,26 +517,28 @@ msgstr "校验和"
 msgid "Checksum: %s"
 msgstr "校验和: %s"
 
-#: ../cleanup_action.cpp:39
-#: ../utils.cpp:306
+#: ../cleanup_action.cpp:39 ../utils.cpp:315
 msgid "Cleanup"
 msgstr "清理"
 
-#: ../utils.cpp:288
+#: ../rapidsvn_generated.cpp:1173
+#, fuzzy
+msgid "Close"
+msgstr "关闭(&C)"
+
+#: ../utils.cpp:297
 msgid "Co&mmit...\tCTRL-ENTER"
 msgstr "提交(&m)...\tCTRL-Enter"
 
-#: ../main_frame.cpp:265
+#: ../main_frame.cpp:274
 msgid "Columns"
 msgstr "信息列"
 
-#: ../rapidsvn_generated.cpp:275
-#: ../rapidsvn_generated.cpp:315
+#: ../rapidsvn_generated.cpp:737 ../rapidsvn_generated.cpp:775
 msgid "Combo!"
 msgstr ""
 
-#: ../commit_action.cpp:42
-#: ../commit_dlg.cpp:45
+#: ../commit_action.cpp:42 ../commit_dlg.cpp:45
 msgid "Commit"
 msgstr "提交"
 
@@ -539,11 +546,11 @@ msgstr "提交"
 msgid "Commit Log Message"
 msgstr "提交历史记录信息"
 
-#: ../rapidsvn_generated.cpp:30
+#: ../rapidsvn_generated.cpp:1549
 msgid "Commit log message: default to most recent"
 msgstr ""
 
-#: ../main_frame_helper.cpp:94
+#: ../main_frame_helper.cpp:86
 msgid "Commit selected"
 msgstr "提交选定项目"
 
@@ -551,9 +558,19 @@ msgstr "提交选定项目"
 msgid "Committed revision"
 msgstr "已提交版本"
 
-#: ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:697
 msgid "Compare:"
 msgstr "比较:"
+
+#: ../listener.cpp:496
+#, fuzzy, c-format
+msgid "Completed %s at revision %d"
+msgstr "已提交版本"
+
+#: ../listener.cpp:486
+#, fuzzy, c-format
+msgid "Completed at revision %d"
+msgstr "已提交版本"
 
 #: ../columns.cpp:64
 msgid "Conflict BASE"
@@ -587,6 +604,11 @@ msgstr "冲突的工作副本"
 msgid "Conflict Working File: %s"
 msgstr "冲突的工作副本文件: %s"
 
+#: ../listener.cpp:307
+#, fuzzy
+msgid "Conflicted"
+msgstr "存在冲突"
+
 #: ../columns.cpp:63
 msgid "Copied"
 msgstr "已复制"
@@ -601,31 +623,21 @@ msgstr "已复制, 来自版本: %ld"
 msgid "Copied From URL: %s"
 msgstr "已复制, 来自 URL: %s"
 
-#: ../log_dlg.cpp:244
-msgid "Copied from Path"
-msgstr "已复制, 来自 URL:"
-
-#: ../log_dlg.cpp:245
-msgid "Copied from Rev"
-msgstr "已复制, 来自版本:"
-
-#: ../dnd_dlg.cpp:108
-#: ../listener.cpp:354
-#: ../main_frame.cpp:1399
-#: ../move_action.cpp:44
+#: ../dnd_dlg.cpp:72 ../listener.cpp:394 ../main_frame.cpp:1421
+#: ../move_action.cpp:44 ../rapidsvn_generated.cpp:857
 msgid "Copy"
 msgstr "复制"
 
-#: ../dnd_dlg.cpp:37
+#: ../dnd_dlg.cpp:82
 msgid "Copy/Move"
 msgstr "复制/移动"
 
-#: ../drag_n_drop_action.cpp:314
+#: ../drag_n_drop_action.cpp:322
 #, fuzzy, c-format
 msgid "Copying file into working directory: %s"
 msgstr "无法将工作路径切换到 %s"
 
-#: ../drag_n_drop_action.cpp:288
+#: ../drag_n_drop_action.cpp:296
 #, fuzzy, c-format
 msgid "Copying file: %s"
 msgstr "冲突的工作副本文件: %s"
@@ -635,7 +647,7 @@ msgstr "冲突的工作副本文件: %s"
 msgid "Could not set working directory to %s"
 msgstr "无法将工作路径切换到 %s"
 
-#: ../utils.cpp:271
+#: ../utils.cpp:280
 msgid "Create New Repository..."
 msgstr "新建文档库..."
 
@@ -644,68 +656,51 @@ msgstr "新建文档库..."
 msgid "Create Repository"
 msgstr "新建文档库..."
 
-#: ../rapidsvn_generated.cpp:611
+#: ../rapidsvn_generated.cpp:485
 #, fuzzy
 msgid "Create repository in &directory:"
 msgstr "选择目标目录"
 
-#: ../columns.cpp:54
-#: ../log_dlg.cpp:165
+#: ../columns.cpp:54 ../log_rev_list.cpp:39
 msgid "Date"
 msgstr "日期"
 
-#: ../rapidsvn_generated.cpp:265
-#: ../rapidsvn_generated.cpp:305
+#: ../rapidsvn_generated.cpp:728 ../rapidsvn_generated.cpp:766
 msgid "Date:"
 msgstr "日期:"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 #, fuzzy
 msgid "Default"
 msgstr "删除"
 
-#: ../delete_action.cpp:40
-#: ../delete_dlg.cpp:79
-#: ../listener.cpp:355
-#: ../main_frame.cpp:1400
+#: ../delete_action.cpp:40 ../listener.cpp:395 ../main_frame.cpp:1422
 msgid "Delete"
 msgstr "删除"
 
-#: ../main_frame_helper.cpp:75
+#: ../main_frame_helper.cpp:71
 msgid "Delete files and directories from version control"
 msgstr "从版本控制系统中删除文件和目录"
 
-#: ../main_frame_helper.cpp:74
+#: ../main_frame_helper.cpp:70
 msgid "Delete selected"
 msgstr "删除选定项目"
 
-#: ../listener.cpp:361
-#: ../listener.cpp:370
-#: ../main_frame.cpp:1406
-#: ../main_frame.cpp:1415
+#: ../listener.cpp:310 ../listener.cpp:401 ../listener.cpp:410
+#: ../main_frame.cpp:1428 ../main_frame.cpp:1437
 msgid "Deleted"
 msgstr "已删除"
 
-#: ../checkout_dlg.cpp:72
-#: ../export_dlg.cpp:75
+#: ../rapidsvn_generated.cpp:241 ../rapidsvn_generated.cpp:953
+#: ../rapidsvn_generated.cpp:1478
 msgid "Destination Directory"
 msgstr "目标目录"
 
-#: ../merge_dlg.cpp:168
-msgid "Destination file"
-msgstr "目标文件"
-
-#: ../merge_dlg.cpp:170
-msgid "Destination path"
-msgstr "目标路径"
-
-#: ../diff_action.cpp:191
-#: ../diff_action.cpp:197
-#: ../diff_dlg.cpp:179
+#: ../diff_action.cpp:191 ../diff_action.cpp:197 ../diff_dlg.cpp:179
 msgid "Diff"
 msgstr "比较"
 
-#: ../rapidsvn_generated.cpp:135
+#: ../rapidsvn_generated.cpp:1650
 msgid "Diff Tool"
 msgstr "比较工具"
 
@@ -725,81 +720,96 @@ msgstr "与其它版本/日期比较"
 msgid "Diff two revisions/dates"
 msgstr "比较两个不同版本/日期"
 
-#: ../rapidsvn_generated.cpp:173
+#: ../rapidsvn_generated.cpp:1688
 msgid "Different login for each bookmark in the bookmarks list"
 msgstr "为书签列表中的每个书签使用不同的登陆信息"
+
+#: ../rapidsvn_generated.cpp:1296
+#, fuzzy
+msgid "Directory"
+msgstr "目录:"
 
 #: ../mkdir_action.cpp:51
 msgid "Directory:"
 msgstr "目录:"
 
-#: ../rapidsvn_generated.cpp:681
+#: ../rapidsvn_generated.cpp:554
 msgid "Disable automatic Log removal"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:685
+#: ../rapidsvn_generated.cpp:557
 msgid "Disable fsync when committing database transactions"
 msgstr ""
 
-#: ../main_frame_helper.cpp:195
+#: ../main_frame_helper.cpp:179
 #, fuzzy
 msgid "Display conflicted files/directories"
 msgstr "确定要解除选定文件/目录的锁定状态吗?"
 
-#: ../main_frame_helper.cpp:132
+#: ../main_frame_helper.cpp:118
 msgid "Display info about selected entries"
 msgstr "显示选定项目的信息"
 
-#: ../main_frame_helper.cpp:189
+#: ../main_frame_helper.cpp:173
 msgid "Display modified files/directories"
 msgstr ""
 
-#: ../main_frame_helper.cpp:183
+#: ../main_frame_helper.cpp:167
 msgid "Display unmodified files/directories"
 msgstr "忽略(&I)...\tCTRL-DEL"
 
-#: ../main_frame_helper.cpp:177
+#: ../main_frame_helper.cpp:161
 #, fuzzy
 msgid "Display unversioned files/directories"
 msgstr "显示不在版本控制中的项目"
 
-#: ../delete_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:616
 msgid "Do you want to delete the selected files/directories?"
 msgstr "确定要删除选定的文件/目录吗?"
 
-#: ../revert_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1767
 msgid "Do you want to revert local changes?"
 msgstr "确定要撤销本地的修改吗?"
 
-#: ../unlock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1866
 msgid "Do you want to unlock the selected files/directories?"
 msgstr "确定要解除选定文件/目录的锁定状态吗?"
 
-#: ../utils.cpp:293
+#: ../utils.cpp:302
 msgid "E&xit\tCTRL-Q"
 msgstr "退出(&x)\tCTRL-Q"
 
-#: ../export_dlg.cpp:131
-msgid "EOL:"
-msgstr "换行符:"
-
-#: ../view_action.cpp:76
+#: ../listed_dlg.cpp:184 ../view_action.cpp:76
 msgid "Edit"
 msgstr "编辑"
 
-#: ../main_frame.cpp:1941
+#: ../main_frame.cpp:2130
 msgid "Edit Bookmark"
 msgstr "编辑书签"
 
-#: ../property_dlg.cpp:64
+#: ../property_dlg.cpp:75
 msgid "Edit Property"
 msgstr "编辑属性"
 
-#: ../rapidsvn_generated.cpp:433
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "Edit..."
+msgstr "编辑(&E)..."
+
+#: ../rapidsvn_generated.cpp:1306
+#, fuzzy
+msgid "End &log message"
+msgstr "请输入日志信息(&l)"
+
+#: ../rapidsvn_generated.cpp:988
+msgid "End of line characters"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:334
 msgid "Enter &log message"
 msgstr "请输入日志信息(&l)"
 
-#: ../lock_dlg.cpp:45
+#: ../rapidsvn_generated.cpp:1112
 msgid "Enter a comment for this lock"
 msgstr "请输入此次锁定操作的附注"
 
@@ -808,41 +818,19 @@ msgstr "请输入此次锁定操作的附注"
 msgid "Enter a name for the repository"
 msgstr "请输入此次锁定操作的附注"
 
-#: ../import_dlg.cpp:95
-msgid "Enter log message"
-msgstr "请输入历史记录信息"
-
 #: ../rename_action.cpp:55
 msgid "Enter new name:"
 msgstr "请输入新名称:"
 
-#: ../export_dlg.cpp:80
-msgid "Enter the local path where you want the code be exported."
-msgstr "请输入用于导出代码的本地路径"
-
-#: ../checkout_dlg.cpp:77
+#: ../checkout_dlg.cpp:60 ../export_dlg.cpp:62
 msgid "Enter the local path where you want the code checked out to here."
 msgstr "请输入用于签出代码的本地路径."
 
-#: ../checkout_dlg.cpp:70
-#: ../export_dlg.cpp:73
+#: ../checkout_dlg.cpp:58 ../export_dlg.cpp:60
 msgid "Enter the repository URL (not local path) here."
 msgstr "请输入文档库的 URL (非本地路径)."
 
-#: ../export_dlg.cpp:143
-msgid "Enter what kind of symbol(s) do you want as EOL (end of line) in exported files."
-msgstr "请输入要用作导出文件的换行符(EOL)的符号."
-
-#: ../import_dlg.cpp:178
-#: ../import_dlg.cpp:191
-#: ../log_dlg.cpp:479
-#: ../log_dlg.cpp:494
-#: ../log_dlg.cpp:530
-#: ../main_frame.cpp:1865
-#: ../merge_dlg.cpp:52
-#: ../merge_dlg.cpp:91
-#: ../merge_dlg.cpp:107
-#: ../property_dlg.cpp:120
+#: ../main_frame.cpp:2053 ../property_dlg.cpp:138
 msgid "Error"
 msgstr "错误"
 
@@ -854,57 +842,60 @@ msgstr "获取状态时出错:"
 msgid "Error running svnadmin"
 msgstr ""
 
-#: ../property_dlg.cpp:120
+#: ../property_dlg.cpp:138
 msgid "Error setting the property values"
 msgstr "设置属性值时出错"
 
-#: ../cert_dlg.cpp:97
+#: ../property_dlg.cpp:132
+#, fuzzy, c-format
+msgid ""
+"Error setting the property values:\n"
+"%s"
+msgstr "设置属性值时出错"
+
+#: ../cert_dlg.cpp:68
 #, c-format
 msgid "Error validating server certificate for '%s':"
 msgstr "验证服务器 '%s' 的证书时出错:"
 
-#: ../simple_worker.cpp:216
-#: ../threaded_worker.cpp:178
+#: ../simple_worker.cpp:216 ../threaded_worker.cpp:178
 msgid "Error while performing action."
 msgstr "执行操作时出错."
 
-#: ../simple_worker.cpp:206
-#: ../threaded_worker.cpp:165
+#: ../simple_worker.cpp:206 ../threaded_worker.cpp:165
 #, c-format
 msgid "Error while performing action: %s"
 msgstr "执行操作时出错: %s"
 
-#: ../simple_worker.cpp:167
-#: ../threaded_worker.cpp:286
+#: ../simple_worker.cpp:167 ../threaded_worker.cpp:286
 msgid "Error while preparing action."
 msgstr "准备操作时出错."
 
-#: ../simple_worker.cpp:161
-#: ../threaded_worker.cpp:276
+#: ../simple_worker.cpp:161 ../threaded_worker.cpp:276
 #, c-format
 msgid "Error while preparing action: %s"
 msgstr "准备操作时出错: %s"
 
-#: ../folder_browser.cpp:500
+#: ../folder_browser.cpp:531
 #, c-format
 msgid "Error while refreshing filelist (%s)"
 msgstr "刷新文件列表时出错 (%s)"
 
-#: ../main_frame.cpp:907
+#: ../main_frame.cpp:930
 msgid "Error while updating filelist"
 msgstr "更新文件列表时出错"
 
-#: ../main_frame.cpp:894
+#: ../main_frame.cpp:917
 #, c-format
 msgid "Error while updating filelist (%s)"
 msgstr "更新文件列表时出错 (%s)"
 
-#: ../main_frame.cpp:542
+#: ../main_frame.cpp:561
 #, c-format
 msgid "Error: %s\n"
 msgstr "错误: %s\n"
 
-#: ../main_frame.cpp:1799
+#: ../main_frame.cpp:1987
 msgid "Exception occured during filelist update"
 msgstr "更新文件列表时出现异常"
 
@@ -921,8 +912,7 @@ msgstr "执行"
 msgid "Execute diff tool: %s"
 msgstr "执行比较工具: %s"
 
-#: ../external_program_action.cpp:140
-#: ../view_action.cpp:121
+#: ../external_program_action.cpp:140 ../view_action.cpp:121
 #, c-format
 msgid "Execute editor: %s"
 msgstr "执行编辑器: %s"
@@ -937,18 +927,16 @@ msgstr "执行文件浏览器: %s"
 msgid "Execute merge tool: %s"
 msgstr "执行比较工具: %s"
 
-#: ../simple_worker.cpp:175
-#: ../threaded_worker.cpp:143
+#: ../simple_worker.cpp:175 ../threaded_worker.cpp:143
 #, c-format
 msgid "Execute: %s"
 msgstr "执行: %s"
 
-#: ../utils.cpp:319
+#: ../utils.cpp:328
 msgid "Explore...\tF2"
 msgstr "浏览...\tF2"
 
-#: ../export_action.cpp:40
-#: ../export_dlg.cpp:288
+#: ../export_action.cpp:39
 msgid "Export"
 msgstr "导出"
 
@@ -956,64 +944,58 @@ msgstr "导出"
 msgid "Extension"
 msgstr "扩展名"
 
-#: ../rapidsvn_generated.cpp:603
+#: ../listener.cpp:405
+#, fuzzy
+msgid "External"
+msgstr "外部"
+
+#: ../rapidsvn_generated.cpp:477
 msgid "FSFS"
 msgstr ""
 
-#: ../listener.cpp:376
-#: ../main_frame.cpp:1421
+#: ../listener.cpp:416 ../main_frame.cpp:1443
 msgid "Failed to lock"
 msgstr "锁定失败"
 
-#: ../listener.cpp:377
-#: ../main_frame.cpp:1422
+#: ../listener.cpp:417 ../main_frame.cpp:1444
 msgid "Failed to unlock"
 msgstr "解除锁定失败"
 
-#: ../import_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1296
 msgid "File"
 msgstr "文件"
 
-#: ../import_dlg.cpp:190
-msgid "File path required when importing a file!"
-msgstr "导入文件时必须填写文件路径!"
-
-#: ../cert_dlg.cpp:123
+#: ../rapidsvn_generated.cpp:183
 msgid "Fingerprint:"
 msgstr "指纹(Fingerprint):"
 
-#: ../merge_dlg.cpp:90
-msgid "First path or URL is required for merge!"
-msgstr "合并的第一个路径或  URL 必须填写!"
-
-#: ../merge_dlg.cpp:131
+#: ../rapidsvn_generated.cpp:1426 ../rapidsvn_generated.cpp:1452
 msgid "First working copy or URL"
 msgstr "第一个工作副本或 URL"
 
-#: ../about_dlg.cpp:80
+#: ../about_dlg.cpp:77
 msgid "For more information see:"
 msgstr "更多信息请访问:"
 
-#: ../destination_dlg.cpp:80
-#: ../merge_dlg.cpp:205
-#: ../rapidsvn_generated.cpp:543
+#: ../rapidsvn_generated.cpp:657 ../rapidsvn_generated.cpp:1494
 msgid "Force"
 msgstr "强制"
 
-#: ../delete_dlg.cpp:49
+#: ../rapidsvn_generated.cpp:620
 msgid "Force removal"
 msgstr "强制删除"
 
-#: ../export_dlg.cpp:123
-msgid "Force to execute even if destination directory not empty, causes overwriting of files with the same names."
+#: ../export_dlg.cpp:75
+msgid ""
+"Force to execute even if destination directory not empty, causes overwriting "
+"of files with the same names."
 msgstr "强制执行, 即使目标目录为非空, 具有相同文件名的文件将被覆盖"
 
-#: ../unlock_dlg.cpp:51
+#: ../rapidsvn_generated.cpp:1870
 msgid "Force unlocking even if you are not the lock owner"
 msgstr "强制解除锁定, 即使你不是锁定所有者"
 
-#: ../rapidsvn_generated.cpp:41
-#: ../rapidsvn_generated.cpp:649
+#: ../rapidsvn_generated.cpp:522 ../rapidsvn_generated.cpp:1558
 msgid "General"
 msgstr "常规"
 
@@ -1026,48 +1008,58 @@ msgstr "获取文件 %s (版本 %s)"
 msgid "HEAD"
 msgstr "HEAD"
 
-#: ../log_dlg.cpp:346
+#: ../rapidsvn_generated.cpp:296 ../rapidsvn_generated.cpp:1023
+#, fuzzy
+msgid "Help"
+msgstr "帮助(&H)"
+
+#: ../rapidsvn_generated.cpp:650
+msgid "Here comes the description"
+msgstr ""
+
+#: ../log_dlg.cpp:77 ../rapidsvn_generated.cpp:1158
 #, c-format
 msgid "History: %d revisions"
 msgstr "历史: %d 次版本更新"
 
-#: ../cert_dlg.cpp:107
+#: ../rapidsvn_generated.cpp:151
 msgid "Hostname:"
 msgstr "主机名:"
 
-#: ../checkout_dlg.cpp:88
-#: ../export_dlg.cpp:91
-msgid "If not using the latest version of the files, specify which revision to use here."
+#: ../checkout_dlg.cpp:63 ../export_dlg.cpp:65
+msgid ""
+"If not using the latest version of the files, specify which revision to use "
+"here."
 msgstr "如果不想使用最新版本的文件, 请在此处指定要使用的版本."
 
-#: ../checkout_dlg.cpp:102
-#: ../export_dlg.cpp:105
-msgid "If the files were renamed or moved some time, specify which peg revision to use here."
+#: ../checkout_dlg.cpp:67 ../export_dlg.cpp:69
+msgid ""
+"If the files were renamed or moved some time, specify which peg revision to "
+"use here."
 msgstr "如果文件被改名或移动了多次, 请指定这里要使用的定位版本(peg)."
 
 #: ../ignore_action.cpp:40
 msgid "Ignore"
 msgstr "忽略"
 
-#: ../main_frame.cpp:275
-#: ../rapidsvn_generated.cpp:551
+#: ../main_frame.cpp:284 ../rapidsvn_generated.cpp:1923
 msgid "Ignore Externals"
 msgstr "忽略外部文件"
 
-#: ../checkout_dlg.cpp:122
-#: ../export_dlg.cpp:126
-#: ../update_dlg.cpp:124
+#: ../rapidsvn_generated.cpp:282 ../rapidsvn_generated.cpp:1009
 msgid "Ignore externals"
 msgstr "忽略外部文件"
 
-#: ../dnd_dlg.cpp:37
-#: ../dnd_dlg.cpp:97
-#: ../import_action.cpp:38
-#: ../import_dlg.cpp:149
+#: ../dnd_dlg.cpp:63 ../import_action.cpp:38 ../rapidsvn_generated.cpp:851
 msgid "Import"
 msgstr "导入"
 
-#: ../drag_n_drop_action.cpp:303
+#: ../rapidsvn_generated.cpp:1276
+#, fuzzy
+msgid "Import &Path"
+msgstr "导入"
+
+#: ../drag_n_drop_action.cpp:311
 #, c-format
 msgid "Importing file into repository: %s"
 msgstr ""
@@ -1077,15 +1069,15 @@ msgstr ""
 msgid "In&teractive Resolve...\tCTRL-T"
 msgstr "属性(&P)...\tCTRL-P"
 
-#: ../main_frame.cpp:270
+#: ../main_frame.cpp:279
 msgid "Indicate modified children"
 msgstr ""
 
-#: ../main_frame.cpp:1984
+#: ../main_frame.cpp:2173
 msgid "Info"
 msgstr "信息"
 
-#: ../main_frame_helper.cpp:131
+#: ../main_frame_helper.cpp:117
 msgid "Info selected"
 msgstr "选定项目的信息"
 
@@ -1093,7 +1085,7 @@ msgstr "选定项目的信息"
 msgid "Internal Error: There is another action running"
 msgstr "内部错误: 已有一个操作正在执行中"
 
-#: ../main_frame.cpp:1542
+#: ../main_frame.cpp:1695
 msgid "Internal Error: no client data for action event!"
 msgstr "内部错误: 没有符合操作事件的客户端数据!"
 
@@ -1105,28 +1097,17 @@ msgstr "内部错误: 不存在上下文"
 msgid "Invalid revision number detected"
 msgstr "检测到无效的版本号"
 
-#: ../log_dlg.cpp:478
-msgid "Invalid selection. At least one revisions is needed for diff and no more than two."
-msgstr "选择无效. 至少要指定一个版本才能进行比较."
-
-#: ../log_dlg.cpp:493
-msgid "Invalid selection. Exactly two revisions needed for merge."
-msgstr "选择无效. 必须指定要合并的两个版本."
-
-#: ../log_dlg.cpp:529
-msgid "Invalid selection. Only one revision may be selected for annotate"
-msgstr "选择无效. 一次只能评注一个版本."
-
-#: ../cert_dlg.cpp:111
-msgid "Issue:"
+#: ../rapidsvn_generated.cpp:159
+#, fuzzy
+msgid "Issuer:"
 msgstr "颁发者"
 
-#: ../rapidsvn_generated.cpp:477
+#: ../rapidsvn_generated.cpp:377
 #, fuzzy
 msgid "Keep Locks"
 msgstr "保持锁定"
 
-#: ../export_dlg.cpp:137
+#: ../rapidsvn_generated.cpp:992
 msgid "LF (Unix)"
 msgstr "LF (Unix)"
 
@@ -1148,20 +1129,16 @@ msgstr "最后修改日期"
 msgid "Last Changed Rev: %ld"
 msgstr "最后修改的版本: %ld"
 
-#: ../annotate_dlg.cpp:49
+#: ../annotate_dlg.cpp:36
 msgid "Line"
 msgstr "行"
 
-#: ../main_frame.cpp:330
-msgid "Listener Test"
-msgstr "Listener 测试"
-
-#: ../filelist_ctrl.cpp:1058
+#: ../filelist_ctrl.cpp:1064
 #, c-format
 msgid "Listing entries in '%s'"
 msgstr "正在列出 '%s' 中的项目"
 
-#: ../about_dlg.cpp:88
+#: ../about_dlg.cpp:85
 #, c-format
 msgid ""
 "Locale Information:\n"
@@ -1174,21 +1151,7 @@ msgstr ""
 "系统名称: %s\n"
 "规范名称: %s\n"
 
-#: ../rapidsvn_app.cpp:198
-#: ../rapidsvn_app.cpp:206
-msgid "Locate help"
-msgstr "定位帮助文件"
-
-#: ../rapidsvn_app.cpp:266
-msgid "Locate tips"
-msgstr "定位技巧提示文件"
-
-#: ../rapidsvn_app.cpp:258
-msgid "Locate tips file"
-msgstr "定位帮助技巧文件"
-
 #: ../lock_action.cpp:40
-#: ../lock_dlg.cpp:100
 msgid "Lock"
 msgstr "锁定"
 
@@ -1223,32 +1186,27 @@ msgstr "锁定所有者: %s"
 msgid "Lock Token: %s"
 msgstr "锁定标识: %s"
 
-#: ../listener.cpp:374
-#: ../main_frame.cpp:1419
+#: ../listener.cpp:414 ../main_frame.cpp:1441
 msgid "Locked"
 msgstr "已锁定"
 
-#: ../log_action.cpp:41
+#: ../log_action.cpp:82 ../log_action.cpp:136
 msgid "Log"
 msgstr "历史记录"
 
-#: ../log_dlg.cpp:571
+#: ../log_dlg.cpp:71
 msgid "Log History"
 msgstr "历史记录"
 
-#: ../log_dlg.cpp:166
+#: ../log_rev_list.cpp:40 ../rapidsvn_generated.cpp:1211
 msgid "Log Message"
 msgstr "历史记录信息"
 
-#: ../log_dlg.cpp:355
-msgid "Log Message:"
-msgstr "历史记录信息:"
-
-#: ../main_frame_helper.cpp:141
+#: ../main_frame_helper.cpp:125
 msgid "Log selected"
 msgstr "选定项目的历史记录"
 
-#: ../utils.cpp:279
+#: ../utils.cpp:288
 msgid "Login..."
 msgstr "登录..."
 
@@ -1273,43 +1231,40 @@ msgstr "创建目录(&d)...\tF7"
 msgid "Make directory"
 msgstr "创建目录"
 
-#: ../merge_action.cpp:38
-#: ../merge_action.cpp:44
-#: ../merge_dlg.cpp:125
+#: ../merge_action.cpp:38 ../merge_action.cpp:44
 msgid "Merge"
 msgstr "合并"
 
-#: ../rapidsvn_generated.cpp:161
+#: ../rapidsvn_generated.cpp:1676
 msgid "Merge Tool"
 msgstr "合并工具"
 
-#: ../merge_dlg.cpp:60
-msgid "Merge revisions"
-msgstr "合并版本"
-
-#: ../main_frame.cpp:294
+#: ../main_frame.cpp:303
 msgid "Merge..."
 msgstr "合并..."
+
+#: ../listener.cpp:308
+#, fuzzy
+msgid "Merged"
+msgstr "合并"
 
 #: ../mkdir_action.cpp:37
 msgid "Mkdir"
 msgstr "Mkdir"
 
-#: ../listener.cpp:368
-#: ../main_frame.cpp:1413
+#: ../listener.cpp:408 ../main_frame.cpp:1435
 msgid "Modified"
 msgstr "已修改"
 
-#: ../rapidsvn_generated.cpp:692
+#: ../rapidsvn_generated.cpp:563
 msgid "More options"
 msgstr ""
 
-#: ../dnd_dlg.cpp:104
-#: ../move_action.cpp:42
+#: ../move_action.cpp:42 ../rapidsvn_generated.cpp:854
 msgid "Move"
 msgstr "移动"
 
-#: ../drag_n_drop_action.cpp:293
+#: ../drag_n_drop_action.cpp:301
 #, fuzzy, c-format
 msgid "Moving file: %s"
 msgstr "冲突的工作副本文件: %s"
@@ -1318,10 +1273,16 @@ msgstr "冲突的工作副本文件: %s"
 msgid "Multiple Files"
 msgstr ""
 
-#: ../columns.cpp:45
-#: ../listed_dlg.cpp:75
-#: ../listed_dlg.cpp:171
-#: ../listed_dlg.cpp:324
+#: ../rapidsvn_generated.cpp:30 ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:38 ../rapidsvn_generated.cpp:131
+#: ../rapidsvn_generated.cpp:135 ../rapidsvn_generated.cpp:137
+#: ../rapidsvn_generated.cpp:155 ../rapidsvn_generated.cpp:163
+#: ../rapidsvn_generated.cpp:171 ../rapidsvn_generated.cpp:179
+#: ../rapidsvn_generated.cpp:187
+msgid "MyLabel"
+msgstr ""
+
+#: ../columns.cpp:45 ../listed_dlg.cpp:65 ../listed_dlg.cpp:182
 msgid "Name"
 msgstr "文件名"
 
@@ -1330,45 +1291,24 @@ msgstr "文件名"
 msgid "Name: %s"
 msgstr "文件名: %s"
 
-#: ../property_dlg.cpp:63
+#: ../property_dlg.cpp:74
 msgid "New Property"
 msgstr "新建属性值"
-
-#: ../revert_dlg.cpp:57
-msgid "No"
-msgstr ""
 
 #: ../diff_action.cpp:217
 msgid "No diff tool set in the preferences"
 msgstr "首选项中没有设置比较工具"
 
-#: ../rapidsvn_app.cpp:206
-msgid ""
-"No help file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"没有选定帮助文件.\n"
-"您希望在下次程序启动时再次提示此信息吗?"
-
 #: ../userresolve_action.cpp:62
 msgid "No merge tool set in the preferences"
 msgstr "首选项中没有设置合并工具"
-
-#: ../rapidsvn_app.cpp:266
-msgid ""
-"No tips file was chosen, would you like to be \n"
-"asked again after next application start?"
-msgstr ""
-"没有选定帮助提示文件.\n"
-"您希望在下次程序启动时再次提示此信息吗?"
 
 #: ../file_info.cpp:118
 #, c-format
 msgid "Node Kind: %s"
 msgstr "节点类型: %s"
 
-#: ../checkout_dlg.cpp:106
-#: ../export_dlg.cpp:109
+#: ../rapidsvn_generated.cpp:268 ../rapidsvn_generated.cpp:980
 msgid "Not specified"
 msgstr "未指定"
 
@@ -1376,55 +1316,38 @@ msgstr "未指定"
 msgid "Not versioned"
 msgstr "未受版本控制"
 
-#: ../about_dlg.cpp:114
-#: ../annotate_dlg.cpp:42
-#: ../auth_dlg.cpp:71
-#: ../checkout_dlg.cpp:126
-#: ../delete_dlg.cpp:54
-#: ../destination_dlg.cpp:87
-#: ../export_dlg.cpp:145
-#: ../import_dlg.cpp:128
-#: ../listed_dlg.cpp:185
-#: ../listed_dlg.cpp:341
-#: ../lock_dlg.cpp:60
-#: ../merge_dlg.cpp:212
-#: ../rapidsvn_generated.cpp:191
-#: ../rapidsvn_generated.cpp:325
-#: ../rapidsvn_generated.cpp:405
-#: ../rapidsvn_generated.cpp:481
-#: ../rapidsvn_generated.cpp:560
-#: ../rapidsvn_generated.cpp:704
-#: ../report_dlg.cpp:57
-#: ../switch_dlg.cpp:137
-#: ../unlock_dlg.cpp:55
-#: ../update_dlg.cpp:133
+#: ../rapidsvn_generated.cpp:44 ../rapidsvn_generated.cpp:66
+#: ../rapidsvn_generated.cpp:107 ../rapidsvn_generated.cpp:289
+#: ../rapidsvn_generated.cpp:380 ../rapidsvn_generated.cpp:439
+#: ../rapidsvn_generated.cpp:575 ../rapidsvn_generated.cpp:626
+#: ../rapidsvn_generated.cpp:663 ../rapidsvn_generated.cpp:785
+#: ../rapidsvn_generated.cpp:915 ../rapidsvn_generated.cpp:1016
+#: ../rapidsvn_generated.cpp:1080 ../rapidsvn_generated.cpp:1125
+#: ../rapidsvn_generated.cpp:1318 ../rapidsvn_generated.cpp:1502
+#: ../rapidsvn_generated.cpp:1704 ../rapidsvn_generated.cpp:1747
+#: ../rapidsvn_generated.cpp:1777 ../rapidsvn_generated.cpp:1833
+#: ../rapidsvn_generated.cpp:1876 ../rapidsvn_generated.cpp:1931
 msgid "OK"
 msgstr "确定"
 
-#: ../utils.cpp:551
+#: ../utils.cpp:561
 msgid "Open..."
 msgstr "打开..."
 
-#: ../export_dlg.cpp:120
+#: ../rapidsvn_generated.cpp:1006
 msgid "Overwrite"
 msgstr "覆盖"
 
-#: ../auth_dlg.cpp:62
-msgid "Password"
-msgstr "密码"
-
 #: ../columns.cpp:46
-#: ../import_dlg.cpp:80
-#: ../log_dlg.cpp:243
 msgid "Path"
 msgstr "路径"
 
-#: ../import_dlg.cpp:112
-msgid "Path type:"
+#: ../rapidsvn_generated.cpp:1292
+#, fuzzy
+msgid "Path &type"
 msgstr "路径类型:"
 
-#: ../checkout_dlg.cpp:97
-#: ../export_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:263 ../rapidsvn_generated.cpp:975
 msgid "Peg Revision"
 msgstr "定位版本"
 
@@ -1432,28 +1355,28 @@ msgstr "定位版本"
 msgid "Preferences"
 msgstr "首选项"
 
-#: ../utils.cpp:302
+#: ../utils.cpp:311
 msgid "Preferences..."
 msgstr "首选项..."
 
-#: ../rapidsvn_generated.cpp:151
+#: ../rapidsvn_generated.cpp:1666
 #, fuzzy
 msgid "Program arguments (%1=base, %2=theirs %3=mine %4=result):"
 msgstr "程序参数 (%1=文件1, %2=文件2):"
 
-#: ../rapidsvn_generated.cpp:125
+#: ../rapidsvn_generated.cpp:1640
 msgid "Program arguments (%1=file1, %2=file2):"
 msgstr "程序参数 (%1=文件1, %2=文件2):"
 
-#: ../rapidsvn_generated.cpp:94
+#: ../rapidsvn_generated.cpp:1610
 msgid "Program arguments (%1=selected directory):"
 msgstr "程序参数 (%1=选定的目录):"
 
-#: ../rapidsvn_generated.cpp:63
+#: ../rapidsvn_generated.cpp:1580
 msgid "Program arguments (%1=selected file):"
 msgstr "程序参数 (%1=选定的文件):"
 
-#: ../rapidsvn_generated.cpp:168
+#: ../rapidsvn_generated.cpp:1683
 msgid "Programs"
 msgstr "程序"
 
@@ -1469,7 +1392,7 @@ msgstr "属性状态"
 msgid "Properties Last Updated"
 msgstr "属性最后更新"
 
-#: ../property_dlg.cpp:62
+#: ../property_dlg.cpp:73
 msgid "Properties:"
 msgstr "属性:"
 
@@ -1481,22 +1404,21 @@ msgstr "属性"
 msgid "Property Editor"
 msgstr "属性编辑器"
 
-#: ../rapidsvn_generated.cpp:26
+#: ../rapidsvn_generated.cpp:1546
 msgid "Purge temporary files on program exit"
 msgstr "退出程序时清除临时文件"
 
-#: ../main_frame_helper.cpp:65
+#: ../main_frame_helper.cpp:63
 msgid "Put files and directories under revision control"
 msgstr "将文件和目录加入版本控制系统中"
 
-#: ../main_frame.cpp:509
+#: ../rapidsvn_generated.cpp:844
+msgid "Question"
+msgstr ""
+
+#: ../main_frame.cpp:528
 msgid "RapidSVN Error"
 msgstr "RapidSVN 错误"
-
-#: ../rapidsvn_app.cpp:97
-#, c-format
-msgid "RapidSVN Help: %s"
-msgstr "RapidSVN 帮助: %s"
 
 #: ../utils.cpp:192
 msgid "Re&name...\tCTRL-N"
@@ -1510,57 +1432,51 @@ msgstr "解决冲突(&s)\tCTRL-S"
 msgid "Re&vert\tCTRL-V"
 msgstr "复原(&v)\tCTRL-V"
 
-#: ../filelist_ctrl.cpp:1134
+#: ../filelist_ctrl.cpp:1140
 msgid "Ready"
 msgstr "就绪"
 
-#: ../main_frame.cpp:1522
-#: ../main_frame.cpp:1566
+#: ../main_frame.cpp:1675 ../main_frame.cpp:1719
 msgid "Ready\n"
 msgstr "就绪\n"
 
-#: ../rapidsvn_generated.cpp:393
+#: ../rapidsvn_generated.cpp:427
 msgid "Recent entries:"
 msgstr "最近条目:"
 
-#: ../checkout_dlg.cpp:111
-#: ../export_dlg.cpp:114
-#: ../import_dlg.cpp:108
-#: ../merge_dlg.cpp:201
-#: ../rapidsvn_generated.cpp:473
-#: ../rapidsvn_generated.cpp:547
-#: ../revert_dlg.cpp:49
-#: ../switch_dlg.cpp:117
-#: ../update_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:279 ../rapidsvn_generated.cpp:374
+#: ../rapidsvn_generated.cpp:1003 ../rapidsvn_generated.cpp:1315
+#: ../rapidsvn_generated.cpp:1491 ../rapidsvn_generated.cpp:1771
+#: ../rapidsvn_generated.cpp:1822 ../rapidsvn_generated.cpp:1920
 msgid "Recursive"
 msgstr "递归"
 
-#: ../main_frame_helper.cpp:206
+#: ../main_frame_helper.cpp:188
 msgid "Refresh"
 msgstr "刷新"
 
-#: ../utils.cpp:297
+#: ../utils.cpp:306
 msgid "Refresh View\tCTRL-R"
 msgstr "刷新视图\tCTRL-R"
 
-#: ../main_frame_helper.cpp:207
+#: ../main_frame_helper.cpp:189
 msgid "Refresh the file list"
 msgstr "刷新文件列表"
 
-#: ../main_frame.cpp:268
+#: ../main_frame.cpp:277
 msgid "Refresh with Update"
 msgstr "刷新并更新"
 
-#: ../switch_dlg.cpp:127
+#: ../rapidsvn_generated.cpp:1825
 #, fuzzy
 msgid "Relocate"
 msgstr "已替换"
 
-#: ../main_frame_helper.cpp:115
+#: ../main_frame_helper.cpp:103
 msgid "Remove 'conflicted' state on working copy files or directories"
 msgstr "移除工作副本文件或目录的'冲突'状态"
 
-#: ../main_frame.cpp:1918
+#: ../main_frame.cpp:2107
 msgid "Removed bookmark"
 msgstr "已移除书签"
 
@@ -1572,8 +1488,7 @@ msgstr "重命名"
 msgid "Rep. Rev."
 msgstr "文档库版本"
 
-#: ../listener.cpp:371
-#: ../main_frame.cpp:1416
+#: ../listener.cpp:411 ../main_frame.cpp:1438
 msgid "Replaced"
 msgstr "已替换"
 
@@ -1581,14 +1496,14 @@ msgstr "已替换"
 msgid "Repository"
 msgstr "文档库"
 
-#: ../import_dlg.cpp:67
-#: ../main_frame.cpp:1890
+#: ../rapidsvn_generated.cpp:1268
+#, fuzzy
+msgid "Repository &URL for import"
+msgstr "必须输入文档库 URL 才能执行导入操作!"
+
+#: ../main_frame.cpp:2079
 msgid "Repository URL"
 msgstr "文档库 URL"
-
-#: ../import_dlg.cpp:177
-msgid "Repository URL is required for import!"
-msgstr "必须输入文档库 URL 才能执行导入操作!"
 
 #: ../file_info.cpp:112
 #, c-format
@@ -1600,81 +1515,63 @@ msgstr "文档库 UUID: %s"
 msgid "Repository: %s"
 msgstr "文档库: %s"
 
-#: ../utils.cpp:310
+#: ../utils.cpp:319
 msgid "Reset Columns"
 msgstr "重置信息列"
 
-#: ../rapidsvn_generated.cpp:34
+#: ../rapidsvn_generated.cpp:1552
 msgid "Reset Flat Mode on every program start"
 msgstr ""
 
-#: ../resolve_action.cpp:37
-#: ../userresolve_action.cpp:44
+#: ../resolve_action.cpp:37 ../userresolve_action.cpp:44
 msgid "Resolve"
 msgstr "解决冲突"
 
-#: ../main_frame_helper.cpp:114
+#: ../main_frame_helper.cpp:102
 msgid "Resolve selected"
 msgstr "解决选定项目的冲突"
 
-#: ../listener.cpp:359
-#: ../main_frame.cpp:1404
+#: ../listener.cpp:399 ../main_frame.cpp:1426
 msgid "Resolved"
 msgstr "已解决冲突"
 
-#: ../listener.cpp:356
-#: ../main_frame.cpp:1401
+#: ../listener.cpp:396 ../main_frame.cpp:1423
 msgid "Restore"
 msgstr "还原"
 
-#: ../main_frame_helper.cpp:105
+#: ../main_frame_helper.cpp:95
 msgid "Restore pristine working copy file (undo all local edits)"
 msgstr "恢复工作副本文件到最原始的状态(撤销所有本地修改)."
 
-#: ../rapidsvn_generated.cpp:632
+#: ../rapidsvn_generated.cpp:506
 msgid "Resulting repository filename:"
 msgstr ""
 
-#: ../listener.cpp:357
-#: ../main_frame.cpp:1402
-#: ../revert_action.cpp:35
-#: ../revert_dlg.cpp:79
+#: ../listener.cpp:397 ../main_frame.cpp:1424 ../revert_action.cpp:35
 msgid "Revert"
 msgstr "复原"
 
-#: ../main_frame_helper.cpp:104
+#: ../main_frame_helper.cpp:94
 msgid "Revert selected"
 msgstr "复原选定的项目"
 
-#: ../annotate_dlg.cpp:47
-#: ../checkout_dlg.cpp:83
-#: ../columns.cpp:47
-#: ../export_dlg.cpp:86
-#: ../log_dlg.cpp:163
-#: ../merge_dlg.cpp:133
-#: ../merge_dlg.cpp:150
-#: ../rapidsvn_generated.cpp:529
-#: ../switch_dlg.cpp:91
-#: ../update_dlg.cpp:88
+#: ../annotate_dlg.cpp:34 ../columns.cpp:47 ../log_rev_list.cpp:37
+#: ../rapidsvn_generated.cpp:252 ../rapidsvn_generated.cpp:964
+#: ../rapidsvn_generated.cpp:1808 ../rapidsvn_generated.cpp:1906
 msgid "Revision"
 msgstr "版本"
 
-#: ../merge_dlg.cpp:51
-msgid "Revision must be an unsigned number!"
-msgstr "版本号必须为正整数!"
-
-#: ../rapidsvn_generated.cpp:243
+#: ../rapidsvn_generated.cpp:707
 #, fuzzy
 msgid "Revision or date #1:"
 msgstr "版本或日期 #&1:"
 
-#: ../rapidsvn_generated.cpp:283
+#: ../rapidsvn_generated.cpp:745
 #, fuzzy
 msgid "Revision or date #2:"
 msgstr "版本或日期 #&2:"
 
-#: ../rapidsvn_generated.cpp:250
-#: ../rapidsvn_generated.cpp:290
+#: ../rapidsvn_generated.cpp:714 ../rapidsvn_generated.cpp:752
 msgid "Revision:"
 msgstr "版本:"
 
@@ -1688,10 +1585,6 @@ msgstr "版本: %ld"
 msgid "Running command %s:"
 msgstr ""
 
-#: ../cert_dlg.cpp:66
-msgid "SSL Certificate"
-msgstr "SSL 证书"
-
 #: ../columns.cpp:62
 msgid "Schedule"
 msgstr "计划"
@@ -1701,38 +1594,28 @@ msgstr "计划"
 msgid "Schedule: %s"
 msgstr "计划: %s"
 
-#: ../merge_dlg.cpp:106
-msgid "Second path or URL is required for merge!"
-msgstr "合并的第二个路径或  URL 必须填写!"
-
-#: ../merge_dlg.cpp:148
-msgid "Second working copy or URL"
-msgstr "第二个工作副本或 URL"
-
-#: ../listener.cpp:169
+#: ../listener.cpp:166
 msgid "Select Certificate File"
 msgstr "选择证书文件"
 
-#: ../checkout_dlg.cpp:273
-#: ../export_dlg.cpp:311
+#: ../checkout_dlg.cpp:108 ../export_dlg.cpp:110
 msgid "Select a destination directory"
 msgstr "选择目标目录"
 
-#: ../merge_dlg.cpp:241
+#: ../merge_dlg.cpp:111
 msgid "Select a destination folder to merge to"
 msgstr "选择要合并到的目标文件夹"
 
-#: ../create_repos_dlg.cpp:185
-#: ../create_repos_dlg.cpp:201
-#: ../main_frame.cpp:1845
+#: ../create_repos_dlg.cpp:185 ../create_repos_dlg.cpp:201
+#: ../main_frame.cpp:2033
 msgid "Select a directory"
 msgstr "选择目录"
 
-#: ../import_dlg.cpp:210
+#: ../import_dlg.cpp:128
 msgid "Select a directory to import"
 msgstr "选择要导入的目录"
 
-#: ../import_dlg.cpp:219
+#: ../import_dlg.cpp:134
 msgid "Select a file to import"
 msgstr "选择要导入的文件"
 
@@ -1761,93 +1644,85 @@ msgstr "选择标准编辑器的执行程序"
 msgid "Select standard file explorer executable"
 msgstr "选择文件浏览器的执行程序"
 
-#: ../main_frame_helper.cpp:95
+#: ../main_frame_helper.cpp:87
 msgid "Send changes from your working copy to the repository"
 msgstr "将您的工作副本中的修改发送到文档库"
 
-#: ../checkout_dlg.cpp:94
-#: ../export_dlg.cpp:97
+#: ../checkout_dlg.cpp:65 ../export_dlg.cpp:67
 msgid "Set this to get the latest version of the files in the repository."
 msgstr "选定此项以获取文档库中最新版本的文件"
 
-#: ../checkout_dlg.cpp:108
-#: ../export_dlg.cpp:111
+#: ../checkout_dlg.cpp:69 ../export_dlg.cpp:71
 msgid "Set this to use BASE/HEAD (current) peg revision of the files."
 msgstr "选定此项以使用文件的 BASE/HEAD(当前) 定位版本."
 
-#: ../checkout_dlg.cpp:119
+#: ../checkout_dlg.cpp:73
 msgid "Set to automatically create a new working copy bookmark."
 msgstr "选定此项会自动创建一个工作副本书签."
 
-#: ../checkout_dlg.cpp:114
-#: ../export_dlg.cpp:117
+#: ../checkout_dlg.cpp:71 ../export_dlg.cpp:73
 msgid "Set to get all subdirectories from the URL also."
 msgstr "选定此项会获取 URL 下所有子目录的内容."
 
-#: ../checkout_dlg.cpp:125
-#: ../export_dlg.cpp:129
-msgid "Set to ignore external definitions and the external working copies managed by them."
+#: ../checkout_dlg.cpp:75 ../export_dlg.cpp:77
+msgid ""
+"Set to ignore external definitions and the external working copies managed "
+"by them."
 msgstr "选定此项以忽略由外部定义文件管理的工作副本."
 
-#: ../main_frame.cpp:320
+#: ../main_frame.cpp:329
 msgid "Show Startup Tips"
 msgstr "显示启动时的技巧提示"
 
-#: ../main_frame.cpp:274
-#: ../main_frame_helper.cpp:194
+#: ../main_frame.cpp:283 ../main_frame_helper.cpp:178
 msgid "Show conflicted entries"
 msgstr "列出有冲突的项目"
 
-#: ../main_frame_helper.cpp:171
+#: ../main_frame_helper.cpp:155
 msgid "Show entries in subdirectories"
 msgstr "列出位于子目录中的项目"
 
-#: ../main_frame.cpp:276
+#: ../main_frame.cpp:285
 msgid "Show ignored entries"
 msgstr "列出已忽略的项目"
 
-#: ../main_frame.cpp:273
-#: ../main_frame_helper.cpp:188
+#: ../main_frame.cpp:282 ../main_frame_helper.cpp:172
 msgid "Show modified entries"
 msgstr "列出已修改的项目"
 
-#: ../main_frame.cpp:269
-#: ../main_frame_helper.cpp:170
+#: ../main_frame.cpp:278 ../main_frame_helper.cpp:154
 msgid "Show subdirectories"
 msgstr "列出子目录中的项目"
 
-#: ../main_frame_helper.cpp:142
+#: ../main_frame_helper.cpp:126
 msgid "Show the log messages for the selected entries"
 msgstr "列出选定项目的日志信息."
 
-#: ../main_frame.cpp:272
-#: ../main_frame_helper.cpp:182
+#: ../main_frame.cpp:281 ../main_frame_helper.cpp:166
 msgid "Show unmodified entries"
 msgstr "列出未修改的项目"
 
-#: ../main_frame.cpp:271
-#: ../main_frame_helper.cpp:176
+#: ../main_frame.cpp:280 ../main_frame_helper.cpp:160
 msgid "Show unversioned entries"
 msgstr "列出不在版本控制中的项目"
 
-#: ../listener.cpp:360
-#: ../main_frame.cpp:1405
+#: ../listener.cpp:400 ../main_frame.cpp:1427
 msgid "Skip"
 msgstr "跳过"
 
-#: ../main_frame.cpp:266
+#: ../main_frame.cpp:275
 msgid "Sort"
 msgstr "排序"
 
-#: ../main_frame.cpp:242
+#: ../main_frame.cpp:251
 msgid "Sort Ascending"
 msgstr "升序排序"
 
-#: ../rapidsvn_generated.cpp:77
+#: ../rapidsvn_generated.cpp:1593
 msgid "Standard Editor"
 msgstr "默认编辑器"
 
-#: ../rapidsvn_generated.cpp:108
+#: ../rapidsvn_generated.cpp:1623
 msgid "Standard Explorer"
 msgstr "默认文件浏览器"
 
@@ -1855,40 +1730,39 @@ msgstr "默认文件浏览器"
 msgid "Status"
 msgstr "状态"
 
-#: ../lock_dlg.cpp:57
+#: ../rapidsvn_generated.cpp:1122
 msgid "Steal lock if it belongs to another user"
 msgstr "如果锁定属于其它用户, 将它强行转给当前用户"
 
-#: ../main_frame_helper.cpp:219
+#: ../main_frame_helper.cpp:199
 msgid "Stop"
 msgstr "停止"
 
-#: ../main_frame_helper.cpp:220
+#: ../main_frame_helper.cpp:200
 msgid "Stop the current action"
 msgstr "停止当前操作"
 
-#: ../rapidsvn_generated.cpp:177
+#: ../rapidsvn_generated.cpp:1691
 msgid "Store authentication credentials on hard disk"
 msgstr "将身份验证信息保存在硬盘上"
 
 #: ../switch_action.cpp:50
-#: ../switch_dlg.cpp:192
 msgid "Switch URL"
 msgstr "切换 URL"
 
-#: ../main_frame.cpp:295
+#: ../main_frame.cpp:304
 msgid "Switch URL...\tCTRL-S"
 msgstr "切换 URL...\tCTRL-S"
 
-#: ../main_frame.cpp:1352
+#: ../main_frame.cpp:1374
 msgid "Test duration"
 msgstr "测试耗时"
 
-#: ../main_frame.cpp:1348
+#: ../main_frame.cpp:1370
 msgid "Test ended at"
 msgstr "测试结束于"
 
-#: ../main_frame.cpp:1345
+#: ../main_frame.cpp:1367
 msgid "Test started at"
 msgstr "测试开始于"
 
@@ -1908,7 +1782,7 @@ msgstr ""
 msgid "The svnadmin command was not successful."
 msgstr ""
 
-#: ../cert_dlg.cpp:70
+#: ../cert_dlg.cpp:37
 msgid ""
 "There were errors validating the server certificate.\n"
 "Do you want to trust this certificate?"
@@ -1916,12 +1790,12 @@ msgstr ""
 "验证服务器证书时发现错误.\n"
 "是否还要相信此证书?"
 
-#: ../rapidsvn_generated.cpp:384
+#: ../rapidsvn_generated.cpp:418
 #, fuzzy
 msgid "This action has resulted in a commit - please enter a &log message"
 msgstr "此操作会产生提交动作 - 请输入历史记录信息"
 
-#: ../about_dlg.cpp:62
+#: ../about_dlg.cpp:59
 msgid ""
 "This program is licensed under the terms\n"
 "of the GNU General Public License version 3\n"
@@ -1929,16 +1803,9 @@ msgid ""
 "Available online under:"
 msgstr ""
 
-#: ../import_dlg.cpp:116
-msgid "Tree"
-msgstr "树"
-
-#: ../checkout_dlg.cpp:65
-#: ../columns.cpp:59
-#: ../export_dlg.cpp:68
-#: ../rapidsvn_generated.cpp:521
-#: ../switch_dlg.cpp:77
-#: ../update_dlg.cpp:73
+#: ../columns.cpp:59 ../rapidsvn_generated.cpp:233
+#: ../rapidsvn_generated.cpp:945 ../rapidsvn_generated.cpp:1801
+#: ../rapidsvn_generated.cpp:1899
 msgid "URL"
 msgstr "URL"
 
@@ -1951,11 +1818,11 @@ msgstr "URL: %s"
 msgid "UUID"
 msgstr "UUID"
 
-#: ../about_dlg.cpp:66
+#: ../about_dlg.cpp:63
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../main_frame.cpp:1494
+#: ../main_frame.cpp:1647
 msgid "Unimplemented action!"
 msgstr "未实现的功能!"
 
@@ -1964,75 +1831,60 @@ msgid "Unknown destination path"
 msgstr "未知的目标路径"
 
 #: ../unlock_action.cpp:39
-#: ../unlock_dlg.cpp:80
 msgid "Unlock"
 msgstr "解除锁定"
 
-#: ../listener.cpp:375
-#: ../main_frame.cpp:1420
+#: ../listener.cpp:415 ../main_frame.cpp:1442
 msgid "Unlocked"
 msgstr "已解除锁定"
 
-#: ../get_action.cpp:38
-#: ../update_action.cpp:39
-#: ../update_action.cpp:51
+#: ../get_action.cpp:38 ../update_action.cpp:39 ../update_action.cpp:51
 msgid "Update"
 msgstr "更新"
 
-#: ../main_frame_helper.cpp:84
+#: ../main_frame_helper.cpp:78
 msgid "Update selected"
 msgstr "更新选定项目"
 
-#: ../listener.cpp:363
-#: ../main_frame.cpp:1408
+#: ../listener.cpp:311 ../listener.cpp:403 ../main_frame.cpp:1430
 msgid "Updated"
 msgstr "已更新"
 
-#: ../main_frame.cpp:1556
-#: ../main_frame.cpp:1561
+#: ../main_frame.cpp:1709 ../main_frame.cpp:1714
 msgid "Updating..."
 msgstr "更新中..."
 
-#: ../main_frame.cpp:241
+#: ../main_frame.cpp:250
 msgid "Use Path for Sorting"
 msgstr "使用路径排序"
 
-#: ../rapidsvn_generated.cpp:271
-#: ../rapidsvn_generated.cpp:311
+#: ../rapidsvn_generated.cpp:734 ../rapidsvn_generated.cpp:772
 msgid "Use URL/path:"
 msgstr "使用URL或路径:"
 
-#: ../rapidsvn_generated.cpp:70
-#: ../rapidsvn_generated.cpp:101
+#: ../rapidsvn_generated.cpp:1587 ../rapidsvn_generated.cpp:1617
 msgid "Use always"
 msgstr "总是使用此程序"
 
-#: ../checkout_dlg.cpp:92
-#: ../export_dlg.cpp:95
-#: ../rapidsvn_generated.cpp:259
-#: ../rapidsvn_generated.cpp:299
-#: ../rapidsvn_generated.cpp:534
-#: ../switch_dlg.cpp:103
-#: ../update_dlg.cpp:100
+#: ../rapidsvn_generated.cpp:257 ../rapidsvn_generated.cpp:723
+#: ../rapidsvn_generated.cpp:761 ../rapidsvn_generated.cpp:969
+#: ../rapidsvn_generated.cpp:1813 ../rapidsvn_generated.cpp:1911
 msgid "Use latest"
 msgstr "使用最新版本"
 
-#: ../auth_dlg.cpp:54
-#: ../log_dlg.cpp:164
+#: ../log_rev_list.cpp:38
 msgid "User"
 msgstr "用户名"
 
-#: ../cert_dlg.cpp:115
+#: ../rapidsvn_generated.cpp:167
 msgid "Valid from:"
 msgstr "有效起始日期:"
 
-#: ../cert_dlg.cpp:119
+#: ../rapidsvn_generated.cpp:175
 msgid "Valid until:"
 msgstr "有效结束日期:"
 
-#: ../listed_dlg.cpp:80
-#: ../listed_dlg.cpp:172
-#: ../listed_dlg.cpp:324
+#: ../listed_dlg.cpp:70 ../listed_dlg.cpp:182
 msgid "Value"
 msgstr "值"
 
@@ -2040,11 +1892,29 @@ msgstr "值"
 msgid "View"
 msgstr "查看"
 
-#: ../rapidsvn_generated.cpp:696
+#: ../listed_dlg.cpp:355
+#, fuzzy
+msgid "View..."
+msgstr "查看(&V)..."
+
+#: ../rapidsvn_generated.cpp:567
 msgid "WARNING"
 msgstr ""
 
-#: ../dnd_dlg.cpp:69
+#: ../dnd_dlg.cpp:48
+#, c-format
+msgid ""
+"Would you like to copy\n"
+"\n"
+"\n"
+"  %s\n"
+"\n"
+"into\n"
+"\n"
+"  %s?"
+msgstr ""
+
+#: ../dnd_dlg.cpp:39
 #, c-format
 msgid ""
 "Would you like to move or copy\n"
@@ -2057,34 +1927,27 @@ msgid ""
 "  %s?"
 msgstr ""
 
-#: ../revert_dlg.cpp:54
-msgid "Yes"
-msgstr ""
-
-#: ../main_frame.cpp:1863
+#: ../main_frame.cpp:2051
 msgid "You cannot add a subversion administrative directory to the bookmarks!"
 msgstr "您不能把 Subversion 的管理目录添加到书签中!"
 
-#: ../file_info.cpp:150
-#: ../filelist_ctrl.cpp:1261
+#: ../file_info.cpp:150 ../filelist_ctrl.cpp:1267
 msgid "add"
 msgstr "添加"
 
-#: ../filelist_ctrl.cpp:1226
-#: ../utils.cpp:398
+#: ../filelist_ctrl.cpp:1232 ../utils.cpp:408
 msgid "added"
 msgstr "已添加"
 
-#: ../utils.cpp:416
+#: ../utils.cpp:426
 msgid "conflicted"
 msgstr "存在冲突"
 
-#: ../file_info.cpp:154
-#: ../filelist_ctrl.cpp:1264
+#: ../file_info.cpp:154 ../filelist_ctrl.cpp:1270
 msgid "delete"
 msgstr "删除"
 
-#: ../utils.cpp:404
+#: ../utils.cpp:414
 msgid "deleted"
 msgstr "已删除"
 
@@ -2092,7 +1955,7 @@ msgstr "已删除"
 msgid "directory"
 msgstr "目录"
 
-#: ../utils.cpp:422
+#: ../utils.cpp:432
 msgid "external"
 msgstr "外部"
 
@@ -2100,69 +1963,67 @@ msgstr "外部"
 msgid "file"
 msgstr "文件"
 
-#: ../utils.cpp:428
+#: ../utils.cpp:438
 msgid "ignored"
 msgstr "已忽略"
 
-#: ../utils.cpp:425
+#: ../utils.cpp:435
 msgid "incomplete"
 msgstr "不完整"
 
-#: ../utils.cpp:413
+#: ../utils.cpp:423
 msgid "merged"
 msgstr "已合并"
 
-#: ../utils.cpp:401
+#: ../utils.cpp:411
 msgid "missing"
 msgstr "丢失"
 
-#: ../filelist_ctrl.cpp:1229
-#: ../utils.cpp:410
+#: ../filelist_ctrl.cpp:1235 ../utils.cpp:420
 msgid "modified"
 msgstr "已修改"
 
-#: ../export_dlg.cpp:135
-#: ../export_dlg.cpp:140
+#: ../rapidsvn_generated.cpp:1165
+msgid "more"
+msgstr ""
+
+#: ../rapidsvn_generated.cpp:992
 msgid "native"
 msgstr "原生"
 
-#: ../file_info.cpp:132
-#: ../utils.cpp:389
+#: ../file_info.cpp:132 ../utils.cpp:399
 msgid "none"
 msgstr "无"
 
-#: ../file_info.cpp:146
-#: ../utils.cpp:395
+#: ../file_info.cpp:146 ../utils.cpp:405
 msgid "normal"
 msgstr "常规"
 
-#: ../utils.cpp:419
+#: ../utils.cpp:429
 msgid "obstructed"
 msgstr "阻塞"
 
-#: ../filelist_ctrl.cpp:1294
-#: ../filelist_ctrl.cpp:1308
+#: ../filelist_ctrl.cpp:1300 ../filelist_ctrl.cpp:1314
 msgid "outdated"
 msgstr "过时"
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.4"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.5"
 msgstr ""
 
-#: ../rapidsvn_generated.cpp:659
+#: ../rapidsvn_generated.cpp:532
 msgid "pre Subversion 1.6"
 msgstr ""
 
-#: ../file_info.cpp:158
-#: ../filelist_ctrl.cpp:1267
+#: ../file_info.cpp:158 ../filelist_ctrl.cpp:1273
 msgid "replace"
 msgstr "替换"
 
-#: ../utils.cpp:407
+#: ../utils.cpp:417
 msgid "replaced"
 msgstr "已替换"
 
@@ -2170,22 +2031,119 @@ msgstr "已替换"
 msgid "svnadmin could not be found"
 msgstr "找不到svnadmin"
 
-#: ../file_info.cpp:137
-#: ../file_info.cpp:162
+#: ../file_info.cpp:137 ../file_info.cpp:162
 msgid "unknown"
 msgstr "未知"
 
-#: ../utils.cpp:430
+#: ../utils.cpp:440
 msgid "unknown value"
 msgstr "未知值"
 
-#: ../utils.cpp:392
+#: ../utils.cpp:402
 msgid "unversioned"
 msgstr "不在版本控制中"
 
-#: ../main_frame.cpp:329
-msgid "wxString Creation&Tracing Test"
-msgstr "wxString 创建和追踪测试"
+#~ msgid "Action"
+#~ msgstr "动作"
+
+#~ msgid "Checkout Test"
+#~ msgstr "签出测试"
+
+#~ msgid "Copied from Path"
+#~ msgstr "已复制, 来自 URL:"
+
+#~ msgid "Copied from Rev"
+#~ msgstr "已复制, 来自版本:"
+
+#~ msgid "Destination file"
+#~ msgstr "目标文件"
+
+#~ msgid "Destination path"
+#~ msgstr "目标路径"
+
+#~ msgid "EOL:"
+#~ msgstr "换行符:"
+
+#~ msgid "Enter log message"
+#~ msgstr "请输入历史记录信息"
+
+#~ msgid "Enter the local path where you want the code be exported."
+#~ msgstr "请输入用于导出代码的本地路径"
+
+#~ msgid ""
+#~ "Enter what kind of symbol(s) do you want as EOL (end of line) in exported "
+#~ "files."
+#~ msgstr "请输入要用作导出文件的换行符(EOL)的符号."
+
+#~ msgid "File path required when importing a file!"
+#~ msgstr "导入文件时必须填写文件路径!"
+
+#~ msgid "First path or URL is required for merge!"
+#~ msgstr "合并的第一个路径或  URL 必须填写!"
+
+#~ msgid ""
+#~ "Invalid selection. At least one revisions is needed for diff and no more "
+#~ "than two."
+#~ msgstr "选择无效. 至少要指定一个版本才能进行比较."
+
+#~ msgid "Invalid selection. Exactly two revisions needed for merge."
+#~ msgstr "选择无效. 必须指定要合并的两个版本."
+
+#~ msgid "Invalid selection. Only one revision may be selected for annotate"
+#~ msgstr "选择无效. 一次只能评注一个版本."
+
+#~ msgid "Listener Test"
+#~ msgstr "Listener 测试"
+
+#~ msgid "Locate help"
+#~ msgstr "定位帮助文件"
+
+#~ msgid "Locate tips"
+#~ msgstr "定位技巧提示文件"
+
+#~ msgid "Locate tips file"
+#~ msgstr "定位帮助技巧文件"
+
+#~ msgid "Log Message:"
+#~ msgstr "历史记录信息:"
+
+#~ msgid "Merge revisions"
+#~ msgstr "合并版本"
+
+#~ msgid ""
+#~ "No help file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "没有选定帮助文件.\n"
+#~ "您希望在下次程序启动时再次提示此信息吗?"
+
+#~ msgid ""
+#~ "No tips file was chosen, would you like to be \n"
+#~ "asked again after next application start?"
+#~ msgstr ""
+#~ "没有选定帮助提示文件.\n"
+#~ "您希望在下次程序启动时再次提示此信息吗?"
+
+#~ msgid "RapidSVN Help: %s"
+#~ msgstr "RapidSVN 帮助: %s"
+
+#~ msgid "Revision must be an unsigned number!"
+#~ msgstr "版本号必须为正整数!"
+
+#~ msgid "SSL Certificate"
+#~ msgstr "SSL 证书"
+
+#~ msgid "Second path or URL is required for merge!"
+#~ msgstr "合并的第二个路径或  URL 必须填写!"
+
+#~ msgid "Second working copy or URL"
+#~ msgstr "第二个工作副本或 URL"
+
+#~ msgid "Tree"
+#~ msgstr "树"
+
+#~ msgid "wxString Creation&Tracing Test"
+#~ msgstr "wxString 创建和追踪测试"
 
 #~ msgid "Information"
 #~ msgstr "信息"

--- a/librapidsvn/src/log_action.cpp
+++ b/librapidsvn/src/log_action.cpp
@@ -26,6 +26,8 @@
 #include "wx/wx.h"
 #include "wx/intl.h"
 
+#include <algorithm>
+
 // svncpp
 #include "svncpp/client.hpp"
 #include "svncpp/info.hpp"
@@ -35,9 +37,94 @@
 
 // app
 #include "action_event.hpp"
+#include "utils.hpp"
 #include "ids.hpp"
 #include "log_action.hpp"
 #include "log_data.hpp"
+
+
+/* static */ int LogAction::LogLimit = 50;
+
+struct LogNextAction::Data
+{
+private:
+  Action * action;
+
+public:
+  LogNextData data;
+  wxWindow * parent;
+
+  Data(Action * action_)
+      : action(action_)
+  {
+  }
+
+  Data(Action * action_, LogNextData & data_)
+      : action(action_), data(data_)
+  {
+  }
+
+  svn::Context *
+  GetContext()
+  {
+    return action->GetContext();
+  }
+
+  void
+  GetLogNext(svn::LogEntries& logEntriesNext)
+  {
+  }
+};
+
+
+LogNextAction::LogNextAction(wxWindow * parent,
+                             LogNextData & data)
+    : Action(parent, _("Log"), UPDATE_LATER)
+{
+  m = new Data(this, data);
+  m->parent = parent;
+}
+
+LogNextAction::~LogNextAction()
+{
+  delete m;
+}
+
+bool
+LogNextAction::Perform()
+{
+  // wxBusyCursor busyCursor;
+  
+  svn::Client client(GetContext());
+
+  svn::Path path = PathUtf8(m->data.path);
+  svn::Path target = GetTarget();
+
+  svn::LogEntries * entries = const_cast<svn::LogEntries *>(client.log(target.c_str(), m->data.startRevision,
+                                                                       svn::Revision::START, LogAction::LogLimit, true, false));
+  std::reverse(entries->begin(), entries->end());
+    
+  LogNextData * data = new LogNextData(m->data.path, m->data.startRevision,
+                                       svn::Revision::HEAD, m->data.logdlg,
+                                       (svn::LogEntries *) entries);
+  ActionEvent::Post(GetParent(), TOKEN_LOG_NEXT_CALLBACK, data);
+
+  return true;
+}
+
+bool
+LogNextAction::CheckStatusSel(const svn::StatusSel & statusSel)
+{
+  if (1 != statusSel.size())
+    return false;
+
+  if (statusSel.hasUnversioned())
+    return false;
+
+  return true;
+}
+
+// ===============================================================================================
 
 LogAction::LogAction(wxWindow * parent)
     : Action(parent, _("Log"), DONT_UPDATE)
@@ -50,10 +137,10 @@ LogAction::Perform()
   svn::Client client(GetContext());
 
   svn::Path target = GetTarget();
-  const svn::LogEntries * entries =
-    client.log(target.c_str(), svn::Revision::START,
-               svn::Revision::HEAD, true, false);
-
+  svn::LogEntries * entries = const_cast<svn::LogEntries *>(client.log(target.c_str(), svn::Revision::HEAD,
+                                                            svn::Revision::START, LogLimit, true, false));
+  std::reverse(entries->begin(), entries->end());
+  
   LogData * data = new LogData(entries, CreateRepositoryPath(client, target));
   ActionEvent::Post(GetParent(), TOKEN_LOG, data);
 

--- a/librapidsvn/src/log_action.cpp
+++ b/librapidsvn/src/log_action.cpp
@@ -43,7 +43,7 @@
 #include "log_data.hpp"
 
 
-/* static */ int LogAction::LogLimit = 50;
+/* static */ int LogAction::LogLimit = 30;
 
 struct LogNextAction::Data
 {
@@ -94,16 +94,16 @@ bool
 LogNextAction::Perform()
 {
   // wxBusyCursor busyCursor;
-  
+
   svn::Client client(GetContext());
 
   svn::Path path = PathUtf8(m->data.path);
   svn::Path target = GetTarget();
 
   svn::LogEntries * entries = const_cast<svn::LogEntries *>(client.log(target.c_str(), m->data.startRevision,
-                                                                       svn::Revision::START, LogAction::LogLimit, true, false));
+                                                                       svn::Revision::START, LogAction::LogLimit + 1, true, false));
   std::reverse(entries->begin(), entries->end());
-    
+
   LogNextData * data = new LogNextData(m->data.path, m->data.startRevision,
                                        svn::Revision::HEAD, m->data.logdlg,
                                        (svn::LogEntries *) entries);
@@ -138,9 +138,9 @@ LogAction::Perform()
 
   svn::Path target = GetTarget();
   svn::LogEntries * entries = const_cast<svn::LogEntries *>(client.log(target.c_str(), svn::Revision::HEAD,
-                                                            svn::Revision::START, LogLimit, true, false));
+                                                            svn::Revision::START, LogLimit + 1, true, false));
   std::reverse(entries->begin(), entries->end());
-  
+
   LogData * data = new LogData(entries, CreateRepositoryPath(client, target));
   ActionEvent::Post(GetParent(), TOKEN_LOG, data);
 

--- a/librapidsvn/src/log_dlg.cpp
+++ b/librapidsvn/src/log_dlg.cpp
@@ -47,17 +47,18 @@
 #include "merge_dlg.hpp"
 #include "utils.hpp"
 #include "annotate_data.hpp"
+#include "log_action.hpp"
 
 struct LogDlg::Data
 {
 public:
-  const svn::LogEntries * entries;
+  svn::LogEntries * entries;
   wxString path;
   svn::RepositoryPath repositoryPath;
 
 public:
   Data(const svn::RepositoryPath & path_,
-       const svn::LogEntries * entries_)
+       svn::LogEntries * entries_)
       : entries(entries_), path(Utf8ToLocal(path_.c_str())), repositoryPath(path_)
   {
   }
@@ -66,7 +67,7 @@ public:
 
 LogDlg::LogDlg(wxWindow * parent,
                const svn::RepositoryPath & path,
-               const svn::LogEntries * entries)
+               svn::LogEntries * entries)
     : LogDlgBase(parent, -1, _("Log History"), wxDefaultPosition,
                  parent->GetSize(), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX)
 {
@@ -76,6 +77,8 @@ LogDlg::LogDlg(wxWindow * parent,
     wxString::Format(_("History: %d revisions"), entries->size()));
 
   m_listRevisions->SetEntries(entries);
+
+  m_buttonMore->Enable((entries->size() == LogAction::LogLimit));
 
   CheckControls();
 
@@ -98,6 +101,26 @@ LogDlg::LogDlg(wxWindow * parent,
 LogDlg::~LogDlg()
 {
   m_listFiles->Disconnect(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(LogDlg::OnAffectedFileOrDirCommand), NULL, this);
+}
+
+void
+LogDlg::NextLogEntriesCallback(svn::LogEntries* nextLogEntries)
+{
+  AddLogEntries(nextLogEntries);
+}
+
+void
+LogDlg::AddLogEntries(svn::LogEntries* logEntries)
+{
+  svn::LogEntries::iterator iter;
+  for(iter = logEntries->begin(); iter != logEntries->end(); ++iter)
+  {
+      const svn::LogEntry & entry = *iter;
+      m->entries->push_back(entry);
+  }
+  m_listRevisions->AddEntriesToList(logEntries);
+
+  m_buttonMore->Enable((logEntries->size() == LogAction::LogLimit));
 }
 
 void
@@ -164,6 +187,8 @@ LogDlg::OnDiff(wxString & path, bool singleItemDiff)
     svn_revnum_t revnumPrior = m_listRevisions->GetPriorRevision(array[0]);
     if(revnumPrior != -1)
     {
+      data = new DiffData();
+      data->path = path;
       data->compareType = DiffData::TWO_REVISIONS;
       data->revision1 = svn::Revision(array[0]);
       data->revision2 = svn::Revision(revnumPrior);
@@ -214,6 +239,28 @@ LogDlg::OnAnnotate(wxString & path)
   data->endRevision = svn::Revision(array[0]);
 
   ActionEvent::Post(GetParent(), TOKEN_ANNOTATE, data);
+}
+
+void
+LogDlg::OnMore(wxCommandEvent & WXUNUSED(event))
+{
+  OnMore(m->path);
+}
+
+void
+LogDlg::OnMore(wxString & path)
+{
+  svn_revnum_t revnum = m_listRevisions->GetLastRevision();
+  if(revnum == -1)
+      return;
+
+  m_buttonMore->Enable(false);
+
+  svn::Revision revisionStart(revnum - 1);
+
+  LogNextData * data = new LogNextData(path, svn::Revision(revisionStart), svn::Revision::HEAD, (LogDlg*)this);
+
+  ActionEvent::Post(GetParent(), TOKEN_LOG_NEXT, data);
 }
 
 void
@@ -281,6 +328,10 @@ LogDlg::UpdateSelection()
   else
   {
     long itemIndex = m_listRevisions->GetFirstSelected();
+    if(itemIndex < 0 || itemIndex >= m->entries->size())
+    {
+      return;
+    }
     const svn::LogEntry & entry = (*m->entries)[itemIndex];
 
     wxString message(Utf8ToLocal(entry.message.c_str()));

--- a/librapidsvn/src/log_rev_list.cpp
+++ b/librapidsvn/src/log_rev_list.cpp
@@ -51,7 +51,7 @@ LogRevList::~LogRevList()
 }
 
 void
-LogRevList::SetEntries(const svn::LogEntries * entries)
+LogRevList::SetEntries(svn::LogEntries * entries)
 {
   DeleteAllItems();
 
@@ -62,7 +62,7 @@ LogRevList::SetEntries(const svn::LogEntries * entries)
 }
 
 void
-LogRevList::AddEntriesToList(const svn::LogEntries * entries)
+LogRevList::AddEntriesToList(svn::LogEntries * entries)
 {
   if (entries == 0)
     return;

--- a/librapidsvn/src/log_rev_list.cpp
+++ b/librapidsvn/src/log_rev_list.cpp
@@ -51,7 +51,7 @@ LogRevList::~LogRevList()
 }
 
 void
-LogRevList::SetEntries(svn::LogEntries * entries)
+LogRevList::SetEntries(const svn::LogEntries * entries)
 {
   DeleteAllItems();
 
@@ -62,7 +62,7 @@ LogRevList::SetEntries(svn::LogEntries * entries)
 }
 
 void
-LogRevList::AddEntriesToList(svn::LogEntries * entries)
+LogRevList::AddEntriesToList(const svn::LogEntries * entries)
 {
   if (entries == 0)
     return;

--- a/librapidsvn/src/main_frame.cpp
+++ b/librapidsvn/src/main_frame.cpp
@@ -70,6 +70,7 @@
 #include "drag_n_drop_action.hpp"
 #include "external_program_action.hpp"
 #include "mkdir_action.hpp"
+#include "log_action.hpp"
 
 #ifdef USE_SIMPLE_WORKER
 #include "simple_worker.hpp"
@@ -86,6 +87,7 @@
 #include "preferences_dlg.hpp"
 #include "update_dlg.hpp"
 #include "log_dlg.hpp"
+
 
 #include "main_frame.hpp"
 #include "main_frame_helper.hpp"
@@ -1887,11 +1889,44 @@ MainFrame::OnActionEvent(wxCommandEvent & event)
 
     if (pData != 0)
     {
-      LogDlg dlg(this, pData->target, pData->logEntries);
+      LogDlg dlg(this, pData->target, const_cast<svn::LogEntries*>(pData->logEntries));
       dlg.ShowModal();
 
       delete pData->logEntries;
       delete pData;
+    }
+  }
+  break;
+  case TOKEN_LOG_NEXT:
+  {
+    LogNextData * pData = static_cast<LogNextData *>(event.GetClientData());
+
+    if (pData != 0)
+    {
+      // copy and delete data
+      LogNextData data(*pData);
+      delete pData;
+      Action * action;
+
+      action = new LogNextAction(this, data);
+      Perform(action);
+    }
+  }
+  break;
+  case TOKEN_LOG_NEXT_CALLBACK:
+  {
+    LogNextData * pData = static_cast<LogNextData *>(event.GetClientData());
+
+    if (pData != 0)
+    {
+      // copy and delete data
+      LogNextData data(*pData);
+      delete pData;
+
+      if(data.logdlg != NULL && data.logEntries != NULL)
+      {
+        data.logdlg->NextLogEntriesCallback(data.logEntries);
+      }
     }
   }
   break;

--- a/librapidsvn/src/rapidsvn.fbp
+++ b/librapidsvn/src/rapidsvn.fbp
@@ -9932,6 +9932,63 @@
                                                     <event name="OnUpdateUI"></event>
                                                 </object>
                                             </object>
+                                            <object class="sizeritem" expanded="0">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxEXPAND</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxButton" expanded="0">
+                                                    <property name="bg"></property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="default">0</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="font"></property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="label">more</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="name">m_buttonMore</property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="pos"></property>
+                                                    <property name="size">-1,20</property>
+                                                    <property name="style"></property>
+                                                    <property name="subclass"></property>
+                                                    <property name="tooltip"></property>
+                                                    <property name="validator_data_type"></property>
+                                                    <property name="validator_style">wxFILTER_NONE</property>
+                                                    <property name="validator_type">wxDefaultValidator</property>
+                                                    <property name="validator_variable"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                    <event name="OnButtonClick">OnMore</event>
+                                                    <event name="OnChar"></event>
+                                                    <event name="OnEnterWindow"></event>
+                                                    <event name="OnEraseBackground"></event>
+                                                    <event name="OnKeyDown"></event>
+                                                    <event name="OnKeyUp"></event>
+                                                    <event name="OnKillFocus"></event>
+                                                    <event name="OnLeaveWindow"></event>
+                                                    <event name="OnLeftDClick"></event>
+                                                    <event name="OnLeftDown"></event>
+                                                    <event name="OnLeftUp"></event>
+                                                    <event name="OnMiddleDClick"></event>
+                                                    <event name="OnMiddleDown"></event>
+                                                    <event name="OnMiddleUp"></event>
+                                                    <event name="OnMotion"></event>
+                                                    <event name="OnMouseEvents"></event>
+                                                    <event name="OnMouseWheel"></event>
+                                                    <event name="OnPaint"></event>
+                                                    <event name="OnRightDClick"></event>
+                                                    <event name="OnRightDown"></event>
+                                                    <event name="OnRightUp"></event>
+                                                    <event name="OnSetFocus"></event>
+                                                    <event name="OnSize"></event>
+                                                    <event name="OnUpdateUI"></event>
+                                                </object>
+                                            </object>
                                         </object>
                                     </object>
                                     <object class="sizeritem" expanded="1">

--- a/librapidsvn/src/rapidsvn_generated.cpp
+++ b/librapidsvn/src/rapidsvn_generated.cpp
@@ -16,38 +16,38 @@
 
 AboutDlgBase::AboutDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	topSizer = new wxFlexGridSizer( 2, 2, 10, 10 );
-	topSizer->SetFlexibleDirection( wxBOTH );
-	topSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
-	m_bitmapLogo = new wxStaticBitmap( this, wxID_ANY, wxNullBitmap, wxDefaultPosition, wxDefaultSize, 0 );
-	topSizer->Add( m_bitmapLogo, 0, wxALL, 5 );
-	
-	m_staticCopy = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticCopy->Wrap( -1 );
-	topSizer->Add( m_staticCopy, 1, wxALL|wxEXPAND, 5 );
-	
-	m_staticBuilt = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticBuilt->Wrap( -1 );
-	topSizer->Add( m_staticBuilt, 0, wxALL, 5 );
-	
-	m_staticInfo = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticInfo->Wrap( -1 );
-	topSizer->Add( m_staticInfo, 0, wxALL, 5 );
-	
-	m_mainSizer->Add( topSizer, 0, wxEXPAND, 5 );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	m_mainSizer->Add( m_buttonOK, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	m_mainSizer->Fit( this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    topSizer = new wxFlexGridSizer( 2, 2, 10, 10 );
+    topSizer->SetFlexibleDirection( wxBOTH );
+    topSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    
+    m_bitmapLogo = new wxStaticBitmap( this, wxID_ANY, wxNullBitmap, wxDefaultPosition, wxDefaultSize, 0 );
+    topSizer->Add( m_bitmapLogo, 0, wxALL, 5 );
+    
+    m_staticCopy = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticCopy->Wrap( -1 );
+    topSizer->Add( m_staticCopy, 1, wxALL|wxEXPAND, 5 );
+    
+    m_staticBuilt = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticBuilt->Wrap( -1 );
+    topSizer->Add( m_staticBuilt, 0, wxALL, 5 );
+    
+    m_staticInfo = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticInfo->Wrap( -1 );
+    topSizer->Add( m_staticInfo, 0, wxALL, 5 );
+    
+    m_mainSizer->Add( topSizer, 0, wxEXPAND, 5 );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    m_mainSizer->Add( m_buttonOK, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    m_mainSizer->Fit( this );
 }
 
 AboutDlgBase::~AboutDlgBase()
@@ -56,19 +56,19 @@ AboutDlgBase::~AboutDlgBase()
 
 AnnotateDlgBase::AnnotateDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_list = new wxListCtrl( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_REPORT );
-	m_mainSizer->Add( m_list, 1, wxALL|wxEXPAND, 5 );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	m_mainSizer->Add( m_buttonOK, 0, wxALIGN_CENTER|wxALL, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_list = new wxListCtrl( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_REPORT );
+    m_mainSizer->Add( m_list, 1, wxALL|wxEXPAND, 5 );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    m_mainSizer->Add( m_buttonOK, 0, wxALIGN_CENTER|wxALL, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
 }
 
 AnnotateDlgBase::~AnnotateDlgBase()
@@ -77,45 +77,45 @@ AnnotateDlgBase::~AnnotateDlgBase()
 
 AuthDlgBase::AuthDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	authSizer = new wxFlexGridSizer( 2, 2, 5, 5 );
-	authSizer->AddGrowableCol( 1 );
-	authSizer->SetFlexibleDirection( wxHORIZONTAL );
-	authSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
-	m_staticUsername = new wxStaticText( this, wxID_ANY, _("&Username"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticUsername->Wrap( -1 );
-	authSizer->Add( m_staticUsername, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_textUsername = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	authSizer->Add( m_textUsername, 1, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5 );
-	
-	m_staticPassword = new wxStaticText( this, wxID_ANY, _("&Password"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticPassword->Wrap( -1 );
-	authSizer->Add( m_staticPassword, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_textPassword = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PASSWORD );
-	authSizer->Add( m_textPassword, 1, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5 );
-	
-	m_mainSizer->Add( authSizer, 0, wxEXPAND, 5 );
-	
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	m_mainSizer->Fit( this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    authSizer = new wxFlexGridSizer( 2, 2, 5, 5 );
+    authSizer->AddGrowableCol( 1 );
+    authSizer->SetFlexibleDirection( wxHORIZONTAL );
+    authSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    
+    m_staticUsername = new wxStaticText( this, wxID_ANY, _("&Username"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticUsername->Wrap( -1 );
+    authSizer->Add( m_staticUsername, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_textUsername = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    authSizer->Add( m_textUsername, 1, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5 );
+    
+    m_staticPassword = new wxStaticText( this, wxID_ANY, _("&Password"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticPassword->Wrap( -1 );
+    authSizer->Add( m_staticPassword, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_textPassword = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PASSWORD );
+    authSizer->Add( m_textPassword, 1, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5 );
+    
+    m_mainSizer->Add( authSizer, 0, wxEXPAND, 5 );
+    
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    m_mainSizer->Fit( this );
 }
 
 AuthDlgBase::~AuthDlgBase()
@@ -124,517 +124,517 @@ AuthDlgBase::~AuthDlgBase()
 
 CertDlgBase::CertDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticTitle = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticTitle->Wrap( -1 );
-	m_mainSizer->Add( m_staticTitle, 0, wxALL, 5 );
-	
-	m_sizerFailures = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("MyLabel") ), wxVERTICAL );
-	
-	m_staticFailures = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticFailures->Wrap( -1 );
-	m_sizerFailures->Add( m_staticFailures, 0, wxALL, 5 );
-	
-	m_mainSizer->Add( m_sizerFailures, 0, wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* sizerCert;
-	sizerCert = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Certificate information:") ), wxVERTICAL );
-	
-	wxFlexGridSizer* fgSizerFailures;
-	fgSizerFailures = new wxFlexGridSizer( 2, 2, 0, 0 );
-	fgSizerFailures->SetFlexibleDirection( wxBOTH );
-	fgSizerFailures->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
-	m_labelHostname = new wxStaticText( this, wxID_ANY, _("Hostname:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_labelHostname->Wrap( -1 );
-	fgSizerFailures->Add( m_labelHostname, 0, wxALL, 5 );
-	
-	m_staticHostname = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticHostname->Wrap( -1 );
-	fgSizerFailures->Add( m_staticHostname, 0, wxALL, 5 );
-	
-	m_labelIssuer = new wxStaticText( this, wxID_ANY, _("Issuer:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_labelIssuer->Wrap( -1 );
-	fgSizerFailures->Add( m_labelIssuer, 0, wxALL, 5 );
-	
-	m_staticIssuer = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticIssuer->Wrap( -1 );
-	fgSizerFailures->Add( m_staticIssuer, 0, wxALL, 5 );
-	
-	m_labelValidFrom = new wxStaticText( this, wxID_ANY, _("Valid from:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_labelValidFrom->Wrap( -1 );
-	fgSizerFailures->Add( m_labelValidFrom, 0, wxALL, 5 );
-	
-	m_staticValidFrom = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticValidFrom->Wrap( -1 );
-	fgSizerFailures->Add( m_staticValidFrom, 0, wxALL, 5 );
-	
-	m_labelValidUntil = new wxStaticText( this, wxID_ANY, _("Valid until:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_labelValidUntil->Wrap( -1 );
-	fgSizerFailures->Add( m_labelValidUntil, 0, wxALL, 5 );
-	
-	m_staticValidUntil = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticValidUntil->Wrap( -1 );
-	fgSizerFailures->Add( m_staticValidUntil, 0, wxALL, 5 );
-	
-	m_labelFingerprint = new wxStaticText( this, wxID_ANY, _("Fingerprint:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_labelFingerprint->Wrap( -1 );
-	fgSizerFailures->Add( m_labelFingerprint, 0, wxALL, 5 );
-	
-	m_staticFingerprint = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticFingerprint->Wrap( -1 );
-	fgSizerFailures->Add( m_staticFingerprint, 0, wxALL, 5 );
-	
-	sizerCert->Add( fgSizerFailures, 1, wxEXPAND, 5 );
-	
-	m_mainSizer->Add( sizerCert, 1, wxEXPAND, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonPerm = new wxButton( this, wxID_ANY, _("&Permanently"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonPerm, 0, wxALL, 5 );
-	
-	m_buttonTemp = new wxButton( this, wxID_ANY, _("&Temporarily"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonTemp, 0, wxALL, 5 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonCancel->SetDefault(); 
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 5 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	
-	// Connect Events
-	m_buttonPerm->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CertDlgBase::OnPerm ), NULL, this );
-	m_buttonTemp->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CertDlgBase::OnTemp ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_staticTitle = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticTitle->Wrap( -1 );
+    m_mainSizer->Add( m_staticTitle, 0, wxALL, 5 );
+    
+    m_sizerFailures = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("MyLabel") ), wxVERTICAL );
+    
+    m_staticFailures = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticFailures->Wrap( -1 );
+    m_sizerFailures->Add( m_staticFailures, 0, wxALL, 5 );
+    
+    m_mainSizer->Add( m_sizerFailures, 0, wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* sizerCert;
+    sizerCert = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Certificate information:") ), wxVERTICAL );
+    
+    wxFlexGridSizer* fgSizerFailures;
+    fgSizerFailures = new wxFlexGridSizer( 2, 2, 0, 0 );
+    fgSizerFailures->SetFlexibleDirection( wxBOTH );
+    fgSizerFailures->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    
+    m_labelHostname = new wxStaticText( this, wxID_ANY, _("Hostname:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_labelHostname->Wrap( -1 );
+    fgSizerFailures->Add( m_labelHostname, 0, wxALL, 5 );
+    
+    m_staticHostname = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticHostname->Wrap( -1 );
+    fgSizerFailures->Add( m_staticHostname, 0, wxALL, 5 );
+    
+    m_labelIssuer = new wxStaticText( this, wxID_ANY, _("Issuer:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_labelIssuer->Wrap( -1 );
+    fgSizerFailures->Add( m_labelIssuer, 0, wxALL, 5 );
+    
+    m_staticIssuer = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticIssuer->Wrap( -1 );
+    fgSizerFailures->Add( m_staticIssuer, 0, wxALL, 5 );
+    
+    m_labelValidFrom = new wxStaticText( this, wxID_ANY, _("Valid from:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_labelValidFrom->Wrap( -1 );
+    fgSizerFailures->Add( m_labelValidFrom, 0, wxALL, 5 );
+    
+    m_staticValidFrom = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticValidFrom->Wrap( -1 );
+    fgSizerFailures->Add( m_staticValidFrom, 0, wxALL, 5 );
+    
+    m_labelValidUntil = new wxStaticText( this, wxID_ANY, _("Valid until:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_labelValidUntil->Wrap( -1 );
+    fgSizerFailures->Add( m_labelValidUntil, 0, wxALL, 5 );
+    
+    m_staticValidUntil = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticValidUntil->Wrap( -1 );
+    fgSizerFailures->Add( m_staticValidUntil, 0, wxALL, 5 );
+    
+    m_labelFingerprint = new wxStaticText( this, wxID_ANY, _("Fingerprint:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_labelFingerprint->Wrap( -1 );
+    fgSizerFailures->Add( m_labelFingerprint, 0, wxALL, 5 );
+    
+    m_staticFingerprint = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticFingerprint->Wrap( -1 );
+    fgSizerFailures->Add( m_staticFingerprint, 0, wxALL, 5 );
+    
+    sizerCert->Add( fgSizerFailures, 1, wxEXPAND, 5 );
+    
+    m_mainSizer->Add( sizerCert, 1, wxEXPAND, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonPerm = new wxButton( this, wxID_ANY, _("&Permanently"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonPerm, 0, wxALL, 5 );
+    
+    m_buttonTemp = new wxButton( this, wxID_ANY, _("&Temporarily"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonTemp, 0, wxALL, 5 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonCancel->SetDefault(); 
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 5 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    
+    // Connect Events
+    m_buttonPerm->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CertDlgBase::OnPerm ), NULL, this );
+    m_buttonTemp->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CertDlgBase::OnTemp ), NULL, this );
 }
 
 CertDlgBase::~CertDlgBase()
 {
-	// Disconnect Events
-	m_buttonPerm->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CertDlgBase::OnPerm ), NULL, this );
-	m_buttonTemp->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CertDlgBase::OnTemp ), NULL, this );
+    // Disconnect Events
+    m_buttonPerm->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CertDlgBase::OnPerm ), NULL, this );
+    m_buttonTemp->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CertDlgBase::OnTemp ), NULL, this );
 }
 
 CheckoutDlgBase::CheckoutDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	this->SetExtraStyle( wxDIALOG_EX_CONTEXTHELP );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	wxStaticBoxSizer* urlSizer;
-	urlSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("URL") ), wxVERTICAL );
-	
-	m_comboUrl = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, 0 ); 
-	urlSizer->Add( m_comboUrl, 0, wxALL|wxEXPAND, 5 );
-	
-	m_mainSizer->Add( urlSizer, 0, wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* destSizer;
-	destSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Destination Directory") ), wxHORIZONTAL );
-	
-	m_comboDest = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 205,-1 ), 0, NULL, 0 ); 
-	destSizer->Add( m_comboDest, 1, wxALL, 5 );
-	
-	m_buttonBrowse = new wxButton( this, wxID_ANY, _("..."), wxDefaultPosition, wxSize( 20,-1 ), 0 );
-	destSizer->Add( m_buttonBrowse, 0, wxALL, 5 );
-	
-	m_mainSizer->Add( destSizer, 0, wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* revisionSizer;
-	revisionSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision") ), wxHORIZONTAL );
-	
-	m_textRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), 0 );
-	revisionSizer->Add( m_textRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_checkUseLatest = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
-	revisionSizer->Add( m_checkUseLatest, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_mainSizer->Add( revisionSizer, 0, wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* pegSizer;
-	pegSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Peg Revision") ), wxHORIZONTAL );
-	
-	m_textPegRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), 0 );
-	pegSizer->Add( m_textPegRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_checkPegNotSpecified = new wxCheckBox( this, wxID_ANY, _("Not specified"), wxDefaultPosition, wxDefaultSize, 0 );
-	pegSizer->Add( m_checkPegNotSpecified, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_mainSizer->Add( pegSizer, 0, wxEXPAND, 5 );
-	
-	wxBoxSizer* extrasSizer;
-	extrasSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_checkAddToBookmarks = new wxCheckBox( this, wxID_ANY, _("Add to bookmarks"), wxDefaultPosition, wxDefaultSize, 0 );
-	extrasSizer->Add( m_checkAddToBookmarks, 0, wxALL, 5 );
-	
-	m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
-	extrasSizer->Add( m_checkRecursive, 0, wxALL, 5 );
-	
-	m_checkIgnoreExternals = new wxCheckBox( this, wxID_ANY, _("Ignore externals"), wxDefaultPosition, wxDefaultSize, 0 );
-	extrasSizer->Add( m_checkIgnoreExternals, 0, wxALL, 5 );
-	
-	m_mainSizer->Add( extrasSizer, 1, wxALIGN_CENTER, 5 );
-	
-	m_buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	m_buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_buttonHelp = new wxButton( this, wxID_ANY, _("Help"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_buttonHelp, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( m_buttonSizer, 0, wxALIGN_CENTER, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	
-	// Connect Events
-	m_comboUrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
-	m_comboDest->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
-	m_buttonBrowse->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnBrowse ), NULL, this );
-	m_textRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
-	m_checkUseLatest->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnCheckBox ), NULL, this );
-	m_textPegRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
-	m_checkPegNotSpecified->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnCheckBox ), NULL, this );
-	m_buttonHelp->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnHelp ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    this->SetExtraStyle( wxDIALOG_EX_CONTEXTHELP );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    wxStaticBoxSizer* urlSizer;
+    urlSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("URL") ), wxVERTICAL );
+    
+    m_comboUrl = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, 0 ); 
+    urlSizer->Add( m_comboUrl, 0, wxALL|wxEXPAND, 5 );
+    
+    m_mainSizer->Add( urlSizer, 0, wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* destSizer;
+    destSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Destination Directory") ), wxHORIZONTAL );
+    
+    m_comboDest = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 205,-1 ), 0, NULL, 0 ); 
+    destSizer->Add( m_comboDest, 1, wxALL, 5 );
+    
+    m_buttonBrowse = new wxButton( this, wxID_ANY, _("..."), wxDefaultPosition, wxSize( 20,-1 ), 0 );
+    destSizer->Add( m_buttonBrowse, 0, wxALL, 5 );
+    
+    m_mainSizer->Add( destSizer, 0, wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* revisionSizer;
+    revisionSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision") ), wxHORIZONTAL );
+    
+    m_textRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), 0 );
+    revisionSizer->Add( m_textRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_checkUseLatest = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
+    revisionSizer->Add( m_checkUseLatest, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_mainSizer->Add( revisionSizer, 0, wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* pegSizer;
+    pegSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Peg Revision") ), wxHORIZONTAL );
+    
+    m_textPegRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), 0 );
+    pegSizer->Add( m_textPegRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_checkPegNotSpecified = new wxCheckBox( this, wxID_ANY, _("Not specified"), wxDefaultPosition, wxDefaultSize, 0 );
+    pegSizer->Add( m_checkPegNotSpecified, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_mainSizer->Add( pegSizer, 0, wxEXPAND, 5 );
+    
+    wxBoxSizer* extrasSizer;
+    extrasSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_checkAddToBookmarks = new wxCheckBox( this, wxID_ANY, _("Add to bookmarks"), wxDefaultPosition, wxDefaultSize, 0 );
+    extrasSizer->Add( m_checkAddToBookmarks, 0, wxALL, 5 );
+    
+    m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
+    extrasSizer->Add( m_checkRecursive, 0, wxALL, 5 );
+    
+    m_checkIgnoreExternals = new wxCheckBox( this, wxID_ANY, _("Ignore externals"), wxDefaultPosition, wxDefaultSize, 0 );
+    extrasSizer->Add( m_checkIgnoreExternals, 0, wxALL, 5 );
+    
+    m_mainSizer->Add( extrasSizer, 1, wxALIGN_CENTER, 5 );
+    
+    m_buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    m_buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_buttonHelp = new wxButton( this, wxID_ANY, _("Help"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_buttonHelp, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( m_buttonSizer, 0, wxALIGN_CENTER, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    
+    // Connect Events
+    m_comboUrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
+    m_comboDest->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
+    m_buttonBrowse->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnBrowse ), NULL, this );
+    m_textRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
+    m_checkUseLatest->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnCheckBox ), NULL, this );
+    m_textPegRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
+    m_checkPegNotSpecified->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnCheckBox ), NULL, this );
+    m_buttonHelp->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnHelp ), NULL, this );
 }
 
 CheckoutDlgBase::~CheckoutDlgBase()
 {
-	// Disconnect Events
-	m_comboUrl->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
-	m_comboDest->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
-	m_buttonBrowse->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnBrowse ), NULL, this );
-	m_textRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
-	m_checkUseLatest->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnCheckBox ), NULL, this );
-	m_textPegRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
-	m_checkPegNotSpecified->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnCheckBox ), NULL, this );
-	m_buttonHelp->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnHelp ), NULL, this );
+    // Disconnect Events
+    m_comboUrl->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
+    m_comboDest->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
+    m_buttonBrowse->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnBrowse ), NULL, this );
+    m_textRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
+    m_checkUseLatest->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnCheckBox ), NULL, this );
+    m_textPegRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CheckoutDlgBase::OnText ), NULL, this );
+    m_checkPegNotSpecified->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnCheckBox ), NULL, this );
+    m_buttonHelp->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CheckoutDlgBase::OnHelp ), NULL, this );
 }
 
 CommitDlgBase::CommitDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_msgSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Enter &log message") ), wxHORIZONTAL );
-	
-	m_textMessage = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
-	m_msgSizer->Add( m_textMessage, 1, wxEXPAND, 5 );
-	
-	m_mainSizer->Add( m_msgSizer, 1, wxALL|wxEXPAND, 5 );
-	
-	m_histSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_labelHistory = new wxStaticText( this, wxID_ANY, _("&Recent entries:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_labelHistory->Wrap( -1 );
-	m_histSizer->Add( m_labelHistory, 0, wxALL, 5 );
-	
-	m_comboHistory = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_READONLY ); 
-	m_histSizer->Add( m_comboHistory, 1, 0, 5 );
-	
-	m_mainSizer->Add( m_histSizer, 0, wxEXPAND|wxLEFT|wxRIGHT, 5 );
-	
-	m_filesSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("&Files to commit") ), wxVERTICAL );
-	
-	wxArrayString m_checkListFilesChoices;
-	m_checkListFiles = new wxCheckListBox( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_checkListFilesChoices, wxLB_EXTENDED );
-	m_filesSizer->Add( m_checkListFiles, 1, wxEXPAND, 5 );
-	
-	wxBoxSizer* bSizerFileButtons;
-	bSizerFileButtons = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonToggle = new wxButton( this, wxID_ANY, _("&Toggle"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizerFileButtons->Add( m_buttonToggle, 0, wxALL, 5 );
-	
-	m_buttonDiff = new wxButton( this, wxID_ANY, _("&Diff"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizerFileButtons->Add( m_buttonDiff, 0, wxALL, 5 );
-	
-	m_filesSizer->Add( bSizerFileButtons, 0, wxEXPAND, 5 );
-	
-	m_mainSizer->Add( m_filesSizer, 1, wxALL|wxEXPAND, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_checkRecursive, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_checkKeepLocks = new wxCheckBox( this, wxID_ANY, _("Keep Locks"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_checkKeepLocks, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_RIGHT|wxLEFT|wxRIGHT, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	
-	// Connect Events
-	m_comboHistory->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( CommitDlgBase::OnComboHistory ), NULL, this );
-	m_checkListFiles->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( CommitDlgBase::OnCheckListFiles ), NULL, this );
-	m_checkListFiles->Connect( wxEVT_COMMAND_LISTBOX_DOUBLECLICKED, wxCommandEventHandler( CommitDlgBase::OnCheckListFilesDClick ), NULL, this );
-	m_checkListFiles->Connect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( CommitDlgBase::OnCheckListFilesToggle ), NULL, this );
-	m_buttonToggle->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CommitDlgBase::OnButtonToggle ), NULL, this );
-	m_buttonDiff->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CommitDlgBase::OnButtonDiff ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_msgSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Enter &log message") ), wxHORIZONTAL );
+    
+    m_textMessage = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
+    m_msgSizer->Add( m_textMessage, 1, wxEXPAND, 5 );
+    
+    m_mainSizer->Add( m_msgSizer, 1, wxALL|wxEXPAND, 5 );
+    
+    m_histSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_labelHistory = new wxStaticText( this, wxID_ANY, _("&Recent entries:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_labelHistory->Wrap( -1 );
+    m_histSizer->Add( m_labelHistory, 0, wxALL, 5 );
+    
+    m_comboHistory = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_READONLY ); 
+    m_histSizer->Add( m_comboHistory, 1, 0, 5 );
+    
+    m_mainSizer->Add( m_histSizer, 0, wxEXPAND|wxLEFT|wxRIGHT, 5 );
+    
+    m_filesSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("&Files to commit") ), wxVERTICAL );
+    
+    wxArrayString m_checkListFilesChoices;
+    m_checkListFiles = new wxCheckListBox( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_checkListFilesChoices, wxLB_EXTENDED );
+    m_filesSizer->Add( m_checkListFiles, 1, wxEXPAND, 5 );
+    
+    wxBoxSizer* bSizerFileButtons;
+    bSizerFileButtons = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonToggle = new wxButton( this, wxID_ANY, _("&Toggle"), wxDefaultPosition, wxDefaultSize, 0 );
+    bSizerFileButtons->Add( m_buttonToggle, 0, wxALL, 5 );
+    
+    m_buttonDiff = new wxButton( this, wxID_ANY, _("&Diff"), wxDefaultPosition, wxDefaultSize, 0 );
+    bSizerFileButtons->Add( m_buttonDiff, 0, wxALL, 5 );
+    
+    m_filesSizer->Add( bSizerFileButtons, 0, wxEXPAND, 5 );
+    
+    m_mainSizer->Add( m_filesSizer, 1, wxALL|wxEXPAND, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_checkRecursive, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_checkKeepLocks = new wxCheckBox( this, wxID_ANY, _("Keep Locks"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_checkKeepLocks, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_RIGHT|wxLEFT|wxRIGHT, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    
+    // Connect Events
+    m_comboHistory->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( CommitDlgBase::OnComboHistory ), NULL, this );
+    m_checkListFiles->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( CommitDlgBase::OnCheckListFiles ), NULL, this );
+    m_checkListFiles->Connect( wxEVT_COMMAND_LISTBOX_DOUBLECLICKED, wxCommandEventHandler( CommitDlgBase::OnCheckListFilesDClick ), NULL, this );
+    m_checkListFiles->Connect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( CommitDlgBase::OnCheckListFilesToggle ), NULL, this );
+    m_buttonToggle->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CommitDlgBase::OnButtonToggle ), NULL, this );
+    m_buttonDiff->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CommitDlgBase::OnButtonDiff ), NULL, this );
 }
 
 CommitDlgBase::~CommitDlgBase()
 {
-	// Disconnect Events
-	m_comboHistory->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( CommitDlgBase::OnComboHistory ), NULL, this );
-	m_checkListFiles->Disconnect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( CommitDlgBase::OnCheckListFiles ), NULL, this );
-	m_checkListFiles->Disconnect( wxEVT_COMMAND_LISTBOX_DOUBLECLICKED, wxCommandEventHandler( CommitDlgBase::OnCheckListFilesDClick ), NULL, this );
-	m_checkListFiles->Disconnect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( CommitDlgBase::OnCheckListFilesToggle ), NULL, this );
-	m_buttonToggle->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CommitDlgBase::OnButtonToggle ), NULL, this );
-	m_buttonDiff->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CommitDlgBase::OnButtonDiff ), NULL, this );
+    // Disconnect Events
+    m_comboHistory->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( CommitDlgBase::OnComboHistory ), NULL, this );
+    m_checkListFiles->Disconnect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( CommitDlgBase::OnCheckListFiles ), NULL, this );
+    m_checkListFiles->Disconnect( wxEVT_COMMAND_LISTBOX_DOUBLECLICKED, wxCommandEventHandler( CommitDlgBase::OnCheckListFilesDClick ), NULL, this );
+    m_checkListFiles->Disconnect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( CommitDlgBase::OnCheckListFilesToggle ), NULL, this );
+    m_buttonToggle->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CommitDlgBase::OnButtonToggle ), NULL, this );
+    m_buttonDiff->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CommitDlgBase::OnButtonDiff ), NULL, this );
 }
 
 CommitLogDlgBase::CommitLogDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_msgSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("This action has resulted in a commit - please enter a &log message") ), wxHORIZONTAL );
-	
-	m_textMessage = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
-	m_msgSizer->Add( m_textMessage, 1, wxEXPAND, 5 );
-	
-	m_mainSizer->Add( m_msgSizer, 1, wxALL|wxEXPAND, 5 );
-	
-	m_histSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_labelHistory = new wxStaticText( this, wxID_ANY, _("Recent entries:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_labelHistory->Wrap( -1 );
-	m_histSizer->Add( m_labelHistory, 0, wxALL, 5 );
-	
-	m_comboHistory = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_READONLY ); 
-	m_histSizer->Add( m_comboHistory, 1, 0, 5 );
-	
-	m_mainSizer->Add( m_histSizer, 0, wxEXPAND|wxLEFT|wxRIGHT, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_RIGHT|wxLEFT|wxRIGHT, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	
-	// Connect Events
-	m_comboHistory->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( CommitLogDlgBase::OnComboHistory ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_msgSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("This action has resulted in a commit - please enter a &log message") ), wxHORIZONTAL );
+    
+    m_textMessage = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
+    m_msgSizer->Add( m_textMessage, 1, wxEXPAND, 5 );
+    
+    m_mainSizer->Add( m_msgSizer, 1, wxALL|wxEXPAND, 5 );
+    
+    m_histSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_labelHistory = new wxStaticText( this, wxID_ANY, _("Recent entries:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_labelHistory->Wrap( -1 );
+    m_histSizer->Add( m_labelHistory, 0, wxALL, 5 );
+    
+    m_comboHistory = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_READONLY ); 
+    m_histSizer->Add( m_comboHistory, 1, 0, 5 );
+    
+    m_mainSizer->Add( m_histSizer, 0, wxEXPAND|wxLEFT|wxRIGHT, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_RIGHT|wxLEFT|wxRIGHT, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    
+    // Connect Events
+    m_comboHistory->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( CommitLogDlgBase::OnComboHistory ), NULL, this );
 }
 
 CommitLogDlgBase::~CommitLogDlgBase()
 {
-	// Disconnect Events
-	m_comboHistory->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( CommitLogDlgBase::OnComboHistory ), NULL, this );
+    // Disconnect Events
+    m_comboHistory->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( CommitLogDlgBase::OnComboHistory ), NULL, this );
 }
 
 CreateReposDlgBase::CreateReposDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_rootSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_notebook = new wxNotebook( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
-	m_panelGeneral = new wxPanel( m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	sizerGeneral = new wxBoxSizer( wxVERTICAL );
-	
-	sizerType = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_staticType = new wxStaticText( m_panelGeneral, wxID_ANY, _("&Type:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticType->Wrap( -1 );
-	sizerType->Add( m_staticType, 0, wxALL, 5 );
-	
-	wxString m_choiceTypeChoices[] = { _("FSFS"), _("BerkeleyDB") };
-	int m_choiceTypeNChoices = sizeof( m_choiceTypeChoices ) / sizeof( wxString );
-	m_choiceType = new wxChoice( m_panelGeneral, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceTypeNChoices, m_choiceTypeChoices, 0 );
-	m_choiceType->SetSelection( 0 );
-	sizerType->Add( m_choiceType, 0, wxALL, 5 );
-	
-	sizerGeneral->Add( sizerType, 0, wxEXPAND, 5 );
-	
-	m_staticDir = new wxStaticText( m_panelGeneral, wxID_ANY, _("Create repository in &directory:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticDir->Wrap( -1 );
-	sizerGeneral->Add( m_staticDir, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
-	
-	sizerDir = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_comboDir = new wxComboBox( m_panelGeneral, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
-	sizerDir->Add( m_comboDir, 1, wxALIGN_CENTER_VERTICAL, 5 );
-	
-	m_buttonBrowseDir = new wxButton( m_panelGeneral, wxID_ANY, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerDir->Add( m_buttonBrowseDir, 0, wxALIGN_CENTER_VERTICAL, 5 );
-	
-	sizerGeneral->Add( sizerDir, 0, wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT, 5 );
-	
-	m_staticName = new wxStaticText( m_panelGeneral, wxID_ANY, _("&Name of the new repository:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticName->Wrap( -1 );
-	sizerGeneral->Add( m_staticName, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
-	
-	m_comboName = new wxComboBox( m_panelGeneral, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
-	sizerGeneral->Add( m_comboName, 0, wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT, 5 );
-	
-	m_staticFilename = new wxStaticText( m_panelGeneral, wxID_ANY, _("Resulting repository filename:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticFilename->Wrap( -1 );
-	sizerGeneral->Add( m_staticFilename, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
-	
-	m_textFilename = new wxTextCtrl( m_panelGeneral, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY );
-	m_textFilename->SetForegroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_BTNTEXT ) );
-	m_textFilename->SetBackgroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_BTNFACE ) );
-	
-	sizerGeneral->Add( m_textFilename, 0, wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT, 5 );
-	
-	m_checkAddBookmark = new wxCheckBox( m_panelGeneral, wxID_ANY, _("Add a bookmark for the new repository"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerGeneral->Add( m_checkAddBookmark, 0, wxALL, 5 );
-	
-	m_panelGeneral->SetSizer( sizerGeneral );
-	m_panelGeneral->Layout();
-	sizerGeneral->Fit( m_panelGeneral );
-	m_notebook->AddPage( m_panelGeneral, _("General"), true );
-	m_panelExtended = new wxPanel( m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	sizerExtended = new wxBoxSizer( wxVERTICAL );
-	
-	sizerCompatibility = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_staticCompatibility = new wxStaticText( m_panelExtended, wxID_ANY, _("&Compatible with:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticCompatibility->Wrap( -1 );
-	sizerCompatibility->Add( m_staticCompatibility, 0, wxALL, 5 );
-	
-	wxString m_choiceCompatChoices[] = { _("Default"), _("pre Subversion 1.6"), _("pre Subversion 1.5"), _("pre Subversion 1.4") };
-	int m_choiceCompatNChoices = sizeof( m_choiceCompatChoices ) / sizeof( wxString );
-	m_choiceCompat = new wxChoice( m_panelExtended, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceCompatNChoices, m_choiceCompatChoices, 0 );
-	m_choiceCompat->SetSelection( 0 );
-	sizerCompatibility->Add( m_choiceCompat, 0, wxALL, 5 );
-	
-	sizerExtended->Add( sizerCompatibility, 0, wxEXPAND, 5 );
-	
-	m_staticConfigDir = new wxStaticText( m_panelExtended, wxID_ANY, _("&Load configuration from directory (optional):"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticConfigDir->Wrap( -1 );
-	sizerExtended->Add( m_staticConfigDir, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
-	
-	sizerConfigDir = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_comboConfigDir = new wxComboBox( m_panelExtended, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
-	sizerConfigDir->Add( m_comboConfigDir, 1, wxALIGN_CENTER_VERTICAL, 5 );
-	
-	m_buttonBrowseConfigDir = new wxButton( m_panelExtended, wxID_ANY, _("&Browse"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerConfigDir->Add( m_buttonBrowseConfigDir, 0, wxALIGN_CENTER_VERTICAL, 5 );
-	
-	sizerExtended->Add( sizerConfigDir, 0, wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT, 5 );
-	
-	m_checkBdbLogKeep = new wxCheckBox( m_panelExtended, wxID_ANY, _("Disable automatic Log removal"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerExtended->Add( m_checkBdbLogKeep, 0, wxALL, 5 );
-	
-	m_checkBdbTxnNoSync = new wxCheckBox( m_panelExtended, wxID_ANY, _("Disable fsync when committing database transactions"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerExtended->Add( m_checkBdbTxnNoSync, 0, wxALL, 5 );
-	
-	m_panelExtended->SetSizer( sizerExtended );
-	m_panelExtended->Layout();
-	sizerExtended->Fit( m_panelExtended );
-	m_notebook->AddPage( m_panelExtended, _("More options"), false );
-	
-	m_rootSizer->Add( m_notebook, 1, wxEXPAND | wxALL, 5 );
-	
-	m_staticWarning = new wxStaticText( this, wxID_ANY, _("WARNING"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticWarning->Wrap( -1 );
-	m_staticWarning->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
-	
-	m_rootSizer->Add( m_staticWarning, 0, wxEXPAND|wxLEFT|wxRIGHT, 5 );
-	
-	sizerButton = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOk = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOk->SetDefault(); 
-	sizerButton->Add( m_buttonOk, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerButton->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_rootSizer->Add( sizerButton, 0, wxALIGN_CENTER, 5 );
-	
-	this->SetSizer( m_rootSizer );
-	this->Layout();
-	m_rootSizer->Fit( this );
-	
-	// Connect Events
-	m_choiceType->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( CreateReposDlgBase::OnChoiceType ), NULL, this );
-	m_comboDir->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboDirText ), NULL, this );
-	m_buttonBrowseDir->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CreateReposDlgBase::OnButtonBrowseDirClick ), NULL, this );
-	m_comboName->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboNameText ), NULL, this );
-	m_choiceCompat->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( CreateReposDlgBase::OnChoiceCompat ), NULL, this );
-	m_comboConfigDir->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboConfigDirText ), NULL, this );
-	m_buttonBrowseConfigDir->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CreateReposDlgBase::OnButtonBrowseConfigDirClick ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_rootSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_notebook = new wxNotebook( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
+    m_panelGeneral = new wxPanel( m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    sizerGeneral = new wxBoxSizer( wxVERTICAL );
+    
+    sizerType = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_staticType = new wxStaticText( m_panelGeneral, wxID_ANY, _("&Type:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticType->Wrap( -1 );
+    sizerType->Add( m_staticType, 0, wxALL, 5 );
+    
+    wxString m_choiceTypeChoices[] = { _("FSFS"), _("BerkeleyDB") };
+    int m_choiceTypeNChoices = sizeof( m_choiceTypeChoices ) / sizeof( wxString );
+    m_choiceType = new wxChoice( m_panelGeneral, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceTypeNChoices, m_choiceTypeChoices, 0 );
+    m_choiceType->SetSelection( 0 );
+    sizerType->Add( m_choiceType, 0, wxALL, 5 );
+    
+    sizerGeneral->Add( sizerType, 0, wxEXPAND, 5 );
+    
+    m_staticDir = new wxStaticText( m_panelGeneral, wxID_ANY, _("Create repository in &directory:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticDir->Wrap( -1 );
+    sizerGeneral->Add( m_staticDir, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
+    
+    sizerDir = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_comboDir = new wxComboBox( m_panelGeneral, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
+    sizerDir->Add( m_comboDir, 1, wxALIGN_CENTER_VERTICAL, 5 );
+    
+    m_buttonBrowseDir = new wxButton( m_panelGeneral, wxID_ANY, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerDir->Add( m_buttonBrowseDir, 0, wxALIGN_CENTER_VERTICAL, 5 );
+    
+    sizerGeneral->Add( sizerDir, 0, wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT, 5 );
+    
+    m_staticName = new wxStaticText( m_panelGeneral, wxID_ANY, _("&Name of the new repository:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticName->Wrap( -1 );
+    sizerGeneral->Add( m_staticName, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
+    
+    m_comboName = new wxComboBox( m_panelGeneral, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
+    sizerGeneral->Add( m_comboName, 0, wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT, 5 );
+    
+    m_staticFilename = new wxStaticText( m_panelGeneral, wxID_ANY, _("Resulting repository filename:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticFilename->Wrap( -1 );
+    sizerGeneral->Add( m_staticFilename, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
+    
+    m_textFilename = new wxTextCtrl( m_panelGeneral, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY );
+    m_textFilename->SetForegroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_BTNTEXT ) );
+    m_textFilename->SetBackgroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_BTNFACE ) );
+    
+    sizerGeneral->Add( m_textFilename, 0, wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT, 5 );
+    
+    m_checkAddBookmark = new wxCheckBox( m_panelGeneral, wxID_ANY, _("Add a bookmark for the new repository"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerGeneral->Add( m_checkAddBookmark, 0, wxALL, 5 );
+    
+    m_panelGeneral->SetSizer( sizerGeneral );
+    m_panelGeneral->Layout();
+    sizerGeneral->Fit( m_panelGeneral );
+    m_notebook->AddPage( m_panelGeneral, _("General"), true );
+    m_panelExtended = new wxPanel( m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    sizerExtended = new wxBoxSizer( wxVERTICAL );
+    
+    sizerCompatibility = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_staticCompatibility = new wxStaticText( m_panelExtended, wxID_ANY, _("&Compatible with:"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticCompatibility->Wrap( -1 );
+    sizerCompatibility->Add( m_staticCompatibility, 0, wxALL, 5 );
+    
+    wxString m_choiceCompatChoices[] = { _("Default"), _("pre Subversion 1.6"), _("pre Subversion 1.5"), _("pre Subversion 1.4") };
+    int m_choiceCompatNChoices = sizeof( m_choiceCompatChoices ) / sizeof( wxString );
+    m_choiceCompat = new wxChoice( m_panelExtended, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceCompatNChoices, m_choiceCompatChoices, 0 );
+    m_choiceCompat->SetSelection( 0 );
+    sizerCompatibility->Add( m_choiceCompat, 0, wxALL, 5 );
+    
+    sizerExtended->Add( sizerCompatibility, 0, wxEXPAND, 5 );
+    
+    m_staticConfigDir = new wxStaticText( m_panelExtended, wxID_ANY, _("&Load configuration from directory (optional):"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticConfigDir->Wrap( -1 );
+    sizerExtended->Add( m_staticConfigDir, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
+    
+    sizerConfigDir = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_comboConfigDir = new wxComboBox( m_panelExtended, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
+    sizerConfigDir->Add( m_comboConfigDir, 1, wxALIGN_CENTER_VERTICAL, 5 );
+    
+    m_buttonBrowseConfigDir = new wxButton( m_panelExtended, wxID_ANY, _("&Browse"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerConfigDir->Add( m_buttonBrowseConfigDir, 0, wxALIGN_CENTER_VERTICAL, 5 );
+    
+    sizerExtended->Add( sizerConfigDir, 0, wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT, 5 );
+    
+    m_checkBdbLogKeep = new wxCheckBox( m_panelExtended, wxID_ANY, _("Disable automatic Log removal"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerExtended->Add( m_checkBdbLogKeep, 0, wxALL, 5 );
+    
+    m_checkBdbTxnNoSync = new wxCheckBox( m_panelExtended, wxID_ANY, _("Disable fsync when committing database transactions"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerExtended->Add( m_checkBdbTxnNoSync, 0, wxALL, 5 );
+    
+    m_panelExtended->SetSizer( sizerExtended );
+    m_panelExtended->Layout();
+    sizerExtended->Fit( m_panelExtended );
+    m_notebook->AddPage( m_panelExtended, _("More options"), false );
+    
+    m_rootSizer->Add( m_notebook, 1, wxEXPAND | wxALL, 5 );
+    
+    m_staticWarning = new wxStaticText( this, wxID_ANY, _("WARNING"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticWarning->Wrap( -1 );
+    m_staticWarning->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+    
+    m_rootSizer->Add( m_staticWarning, 0, wxEXPAND|wxLEFT|wxRIGHT, 5 );
+    
+    sizerButton = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOk = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOk->SetDefault(); 
+    sizerButton->Add( m_buttonOk, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerButton->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_rootSizer->Add( sizerButton, 0, wxALIGN_CENTER, 5 );
+    
+    this->SetSizer( m_rootSizer );
+    this->Layout();
+    m_rootSizer->Fit( this );
+    
+    // Connect Events
+    m_choiceType->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( CreateReposDlgBase::OnChoiceType ), NULL, this );
+    m_comboDir->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboDirText ), NULL, this );
+    m_buttonBrowseDir->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CreateReposDlgBase::OnButtonBrowseDirClick ), NULL, this );
+    m_comboName->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboNameText ), NULL, this );
+    m_choiceCompat->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( CreateReposDlgBase::OnChoiceCompat ), NULL, this );
+    m_comboConfigDir->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboConfigDirText ), NULL, this );
+    m_buttonBrowseConfigDir->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CreateReposDlgBase::OnButtonBrowseConfigDirClick ), NULL, this );
 }
 
 CreateReposDlgBase::~CreateReposDlgBase()
 {
-	// Disconnect Events
-	m_choiceType->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( CreateReposDlgBase::OnChoiceType ), NULL, this );
-	m_comboDir->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboDirText ), NULL, this );
-	m_buttonBrowseDir->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CreateReposDlgBase::OnButtonBrowseDirClick ), NULL, this );
-	m_comboName->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboNameText ), NULL, this );
-	m_choiceCompat->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( CreateReposDlgBase::OnChoiceCompat ), NULL, this );
-	m_comboConfigDir->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboConfigDirText ), NULL, this );
-	m_buttonBrowseConfigDir->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CreateReposDlgBase::OnButtonBrowseConfigDirClick ), NULL, this );
+    // Disconnect Events
+    m_choiceType->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( CreateReposDlgBase::OnChoiceType ), NULL, this );
+    m_comboDir->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboDirText ), NULL, this );
+    m_buttonBrowseDir->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CreateReposDlgBase::OnButtonBrowseDirClick ), NULL, this );
+    m_comboName->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboNameText ), NULL, this );
+    m_choiceCompat->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( CreateReposDlgBase::OnChoiceCompat ), NULL, this );
+    m_comboConfigDir->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CreateReposDlgBase::OnComboConfigDirText ), NULL, this );
+    m_buttonBrowseConfigDir->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CreateReposDlgBase::OnButtonBrowseConfigDirClick ), NULL, this );
 }
 
 DeleteDlgBase::DeleteDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticQuestion = new wxStaticText( this, wxID_ANY, _("Do you want to delete the selected files/directories?"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticQuestion->Wrap( -1 );
-	m_mainSizer->Add( m_staticQuestion, 1, wxALL|wxEXPAND, 5 );
-	
-	m_checkForce = new wxCheckBox( this, wxID_ANY, _("Force removal"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_mainSizer->Add( m_checkForce, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	m_mainSizer->Fit( this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_staticQuestion = new wxStaticText( this, wxID_ANY, _("Do you want to delete the selected files/directories?"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticQuestion->Wrap( -1 );
+    m_mainSizer->Add( m_staticQuestion, 1, wxALL|wxEXPAND, 5 );
+    
+    m_checkForce = new wxCheckBox( this, wxID_ANY, _("Force removal"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_mainSizer->Add( m_checkForce, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    m_mainSizer->Fit( this );
 }
 
 DeleteDlgBase::~DeleteDlgBase()
@@ -643,497 +643,497 @@ DeleteDlgBase::~DeleteDlgBase()
 
 DestinationDlgBase::DestinationDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticQuestion = new wxStaticText( this, wxID_ANY, _("Here comes the description"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticQuestion->Wrap( -1 );
-	m_mainSizer->Add( m_staticQuestion, 0, wxALL, 5 );
-	
-	m_comboDestination = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, 0 ); 
-	m_mainSizer->Add( m_comboDestination, 0, wxALL|wxEXPAND, 5 );
-	
-	m_checkForce = new wxCheckBox( this, wxID_ANY, _("Force"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_mainSizer->Add( m_checkForce, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	m_mainSizer->Fit( this );
-	
-	// Connect Events
-	m_comboDestination->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DestinationDlgBase::OnText ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_staticQuestion = new wxStaticText( this, wxID_ANY, _("Here comes the description"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticQuestion->Wrap( -1 );
+    m_mainSizer->Add( m_staticQuestion, 0, wxALL, 5 );
+    
+    m_comboDestination = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, 0 ); 
+    m_mainSizer->Add( m_comboDestination, 0, wxALL|wxEXPAND, 5 );
+    
+    m_checkForce = new wxCheckBox( this, wxID_ANY, _("Force"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_mainSizer->Add( m_checkForce, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    m_mainSizer->Fit( this );
+    
+    // Connect Events
+    m_comboDestination->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DestinationDlgBase::OnText ), NULL, this );
 }
 
 DestinationDlgBase::~DestinationDlgBase()
 {
-	// Disconnect Events
-	m_comboDestination->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DestinationDlgBase::OnText ), NULL, this );
+    // Disconnect Events
+    m_comboDestination->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DestinationDlgBase::OnText ), NULL, this );
 }
 
 DiffDlgBase::DiffDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	wxBoxSizer* mainSizer;
-	mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	wxBoxSizer* compareSizer;
-	compareSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	wxStaticText* labelCompare;
-	labelCompare = new wxStaticText( this, wxID_ANY, _("Compare:"), wxDefaultPosition, wxDefaultSize, 0 );
-	labelCompare->Wrap( -1 );
-	compareSizer->Add( labelCompare, 0, 0, 5 );
-	
-	m_comboCompare = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_DROPDOWN|wxCB_READONLY ); 
-	compareSizer->Add( m_comboCompare, 1, 0, 5 );
-	
-	mainSizer->Add( compareSizer, 0, wxALL|wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* sbSizer1;
-	sbSizer1 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision or date #1:") ), wxVERTICAL );
-	
-	wxFlexGridSizer* fgSizer1;
-	fgSizer1 = new wxFlexGridSizer( 3, 2, 0, 0 );
-	fgSizer1->SetFlexibleDirection( wxBOTH );
-	fgSizer1->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
-	m_radioUseRevision1 = new wxRadioButton( this, wxID_ANY, _("Revision:"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
-	fgSizer1->Add( m_radioUseRevision1, 0, 0, 5 );
-	
-	wxBoxSizer* bSizer16;
-	bSizer16 = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_textRevision1 = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer16->Add( m_textRevision1, 0, wxEXPAND, 5 );
-	
-	m_checkUseLatest1 = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer16->Add( m_checkUseLatest1, 0, 0, 5 );
-	
-	fgSizer1->Add( bSizer16, 1, wxEXPAND, 5 );
-	
-	m_radioUseDate1 = new wxRadioButton( this, wxID_ANY, _("Date:"), wxDefaultPosition, wxDefaultSize, 0 );
-	fgSizer1->Add( m_radioUseDate1, 0, 0, 5 );
-	
-	m_datePicker1 = new wxDatePickerCtrl( this, wxID_ANY, wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, wxDP_DEFAULT );
-	fgSizer1->Add( m_datePicker1, 0, wxEXPAND, 5 );
-	
-	m_checkUsePath1 = new wxCheckBox( this, wxID_ANY, _("Use URL/path:"), wxDefaultPosition, wxDefaultSize, 0 );
-	fgSizer1->Add( m_checkUsePath1, 0, 0, 5 );
-	
-	m_comboPath1 = new wxComboBox( this, wxID_ANY, _("Combo!"), wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
-	fgSizer1->Add( m_comboPath1, 0, wxEXPAND, 5 );
-	
-	sbSizer1->Add( fgSizer1, 1, wxEXPAND, 5 );
-	
-	mainSizer->Add( sbSizer1, 1, wxALL|wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* sbSizer2;
-	sbSizer2 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision or date #2:") ), wxVERTICAL );
-	
-	wxFlexGridSizer* fgSizer2;
-	fgSizer2 = new wxFlexGridSizer( 3, 2, 0, 0 );
-	fgSizer2->SetFlexibleDirection( wxBOTH );
-	fgSizer2->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
-	m_radioUseRevision2 = new wxRadioButton( this, wxID_ANY, _("Revision:"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
-	fgSizer2->Add( m_radioUseRevision2, 0, 0, 5 );
-	
-	wxBoxSizer* bSizer161;
-	bSizer161 = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_textRevision2 = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer161->Add( m_textRevision2, 0, wxEXPAND, 5 );
-	
-	m_checkUseLatest2 = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer161->Add( m_checkUseLatest2, 0, 0, 5 );
-	
-	fgSizer2->Add( bSizer161, 1, wxEXPAND, 5 );
-	
-	m_radioUseDate2 = new wxRadioButton( this, wxID_ANY, _("Date:"), wxDefaultPosition, wxDefaultSize, 0 );
-	fgSizer2->Add( m_radioUseDate2, 0, 0, 5 );
-	
-	m_datePicker2 = new wxDatePickerCtrl( this, wxID_ANY, wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, wxDP_DEFAULT );
-	fgSizer2->Add( m_datePicker2, 0, wxEXPAND, 5 );
-	
-	m_checkUsePath2 = new wxCheckBox( this, wxID_ANY, _("Use URL/path:"), wxDefaultPosition, wxDefaultSize, 0 );
-	fgSizer2->Add( m_checkUsePath2, 0, 0, 5 );
-	
-	m_comboPath2 = new wxComboBox( this, wxID_ANY, _("Combo!"), wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
-	fgSizer2->Add( m_comboPath2, 0, wxEXPAND, 5 );
-	
-	sbSizer2->Add( fgSizer2, 1, wxEXPAND, 5 );
-	
-	mainSizer->Add( sbSizer2, 1, wxALL|wxEXPAND, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 5 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 5 );
-	
-	mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER, 5 );
-	
-	this->SetSizer( mainSizer );
-	this->Layout();
-	mainSizer->Fit( this );
-	
-	// Connect Events
-	m_comboCompare->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboCompare ), NULL, this );
-	m_radioUseRevision1->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseRevision1 ), NULL, this );
-	m_textRevision1->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DiffDlgBase::OnTextRevision1 ), NULL, this );
-	m_checkUseLatest1->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUseLatest1 ), NULL, this );
-	m_radioUseDate1->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseDate1 ), NULL, this );
-	m_datePicker1->Connect( wxEVT_DATE_CHANGED, wxDateEventHandler( DiffDlgBase::OnDatePicker1 ), NULL, this );
-	m_checkUsePath1->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnUsePath1 ), NULL, this );
-	m_comboPath1->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboPath1 ), NULL, this );
-	m_radioUseRevision2->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseRevision2 ), NULL, this );
-	m_textRevision2->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DiffDlgBase::OnTextRevision2 ), NULL, this );
-	m_checkUseLatest2->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUseLatest2 ), NULL, this );
-	m_radioUseDate2->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseDate2 ), NULL, this );
-	m_datePicker2->Connect( wxEVT_DATE_CHANGED, wxDateEventHandler( DiffDlgBase::OnDatePicker2 ), NULL, this );
-	m_checkUsePath2->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUsePath2 ), NULL, this );
-	m_comboPath2->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboPath2 ), NULL, this );
-	m_buttonOK->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DiffDlgBase::OnButtonOK ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    wxBoxSizer* mainSizer;
+    mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    wxBoxSizer* compareSizer;
+    compareSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    wxStaticText* labelCompare;
+    labelCompare = new wxStaticText( this, wxID_ANY, _("Compare:"), wxDefaultPosition, wxDefaultSize, 0 );
+    labelCompare->Wrap( -1 );
+    compareSizer->Add( labelCompare, 0, 0, 5 );
+    
+    m_comboCompare = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_DROPDOWN|wxCB_READONLY ); 
+    compareSizer->Add( m_comboCompare, 1, 0, 5 );
+    
+    mainSizer->Add( compareSizer, 0, wxALL|wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* sbSizer1;
+    sbSizer1 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision or date #1:") ), wxVERTICAL );
+    
+    wxFlexGridSizer* fgSizer1;
+    fgSizer1 = new wxFlexGridSizer( 3, 2, 0, 0 );
+    fgSizer1->SetFlexibleDirection( wxBOTH );
+    fgSizer1->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    
+    m_radioUseRevision1 = new wxRadioButton( this, wxID_ANY, _("Revision:"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    fgSizer1->Add( m_radioUseRevision1, 0, 0, 5 );
+    
+    wxBoxSizer* bSizer16;
+    bSizer16 = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_textRevision1 = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    bSizer16->Add( m_textRevision1, 0, wxEXPAND, 5 );
+    
+    m_checkUseLatest1 = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
+    bSizer16->Add( m_checkUseLatest1, 0, 0, 5 );
+    
+    fgSizer1->Add( bSizer16, 1, wxEXPAND, 5 );
+    
+    m_radioUseDate1 = new wxRadioButton( this, wxID_ANY, _("Date:"), wxDefaultPosition, wxDefaultSize, 0 );
+    fgSizer1->Add( m_radioUseDate1, 0, 0, 5 );
+    
+    m_datePicker1 = new wxDatePickerCtrl( this, wxID_ANY, wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, wxDP_DEFAULT );
+    fgSizer1->Add( m_datePicker1, 0, wxEXPAND, 5 );
+    
+    m_checkUsePath1 = new wxCheckBox( this, wxID_ANY, _("Use URL/path:"), wxDefaultPosition, wxDefaultSize, 0 );
+    fgSizer1->Add( m_checkUsePath1, 0, 0, 5 );
+    
+    m_comboPath1 = new wxComboBox( this, wxID_ANY, _("Combo!"), wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
+    fgSizer1->Add( m_comboPath1, 0, wxEXPAND, 5 );
+    
+    sbSizer1->Add( fgSizer1, 1, wxEXPAND, 5 );
+    
+    mainSizer->Add( sbSizer1, 1, wxALL|wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* sbSizer2;
+    sbSizer2 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision or date #2:") ), wxVERTICAL );
+    
+    wxFlexGridSizer* fgSizer2;
+    fgSizer2 = new wxFlexGridSizer( 3, 2, 0, 0 );
+    fgSizer2->SetFlexibleDirection( wxBOTH );
+    fgSizer2->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    
+    m_radioUseRevision2 = new wxRadioButton( this, wxID_ANY, _("Revision:"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    fgSizer2->Add( m_radioUseRevision2, 0, 0, 5 );
+    
+    wxBoxSizer* bSizer161;
+    bSizer161 = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_textRevision2 = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    bSizer161->Add( m_textRevision2, 0, wxEXPAND, 5 );
+    
+    m_checkUseLatest2 = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
+    bSizer161->Add( m_checkUseLatest2, 0, 0, 5 );
+    
+    fgSizer2->Add( bSizer161, 1, wxEXPAND, 5 );
+    
+    m_radioUseDate2 = new wxRadioButton( this, wxID_ANY, _("Date:"), wxDefaultPosition, wxDefaultSize, 0 );
+    fgSizer2->Add( m_radioUseDate2, 0, 0, 5 );
+    
+    m_datePicker2 = new wxDatePickerCtrl( this, wxID_ANY, wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, wxDP_DEFAULT );
+    fgSizer2->Add( m_datePicker2, 0, wxEXPAND, 5 );
+    
+    m_checkUsePath2 = new wxCheckBox( this, wxID_ANY, _("Use URL/path:"), wxDefaultPosition, wxDefaultSize, 0 );
+    fgSizer2->Add( m_checkUsePath2, 0, 0, 5 );
+    
+    m_comboPath2 = new wxComboBox( this, wxID_ANY, _("Combo!"), wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
+    fgSizer2->Add( m_comboPath2, 0, wxEXPAND, 5 );
+    
+    sbSizer2->Add( fgSizer2, 1, wxEXPAND, 5 );
+    
+    mainSizer->Add( sbSizer2, 1, wxALL|wxEXPAND, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 5 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 5 );
+    
+    mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER, 5 );
+    
+    this->SetSizer( mainSizer );
+    this->Layout();
+    mainSizer->Fit( this );
+    
+    // Connect Events
+    m_comboCompare->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboCompare ), NULL, this );
+    m_radioUseRevision1->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseRevision1 ), NULL, this );
+    m_textRevision1->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DiffDlgBase::OnTextRevision1 ), NULL, this );
+    m_checkUseLatest1->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUseLatest1 ), NULL, this );
+    m_radioUseDate1->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseDate1 ), NULL, this );
+    m_datePicker1->Connect( wxEVT_DATE_CHANGED, wxDateEventHandler( DiffDlgBase::OnDatePicker1 ), NULL, this );
+    m_checkUsePath1->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnUsePath1 ), NULL, this );
+    m_comboPath1->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboPath1 ), NULL, this );
+    m_radioUseRevision2->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseRevision2 ), NULL, this );
+    m_textRevision2->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DiffDlgBase::OnTextRevision2 ), NULL, this );
+    m_checkUseLatest2->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUseLatest2 ), NULL, this );
+    m_radioUseDate2->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseDate2 ), NULL, this );
+    m_datePicker2->Connect( wxEVT_DATE_CHANGED, wxDateEventHandler( DiffDlgBase::OnDatePicker2 ), NULL, this );
+    m_checkUsePath2->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUsePath2 ), NULL, this );
+    m_comboPath2->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboPath2 ), NULL, this );
+    m_buttonOK->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DiffDlgBase::OnButtonOK ), NULL, this );
 }
 
 DiffDlgBase::~DiffDlgBase()
 {
-	// Disconnect Events
-	m_comboCompare->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboCompare ), NULL, this );
-	m_radioUseRevision1->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseRevision1 ), NULL, this );
-	m_textRevision1->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DiffDlgBase::OnTextRevision1 ), NULL, this );
-	m_checkUseLatest1->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUseLatest1 ), NULL, this );
-	m_radioUseDate1->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseDate1 ), NULL, this );
-	m_datePicker1->Disconnect( wxEVT_DATE_CHANGED, wxDateEventHandler( DiffDlgBase::OnDatePicker1 ), NULL, this );
-	m_checkUsePath1->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnUsePath1 ), NULL, this );
-	m_comboPath1->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboPath1 ), NULL, this );
-	m_radioUseRevision2->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseRevision2 ), NULL, this );
-	m_textRevision2->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DiffDlgBase::OnTextRevision2 ), NULL, this );
-	m_checkUseLatest2->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUseLatest2 ), NULL, this );
-	m_radioUseDate2->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseDate2 ), NULL, this );
-	m_datePicker2->Disconnect( wxEVT_DATE_CHANGED, wxDateEventHandler( DiffDlgBase::OnDatePicker2 ), NULL, this );
-	m_checkUsePath2->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUsePath2 ), NULL, this );
-	m_comboPath2->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboPath2 ), NULL, this );
-	m_buttonOK->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DiffDlgBase::OnButtonOK ), NULL, this );
+    // Disconnect Events
+    m_comboCompare->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboCompare ), NULL, this );
+    m_radioUseRevision1->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseRevision1 ), NULL, this );
+    m_textRevision1->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DiffDlgBase::OnTextRevision1 ), NULL, this );
+    m_checkUseLatest1->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUseLatest1 ), NULL, this );
+    m_radioUseDate1->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseDate1 ), NULL, this );
+    m_datePicker1->Disconnect( wxEVT_DATE_CHANGED, wxDateEventHandler( DiffDlgBase::OnDatePicker1 ), NULL, this );
+    m_checkUsePath1->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnUsePath1 ), NULL, this );
+    m_comboPath1->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboPath1 ), NULL, this );
+    m_radioUseRevision2->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseRevision2 ), NULL, this );
+    m_textRevision2->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( DiffDlgBase::OnTextRevision2 ), NULL, this );
+    m_checkUseLatest2->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUseLatest2 ), NULL, this );
+    m_radioUseDate2->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( DiffDlgBase::OnRadioUseDate2 ), NULL, this );
+    m_datePicker2->Disconnect( wxEVT_DATE_CHANGED, wxDateEventHandler( DiffDlgBase::OnDatePicker2 ), NULL, this );
+    m_checkUsePath2->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( DiffDlgBase::OnCheckUsePath2 ), NULL, this );
+    m_comboPath2->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( DiffDlgBase::OnComboPath2 ), NULL, this );
+    m_buttonOK->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DiffDlgBase::OnButtonOK ), NULL, this );
 }
 
 DragAndDropDlgBase::DragAndDropDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticQuestion = new wxStaticText( this, wxID_ANY, _("Question"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticQuestion->Wrap( -1 );
-	m_mainSizer->Add( m_staticQuestion, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonImport = new wxButton( this, wxID_ANY, _("Import"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonImport, 0, wxALL, 10 );
-	
-	m_buttonMove = new wxButton( this, wxID_ANY, _("Move"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonMove, 0, wxALL, 10 );
-	
-	m_buttonCopy = new wxButton( this, wxID_ANY, _("Copy"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCopy, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonCancel->SetDefault(); 
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	m_mainSizer->Fit( this );
-	
-	// Connect Events
-	m_buttonImport->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonImport ), NULL, this );
-	m_buttonMove->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonMove ), NULL, this );
-	m_buttonCopy->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonCopy ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_staticQuestion = new wxStaticText( this, wxID_ANY, _("Question"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticQuestion->Wrap( -1 );
+    m_mainSizer->Add( m_staticQuestion, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonImport = new wxButton( this, wxID_ANY, _("Import"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonImport, 0, wxALL, 10 );
+    
+    m_buttonMove = new wxButton( this, wxID_ANY, _("Move"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonMove, 0, wxALL, 10 );
+    
+    m_buttonCopy = new wxButton( this, wxID_ANY, _("Copy"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCopy, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonCancel->SetDefault(); 
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    m_mainSizer->Fit( this );
+    
+    // Connect Events
+    m_buttonImport->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonImport ), NULL, this );
+    m_buttonMove->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonMove ), NULL, this );
+    m_buttonCopy->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonCopy ), NULL, this );
 }
 
 DragAndDropDlgBase::~DragAndDropDlgBase()
 {
-	// Disconnect Events
-	m_buttonImport->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonImport ), NULL, this );
-	m_buttonMove->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonMove ), NULL, this );
-	m_buttonCopy->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonCopy ), NULL, this );
+    // Disconnect Events
+    m_buttonImport->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonImport ), NULL, this );
+    m_buttonMove->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonMove ), NULL, this );
+    m_buttonCopy->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DragAndDropDlgBase::OnButtonCopy ), NULL, this );
 }
 
 EntryDlgBase::EntryDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	wxFlexGridSizer* fgSizer6;
-	fgSizer6 = new wxFlexGridSizer( 2, 2, 5, 5 );
-	fgSizer6->AddGrowableCol( 1 );
-	fgSizer6->AddGrowableRow( 1 );
-	fgSizer6->SetFlexibleDirection( wxBOTH );
-	fgSizer6->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
-	m_staticName = new wxStaticText( this, wxID_ANY, _("&Name"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticName->Wrap( -1 );
-	fgSizer6->Add( m_staticName, 0, 0, 5 );
-	
-	m_comboName = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
-	fgSizer6->Add( m_comboName, 0, wxEXPAND, 5 );
-	
-	m_staticValue = new wxStaticText( this, wxID_ANY, _("&Value"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticValue->Wrap( -1 );
-	fgSizer6->Add( m_staticValue, 0, 0, 5 );
-	
-	m_textValue = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 300,100 ), wxTE_MULTILINE );
-	fgSizer6->Add( m_textValue, 1, wxEXPAND, 5 );
-	
-	m_mainSizer->Add( fgSizer6, 1, wxALL|wxEXPAND, 5 );
-	
-	m_buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	m_buttonSizer->Add( m_buttonOK, 0, wxALL, 5 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_buttonCancel, 0, wxALL, 5 );
-	
-	m_mainSizer->Add( m_buttonSizer, 0, wxALIGN_RIGHT|wxALL, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	
-	// Connect Events
-	m_comboName->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( EntryDlgBase::OnText ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    wxFlexGridSizer* fgSizer6;
+    fgSizer6 = new wxFlexGridSizer( 2, 2, 5, 5 );
+    fgSizer6->AddGrowableCol( 1 );
+    fgSizer6->AddGrowableRow( 1 );
+    fgSizer6->SetFlexibleDirection( wxBOTH );
+    fgSizer6->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    
+    m_staticName = new wxStaticText( this, wxID_ANY, _("&Name"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticName->Wrap( -1 );
+    fgSizer6->Add( m_staticName, 0, 0, 5 );
+    
+    m_comboName = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
+    fgSizer6->Add( m_comboName, 0, wxEXPAND, 5 );
+    
+    m_staticValue = new wxStaticText( this, wxID_ANY, _("&Value"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticValue->Wrap( -1 );
+    fgSizer6->Add( m_staticValue, 0, 0, 5 );
+    
+    m_textValue = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 300,100 ), wxTE_MULTILINE );
+    fgSizer6->Add( m_textValue, 1, wxEXPAND, 5 );
+    
+    m_mainSizer->Add( fgSizer6, 1, wxALL|wxEXPAND, 5 );
+    
+    m_buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    m_buttonSizer->Add( m_buttonOK, 0, wxALL, 5 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_buttonCancel, 0, wxALL, 5 );
+    
+    m_mainSizer->Add( m_buttonSizer, 0, wxALIGN_RIGHT|wxALL, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    
+    // Connect Events
+    m_comboName->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( EntryDlgBase::OnText ), NULL, this );
 }
 
 EntryDlgBase::~EntryDlgBase()
 {
-	// Disconnect Events
-	m_comboName->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( EntryDlgBase::OnText ), NULL, this );
+    // Disconnect Events
+    m_comboName->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( EntryDlgBase::OnText ), NULL, this );
 }
 
 ExportDlgBase::ExportDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	this->SetExtraStyle( wxDIALOG_EX_CONTEXTHELP );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	wxStaticBoxSizer* urlSizer;
-	urlSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("URL") ), wxVERTICAL );
-	
-	m_comboUrl = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, 0 ); 
-	urlSizer->Add( m_comboUrl, 0, wxALL|wxEXPAND, 5 );
-	
-	m_mainSizer->Add( urlSizer, 0, wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* destSizer;
-	destSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Destination Directory") ), wxHORIZONTAL );
-	
-	m_comboDest = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 205,-1 ), 0, NULL, 0 ); 
-	destSizer->Add( m_comboDest, 1, wxALL, 5 );
-	
-	m_buttonBrowse = new wxButton( this, wxID_ANY, _("..."), wxDefaultPosition, wxSize( 20,-1 ), 0 );
-	destSizer->Add( m_buttonBrowse, 0, wxALL, 5 );
-	
-	m_mainSizer->Add( destSizer, 0, wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* revisionSizer;
-	revisionSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision") ), wxHORIZONTAL );
-	
-	m_textRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), 0 );
-	revisionSizer->Add( m_textRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_checkUseLatest = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
-	revisionSizer->Add( m_checkUseLatest, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_mainSizer->Add( revisionSizer, 0, wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* pegSizer;
-	pegSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Peg Revision") ), wxHORIZONTAL );
-	
-	m_textPegRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), 0 );
-	pegSizer->Add( m_textPegRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_checkPegNotSpecified = new wxCheckBox( this, wxID_ANY, _("Not specified"), wxDefaultPosition, wxDefaultSize, 0 );
-	pegSizer->Add( m_checkPegNotSpecified, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_mainSizer->Add( pegSizer, 0, wxEXPAND, 5 );
-	
-	wxBoxSizer* eolSizer;
-	eolSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_staticEol = new wxStaticText( this, wxID_ANY, _("End of line characters"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticEol->Wrap( -1 );
-	eolSizer->Add( m_staticEol, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	wxString m_choice3Choices[] = { _("native"), _("CRLF (Windows)"), _("LF (Unix)"), _("CR (MacOS)") };
-	int m_choice3NChoices = sizeof( m_choice3Choices ) / sizeof( wxString );
-	m_choice3 = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choice3NChoices, m_choice3Choices, 0 );
-	m_choice3->SetSelection( 0 );
-	eolSizer->Add( m_choice3, 0, wxALL, 5 );
-	
-	m_mainSizer->Add( eolSizer, 0, wxEXPAND, 5 );
-	
-	wxBoxSizer* extrasSizer;
-	extrasSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
-	extrasSizer->Add( m_checkRecursive, 0, wxALL, 5 );
-	
-	m_checkOverwrite = new wxCheckBox( this, wxID_ANY, _("Overwrite"), wxDefaultPosition, wxDefaultSize, 0 );
-	extrasSizer->Add( m_checkOverwrite, 0, wxALL, 5 );
-	
-	m_checkIgnoreExternals = new wxCheckBox( this, wxID_ANY, _("Ignore externals"), wxDefaultPosition, wxDefaultSize, 0 );
-	extrasSizer->Add( m_checkIgnoreExternals, 0, wxALL, 5 );
-	
-	m_mainSizer->Add( extrasSizer, 1, wxALIGN_CENTER, 5 );
-	
-	m_buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	m_buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_buttonHelp = new wxButton( this, wxID_ANY, _("Help"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_buttonHelp, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( m_buttonSizer, 0, wxALIGN_CENTER, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	m_mainSizer->Fit( this );
-	
-	// Connect Events
-	m_comboUrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
-	m_comboDest->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
-	m_buttonBrowse->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ExportDlgBase::OnBrowse ), NULL, this );
-	m_textRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
-	m_checkUseLatest->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ExportDlgBase::OnCheckBox ), NULL, this );
-	m_textPegRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
-	m_checkPegNotSpecified->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ExportDlgBase::OnCheckBox ), NULL, this );
-	m_buttonHelp->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ExportDlgBase::OnHelp ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    this->SetExtraStyle( wxDIALOG_EX_CONTEXTHELP );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    wxStaticBoxSizer* urlSizer;
+    urlSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("URL") ), wxVERTICAL );
+    
+    m_comboUrl = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, 0 ); 
+    urlSizer->Add( m_comboUrl, 0, wxALL|wxEXPAND, 5 );
+    
+    m_mainSizer->Add( urlSizer, 0, wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* destSizer;
+    destSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Destination Directory") ), wxHORIZONTAL );
+    
+    m_comboDest = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 205,-1 ), 0, NULL, 0 ); 
+    destSizer->Add( m_comboDest, 1, wxALL, 5 );
+    
+    m_buttonBrowse = new wxButton( this, wxID_ANY, _("..."), wxDefaultPosition, wxSize( 20,-1 ), 0 );
+    destSizer->Add( m_buttonBrowse, 0, wxALL, 5 );
+    
+    m_mainSizer->Add( destSizer, 0, wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* revisionSizer;
+    revisionSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision") ), wxHORIZONTAL );
+    
+    m_textRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), 0 );
+    revisionSizer->Add( m_textRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_checkUseLatest = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
+    revisionSizer->Add( m_checkUseLatest, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_mainSizer->Add( revisionSizer, 0, wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* pegSizer;
+    pegSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Peg Revision") ), wxHORIZONTAL );
+    
+    m_textPegRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), 0 );
+    pegSizer->Add( m_textPegRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_checkPegNotSpecified = new wxCheckBox( this, wxID_ANY, _("Not specified"), wxDefaultPosition, wxDefaultSize, 0 );
+    pegSizer->Add( m_checkPegNotSpecified, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_mainSizer->Add( pegSizer, 0, wxEXPAND, 5 );
+    
+    wxBoxSizer* eolSizer;
+    eolSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_staticEol = new wxStaticText( this, wxID_ANY, _("End of line characters"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticEol->Wrap( -1 );
+    eolSizer->Add( m_staticEol, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    wxString m_choice3Choices[] = { _("native"), _("CRLF (Windows)"), _("LF (Unix)"), _("CR (MacOS)") };
+    int m_choice3NChoices = sizeof( m_choice3Choices ) / sizeof( wxString );
+    m_choice3 = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choice3NChoices, m_choice3Choices, 0 );
+    m_choice3->SetSelection( 0 );
+    eolSizer->Add( m_choice3, 0, wxALL, 5 );
+    
+    m_mainSizer->Add( eolSizer, 0, wxEXPAND, 5 );
+    
+    wxBoxSizer* extrasSizer;
+    extrasSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
+    extrasSizer->Add( m_checkRecursive, 0, wxALL, 5 );
+    
+    m_checkOverwrite = new wxCheckBox( this, wxID_ANY, _("Overwrite"), wxDefaultPosition, wxDefaultSize, 0 );
+    extrasSizer->Add( m_checkOverwrite, 0, wxALL, 5 );
+    
+    m_checkIgnoreExternals = new wxCheckBox( this, wxID_ANY, _("Ignore externals"), wxDefaultPosition, wxDefaultSize, 0 );
+    extrasSizer->Add( m_checkIgnoreExternals, 0, wxALL, 5 );
+    
+    m_mainSizer->Add( extrasSizer, 1, wxALIGN_CENTER, 5 );
+    
+    m_buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    m_buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_buttonHelp = new wxButton( this, wxID_ANY, _("Help"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_buttonHelp, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( m_buttonSizer, 0, wxALIGN_CENTER, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    m_mainSizer->Fit( this );
+    
+    // Connect Events
+    m_comboUrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
+    m_comboDest->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
+    m_buttonBrowse->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ExportDlgBase::OnBrowse ), NULL, this );
+    m_textRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
+    m_checkUseLatest->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ExportDlgBase::OnCheckBox ), NULL, this );
+    m_textPegRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
+    m_checkPegNotSpecified->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ExportDlgBase::OnCheckBox ), NULL, this );
+    m_buttonHelp->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ExportDlgBase::OnHelp ), NULL, this );
 }
 
 ExportDlgBase::~ExportDlgBase()
 {
-	// Disconnect Events
-	m_comboUrl->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
-	m_comboDest->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
-	m_buttonBrowse->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ExportDlgBase::OnBrowse ), NULL, this );
-	m_textRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
-	m_checkUseLatest->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ExportDlgBase::OnCheckBox ), NULL, this );
-	m_textPegRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
-	m_checkPegNotSpecified->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ExportDlgBase::OnCheckBox ), NULL, this );
-	m_buttonHelp->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ExportDlgBase::OnHelp ), NULL, this );
+    // Disconnect Events
+    m_comboUrl->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
+    m_comboDest->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
+    m_buttonBrowse->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ExportDlgBase::OnBrowse ), NULL, this );
+    m_textRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
+    m_checkUseLatest->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ExportDlgBase::OnCheckBox ), NULL, this );
+    m_textPegRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ExportDlgBase::OnText ), NULL, this );
+    m_checkPegNotSpecified->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ExportDlgBase::OnCheckBox ), NULL, this );
+    m_buttonHelp->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ExportDlgBase::OnHelp ), NULL, this );
 }
 
 ListEditorDlgBase::ListEditorDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_listSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxEmptyString ), wxVERTICAL );
-	
-	m_mainSizer->Add( m_listSizer, 1, wxEXPAND, 5 );
-	
-	m_buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonNew = new wxButton( this, wxID_ANY, _("&New..."), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_buttonNew, 0, wxALL, 10 );
-	
-	m_buttonEdit = new wxButton( this, wxID_ANY, _("&Edit..."), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_buttonEdit, 0, wxALL, 10 );
-	
-	m_buttonDelete = new wxButton( this, wxID_ANY, _("&Delete..."), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_buttonDelete, 0, wxALL, 10 );
-	
-	
-	m_buttonSizer->Add( 20, 20, 1, wxEXPAND, 5 );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonCancel->SetDefault(); 
-	m_buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( m_buttonSizer, 0, wxEXPAND, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	
-	// Connect Events
-	m_buttonNew->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnNew ), NULL, this );
-	m_buttonEdit->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnEdit ), NULL, this );
-	m_buttonDelete->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnDelete ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_listSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxEmptyString ), wxVERTICAL );
+    
+    m_mainSizer->Add( m_listSizer, 1, wxEXPAND, 5 );
+    
+    m_buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonNew = new wxButton( this, wxID_ANY, _("&New..."), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_buttonNew, 0, wxALL, 10 );
+    
+    m_buttonEdit = new wxButton( this, wxID_ANY, _("&Edit..."), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_buttonEdit, 0, wxALL, 10 );
+    
+    m_buttonDelete = new wxButton( this, wxID_ANY, _("&Delete..."), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_buttonDelete, 0, wxALL, 10 );
+    
+    
+    m_buttonSizer->Add( 20, 20, 1, wxEXPAND, 5 );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonCancel->SetDefault(); 
+    m_buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( m_buttonSizer, 0, wxEXPAND, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    
+    // Connect Events
+    m_buttonNew->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnNew ), NULL, this );
+    m_buttonEdit->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnEdit ), NULL, this );
+    m_buttonDelete->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnDelete ), NULL, this );
 }
 
 ListEditorDlgBase::~ListEditorDlgBase()
 {
-	// Disconnect Events
-	m_buttonNew->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnNew ), NULL, this );
-	m_buttonEdit->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnEdit ), NULL, this );
-	m_buttonDelete->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnDelete ), NULL, this );
+    // Disconnect Events
+    m_buttonNew->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnNew ), NULL, this );
+    m_buttonEdit->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnEdit ), NULL, this );
+    m_buttonDelete->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ListEditorDlgBase::OnDelete ), NULL, this );
 }
 
 LockDlgBase::LockDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_msgSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Enter a comment for this lock") ), wxHORIZONTAL );
-	
-	m_textMessage = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
-	m_msgSizer->Add( m_textMessage, 1, wxEXPAND, 5 );
-	
-	m_mainSizer->Add( m_msgSizer, 1, wxALL|wxEXPAND, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_checkStealLock = new wxCheckBox( this, wxID_ANY, _("Steal lock if it belongs to another user"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_checkStealLock, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_RIGHT|wxLEFT|wxRIGHT, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	m_mainSizer->Fit( this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_msgSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Enter a comment for this lock") ), wxHORIZONTAL );
+    
+    m_textMessage = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
+    m_msgSizer->Add( m_textMessage, 1, wxEXPAND, 5 );
+    
+    m_mainSizer->Add( m_msgSizer, 1, wxALL|wxEXPAND, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_checkStealLock = new wxCheckBox( this, wxID_ANY, _("Steal lock if it belongs to another user"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_checkStealLock, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_RIGHT|wxLEFT|wxRIGHT, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    m_mainSizer->Fit( this );
 }
 
 LockDlgBase::~LockDlgBase()
@@ -1142,611 +1142,616 @@ LockDlgBase::~LockDlgBase()
 
 LogDlgBase::LogDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_splitter = new wxSplitterWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE|wxNO_BORDER );
-	m_splitter->Connect( wxEVT_IDLE, wxIdleEventHandler( LogDlgBase::m_splitterOnIdle ), NULL, this );
-	m_upperPanel = new wxPanel( m_splitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* upperSizer;
-	upperSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	wxBoxSizer* upperLeftSizer;
-	upperLeftSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticRevisions = new wxStaticText( m_upperPanel, wxID_ANY, _("History: %d revisions"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticRevisions->Wrap( -1 );
-	upperLeftSizer->Add( m_staticRevisions, 0, wxALL, 5 );
-	
-	m_listRevisions = new LogRevList( m_upperPanel, wxID_ANY, wxDefaultPosition, wxSize( 365,150 ), wxLC_REPORT );
-	upperLeftSizer->Add( m_listRevisions, 1, wxALL|wxEXPAND, 5 );
-	
-	upperSizer->Add( upperLeftSizer, 1, wxEXPAND, 5 );
-	
-	wxBoxSizer* upperRightSizer;
-	upperRightSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_buttonClose = new wxButton( m_upperPanel, wxID_CANCEL, _("Close"), wxDefaultPosition, wxDefaultSize, 0 );
-	upperRightSizer->Add( m_buttonClose, 0, wxALL|wxEXPAND, 5 );
-	
-	m_buttonView = new wxButton( m_upperPanel, wxID_ANY, _("&View"), wxDefaultPosition, wxDefaultSize, 0 );
-	upperRightSizer->Add( m_buttonView, 0, wxALL|wxEXPAND, 5 );
-	
-	m_buttonGet = new wxButton( m_upperPanel, wxID_ANY, _("&Get"), wxDefaultPosition, wxDefaultSize, 0 );
-	upperRightSizer->Add( m_buttonGet, 0, wxALL|wxEXPAND, 5 );
-	
-	m_buttonDiff = new wxButton( m_upperPanel, wxID_ANY, _("&Diff"), wxDefaultPosition, wxDefaultSize, 0 );
-	upperRightSizer->Add( m_buttonDiff, 0, wxALL|wxEXPAND, 5 );
-	
-	m_buttonMerge = new wxButton( m_upperPanel, wxID_ANY, _("&Merge"), wxDefaultPosition, wxDefaultSize, 0 );
-	upperRightSizer->Add( m_buttonMerge, 0, wxALL|wxEXPAND, 5 );
-	
-	m_buttonAnnotate = new wxButton( m_upperPanel, wxID_ANY, _("&Annotate"), wxDefaultPosition, wxDefaultSize, 0 );
-	upperRightSizer->Add( m_buttonAnnotate, 0, wxALL|wxEXPAND, 5 );
-	
-	upperSizer->Add( upperRightSizer, 0, wxEXPAND, 5 );
-	
-	m_upperPanel->SetSizer( upperSizer );
-	m_upperPanel->Layout();
-	upperSizer->Fit( m_upperPanel );
-	m_lowerPanel = new wxPanel( m_splitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* lowerSizer;
-	lowerSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_notebook = new wxNotebook( m_lowerPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
-	m_panelLog = new wxPanel( m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* logSizer;
-	logSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_textLog = new wxTextCtrl( m_panelLog, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY );
-	logSizer->Add( m_textLog, 1, wxEXPAND, 5 );
-	
-	m_panelLog->SetSizer( logSizer );
-	m_panelLog->Layout();
-	logSizer->Fit( m_panelLog );
-	m_notebook->AddPage( m_panelLog, _("Log Message"), true );
-	m_panelFiles = new wxPanel( m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* filesSizer;
-	filesSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_listFiles = new LogAffectedList( m_panelFiles, wxID_ANY, wxDefaultPosition, wxSize( 365,150 ), wxLC_REPORT );
-	filesSizer->Add( m_listFiles, 1, wxEXPAND, 5 );
-	
-	m_panelFiles->SetSizer( filesSizer );
-	m_panelFiles->Layout();
-	filesSizer->Fit( m_panelFiles );
-	m_notebook->AddPage( m_panelFiles, _("Affected Files/Dirs"), false );
-	
-	lowerSizer->Add( m_notebook, 1, wxEXPAND | wxALL, 5 );
-	
-	m_lowerPanel->SetSizer( lowerSizer );
-	m_lowerPanel->Layout();
-	lowerSizer->Fit( m_lowerPanel );
-	m_splitter->SplitHorizontally( m_upperPanel, m_lowerPanel, 0 );
-	m_mainSizer->Add( m_splitter, 1, wxEXPAND, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	
-	// Connect Events
-	m_listRevisions->Connect( wxEVT_COMMAND_LIST_ITEM_DESELECTED, wxListEventHandler( LogDlgBase::OnRevDeselected ), NULL, this );
-	m_listRevisions->Connect( wxEVT_COMMAND_LIST_ITEM_SELECTED, wxListEventHandler( LogDlgBase::OnRevSelected ), NULL, this );
-	m_buttonView->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnView ), NULL, this );
-	m_buttonGet->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnGet ), NULL, this );
-	m_buttonDiff->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnDiff ), NULL, this );
-	m_buttonMerge->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnMerge ), NULL, this );
-	m_buttonAnnotate->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnAnnotate ), NULL, this );
-	m_listFiles->Connect( wxEVT_COMMAND_LIST_ITEM_RIGHT_CLICK, wxListEventHandler( LogDlgBase::OnAffectedFileOrDirRightClick ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_splitter = new wxSplitterWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE|wxNO_BORDER );
+    m_splitter->Connect( wxEVT_IDLE, wxIdleEventHandler( LogDlgBase::m_splitterOnIdle ), NULL, this );
+    m_upperPanel = new wxPanel( m_splitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* upperSizer;
+    upperSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    wxBoxSizer* upperLeftSizer;
+    upperLeftSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_staticRevisions = new wxStaticText( m_upperPanel, wxID_ANY, _("History: %d revisions"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticRevisions->Wrap( -1 );
+    upperLeftSizer->Add( m_staticRevisions, 0, wxALL, 5 );
+    
+    m_listRevisions = new LogRevList( m_upperPanel, wxID_ANY, wxDefaultPosition, wxSize( 365,100 ), wxLC_REPORT );
+    upperLeftSizer->Add( m_listRevisions, 1, wxALL|wxEXPAND, 5 );
+
+    m_buttonMore = new wxButton( m_upperPanel, wxID_ANY, _("more"), wxDefaultPosition, wxSize( -1,25 ), 0 );
+    upperLeftSizer->Add( m_buttonMore, 0, wxEXPAND, 5 );
+    
+    upperSizer->Add( upperLeftSizer, 1, wxEXPAND, 5 );
+    
+    wxBoxSizer* upperRightSizer;
+    upperRightSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_buttonClose = new wxButton( m_upperPanel, wxID_CANCEL, _("Close"), wxDefaultPosition, wxDefaultSize, 0 );
+    upperRightSizer->Add( m_buttonClose, 0, wxALL|wxEXPAND, 5 );
+    
+    m_buttonView = new wxButton( m_upperPanel, wxID_ANY, _("&View"), wxDefaultPosition, wxDefaultSize, 0 );
+    upperRightSizer->Add( m_buttonView, 0, wxALL|wxEXPAND, 5 );
+    
+    m_buttonGet = new wxButton( m_upperPanel, wxID_ANY, _("&Get"), wxDefaultPosition, wxDefaultSize, 0 );
+    upperRightSizer->Add( m_buttonGet, 0, wxALL|wxEXPAND, 5 );
+    
+    m_buttonDiff = new wxButton( m_upperPanel, wxID_ANY, _("&Diff"), wxDefaultPosition, wxDefaultSize, 0 );
+    upperRightSizer->Add( m_buttonDiff, 0, wxALL|wxEXPAND, 5 );
+    
+    m_buttonMerge = new wxButton( m_upperPanel, wxID_ANY, _("&Merge"), wxDefaultPosition, wxDefaultSize, 0 );
+    upperRightSizer->Add( m_buttonMerge, 0, wxALL|wxEXPAND, 5 );
+    
+    m_buttonAnnotate = new wxButton( m_upperPanel, wxID_ANY, _("&Annotate"), wxDefaultPosition, wxDefaultSize, 0 );
+    upperRightSizer->Add( m_buttonAnnotate, 0, wxALL|wxEXPAND, 5 );
+    
+    upperSizer->Add( upperRightSizer, 0, wxEXPAND, 5 );
+    
+    m_upperPanel->SetSizer( upperSizer );
+    m_upperPanel->Layout();
+    upperSizer->Fit( m_upperPanel );
+    m_lowerPanel = new wxPanel( m_splitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* lowerSizer;
+    lowerSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_notebook = new wxNotebook( m_lowerPanel, wxID_ANY, wxDefaultPosition, wxSize( -1,80 ), 0 );
+    m_panelLog = new wxPanel( m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* logSizer;
+    logSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_textLog = new wxTextCtrl( m_panelLog, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY );
+    logSizer->Add( m_textLog, 1, wxEXPAND, 5 );
+    
+    m_panelLog->SetSizer( logSizer );
+    m_panelLog->Layout();
+    logSizer->Fit( m_panelLog );
+    m_notebook->AddPage( m_panelLog, _("Log Message"), true );
+    m_panelFiles = new wxPanel( m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* filesSizer;
+    filesSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_listFiles = new LogAffectedList( m_panelFiles, wxID_ANY, wxDefaultPosition, wxSize( 365,150 ), wxLC_REPORT );
+    filesSizer->Add( m_listFiles, 1, wxEXPAND, 5 );
+    
+    m_panelFiles->SetSizer( filesSizer );
+    m_panelFiles->Layout();
+    filesSizer->Fit( m_panelFiles );
+    m_notebook->AddPage( m_panelFiles, _("Affected Files/Dirs"), false );
+    
+    lowerSizer->Add( m_notebook, 1, wxEXPAND | wxALL, 5 );
+    
+    m_lowerPanel->SetSizer( lowerSizer );
+    m_lowerPanel->Layout();
+    lowerSizer->Fit( m_lowerPanel );
+    m_splitter->SplitHorizontally( m_upperPanel, m_lowerPanel, 0 );
+    m_mainSizer->Add( m_splitter, 1, wxEXPAND, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    
+    // Connect Events
+    m_listRevisions->Connect( wxEVT_COMMAND_LIST_ITEM_DESELECTED, wxListEventHandler( LogDlgBase::OnRevDeselected ), NULL, this );
+    m_listRevisions->Connect( wxEVT_COMMAND_LIST_ITEM_SELECTED, wxListEventHandler( LogDlgBase::OnRevSelected ), NULL, this );
+    m_buttonMore->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnMore ), NULL, this );
+    m_buttonView->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnView ), NULL, this );
+    m_buttonGet->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnGet ), NULL, this );
+    m_buttonDiff->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnDiff ), NULL, this );
+    m_buttonMerge->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnMerge ), NULL, this );
+    m_buttonAnnotate->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnAnnotate ), NULL, this );
+    m_listFiles->Connect( wxEVT_COMMAND_LIST_ITEM_RIGHT_CLICK, wxListEventHandler( LogDlgBase::OnAffectedFileOrDirRightClick ), NULL, this );
 }
 
 LogDlgBase::~LogDlgBase()
 {
-	// Disconnect Events
-	m_listRevisions->Disconnect( wxEVT_COMMAND_LIST_ITEM_DESELECTED, wxListEventHandler( LogDlgBase::OnRevDeselected ), NULL, this );
-	m_listRevisions->Disconnect( wxEVT_COMMAND_LIST_ITEM_SELECTED, wxListEventHandler( LogDlgBase::OnRevSelected ), NULL, this );
-	m_buttonView->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnView ), NULL, this );
-	m_buttonGet->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnGet ), NULL, this );
-	m_buttonDiff->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnDiff ), NULL, this );
-	m_buttonMerge->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnMerge ), NULL, this );
-	m_buttonAnnotate->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnAnnotate ), NULL, this );
-	m_listFiles->Disconnect( wxEVT_COMMAND_LIST_ITEM_RIGHT_CLICK, wxListEventHandler( LogDlgBase::OnAffectedFileOrDirRightClick ), NULL, this );
+    // Disconnect Events
+    m_listRevisions->Disconnect( wxEVT_COMMAND_LIST_ITEM_DESELECTED, wxListEventHandler( LogDlgBase::OnRevDeselected ), NULL, this );
+    m_listRevisions->Disconnect( wxEVT_COMMAND_LIST_ITEM_SELECTED, wxListEventHandler( LogDlgBase::OnRevSelected ), NULL, this );
+    m_buttonMore->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnMore ), NULL, this );
+    m_buttonView->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnView ), NULL, this );
+    m_buttonGet->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnGet ), NULL, this );
+    m_buttonDiff->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnDiff ), NULL, this );
+    m_buttonMerge->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnMerge ), NULL, this );
+    m_buttonAnnotate->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( LogDlgBase::OnAnnotate ), NULL, this );
+    m_listFiles->Disconnect( wxEVT_COMMAND_LIST_ITEM_RIGHT_CLICK, wxListEventHandler( LogDlgBase::OnAffectedFileOrDirRightClick ), NULL, this );
 }
 
 ImportDlgBase::ImportDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	wxStaticBoxSizer* urlSizer;
-	urlSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Repository &URL for import") ), wxVERTICAL );
-	
-	m_comboUrl = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, 0 ); 
-	urlSizer->Add( m_comboUrl, 0, wxALL|wxEXPAND, 5 );
-	
-	m_mainSizer->Add( urlSizer, 0, wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* pathSizer;
-	pathSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Import &Path") ), wxVERTICAL );
-	
-	wxBoxSizer* pathNameSizer;
-	pathNameSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_textPath = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	pathNameSizer->Add( m_textPath, 1, wxALL, 5 );
-	
-	m_buttonBrowse = new wxButton( this, wxID_ANY, _("..."), wxDefaultPosition, wxSize( 20,-1 ), 0 );
-	pathNameSizer->Add( m_buttonBrowse, 0, wxALL, 5 );
-	
-	pathSizer->Add( pathNameSizer, 0, wxEXPAND, 5 );
-	
-	wxBoxSizer* importTypeSizer;
-	importTypeSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_staticPathType = new wxStaticText( this, wxID_ANY, _("Path &type"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticPathType->Wrap( -1 );
-	importTypeSizer->Add( m_staticPathType, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxALL, 5 );
-	
-	wxString m_choicePathTypeChoices[] = { _("Directory"), _("File") };
-	int m_choicePathTypeNChoices = sizeof( m_choicePathTypeChoices ) / sizeof( wxString );
-	m_choicePathType = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choicePathTypeNChoices, m_choicePathTypeChoices, 0 );
-	m_choicePathType->SetSelection( 0 );
-	importTypeSizer->Add( m_choicePathType, 0, wxALIGN_CENTER_VERTICAL, 5 );
-	
-	pathSizer->Add( importTypeSizer, 0, 0, 5 );
-	
-	m_mainSizer->Add( pathSizer, 0, wxEXPAND, 5 );
-	
-	m_msgSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("End &log message") ), wxHORIZONTAL );
-	
-	m_textMessage = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
-	m_msgSizer->Add( m_textMessage, 1, wxEXPAND, 5 );
-	
-	m_mainSizer->Add( m_msgSizer, 1, wxEXPAND, 5 );
-	
-	m_buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_checkRecursive, 0, wxALIGN_CENTER_VERTICAL|wxALL, 10 );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	m_buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( m_buttonSizer, 0, wxALIGN_CENTER, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	m_mainSizer->Fit( this );
-	
-	// Connect Events
-	m_comboUrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
-	m_textPath->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
-	m_buttonBrowse->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ImportDlgBase::OnBrowse ), NULL, this );
-	m_choicePathType->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    wxStaticBoxSizer* urlSizer;
+    urlSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Repository &URL for import") ), wxVERTICAL );
+    
+    m_comboUrl = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, 0 ); 
+    urlSizer->Add( m_comboUrl, 0, wxALL|wxEXPAND, 5 );
+    
+    m_mainSizer->Add( urlSizer, 0, wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* pathSizer;
+    pathSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Import &Path") ), wxVERTICAL );
+    
+    wxBoxSizer* pathNameSizer;
+    pathNameSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_textPath = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    pathNameSizer->Add( m_textPath, 1, wxALL, 5 );
+    
+    m_buttonBrowse = new wxButton( this, wxID_ANY, _("..."), wxDefaultPosition, wxSize( 20,-1 ), 0 );
+    pathNameSizer->Add( m_buttonBrowse, 0, wxALL, 5 );
+    
+    pathSizer->Add( pathNameSizer, 0, wxEXPAND, 5 );
+    
+    wxBoxSizer* importTypeSizer;
+    importTypeSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_staticPathType = new wxStaticText( this, wxID_ANY, _("Path &type"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticPathType->Wrap( -1 );
+    importTypeSizer->Add( m_staticPathType, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxALL, 5 );
+    
+    wxString m_choicePathTypeChoices[] = { _("Directory"), _("File") };
+    int m_choicePathTypeNChoices = sizeof( m_choicePathTypeChoices ) / sizeof( wxString );
+    m_choicePathType = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choicePathTypeNChoices, m_choicePathTypeChoices, 0 );
+    m_choicePathType->SetSelection( 0 );
+    importTypeSizer->Add( m_choicePathType, 0, wxALIGN_CENTER_VERTICAL, 5 );
+    
+    pathSizer->Add( importTypeSizer, 0, 0, 5 );
+    
+    m_mainSizer->Add( pathSizer, 0, wxEXPAND, 5 );
+    
+    m_msgSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("End &log message") ), wxHORIZONTAL );
+    
+    m_textMessage = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
+    m_msgSizer->Add( m_textMessage, 1, wxEXPAND, 5 );
+    
+    m_mainSizer->Add( m_msgSizer, 1, wxEXPAND, 5 );
+    
+    m_buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_checkRecursive, 0, wxALIGN_CENTER_VERTICAL|wxALL, 10 );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    m_buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( m_buttonSizer, 0, wxALIGN_CENTER, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    m_mainSizer->Fit( this );
+    
+    // Connect Events
+    m_comboUrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
+    m_textPath->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
+    m_buttonBrowse->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ImportDlgBase::OnBrowse ), NULL, this );
+    m_choicePathType->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
 }
 
 ImportDlgBase::~ImportDlgBase()
 {
-	// Disconnect Events
-	m_comboUrl->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
-	m_textPath->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
-	m_buttonBrowse->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ImportDlgBase::OnBrowse ), NULL, this );
-	m_choicePathType->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
+    // Disconnect Events
+    m_comboUrl->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
+    m_textPath->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
+    m_buttonBrowse->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ImportDlgBase::OnBrowse ), NULL, this );
+    m_choicePathType->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( ImportDlgBase::OnCommand ), NULL, this );
 }
 
 MainFrameBase::MainFrameBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxFrame( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	wxBoxSizer* sizerRoot;
-	sizerRoot = new wxBoxSizer( wxVERTICAL );
-	
-	m_splitterHoriz = new SplitterWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE );
-	m_splitterHoriz->SetSashGravity( 1 );
-	m_splitterHoriz->Connect( wxEVT_IDLE, wxIdleEventHandler( MainFrameBase::m_splitterHorizOnIdle ), NULL, this );
-	m_panelTop = new wxPanel( m_splitterHoriz, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* sizerTop;
-	sizerTop = new wxBoxSizer( wxVERTICAL );
-	
-	m_splitterVert = new SplitterWindow( m_panelTop, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE );
-	m_splitterVert->Connect( wxEVT_IDLE, wxIdleEventHandler( MainFrameBase::m_splitterVertOnIdle ), NULL, this );
-	panelFolderBrowser = new wxPanel( m_splitterVert, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	sizerFolderBrowser = new wxBoxSizer( wxVERTICAL );
-	
-	m_folderBrowser = new FolderBrowser( panelFolderBrowser, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE );
-	sizerFolderBrowser->Add( m_folderBrowser, 1, wxEXPAND, 5 );
-	
-	panelFolderBrowser->SetSizer( sizerFolderBrowser );
-	panelFolderBrowser->Layout();
-	sizerFolderBrowser->Fit( panelFolderBrowser );
-	panelListCtrl = new wxPanel( m_splitterVert, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	sizerListCtrl = new wxBoxSizer( wxVERTICAL );
-	
-	m_listCtrl = new FileListCtrl( panelListCtrl, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_REPORT );
-	sizerListCtrl->Add( m_listCtrl, 1, wxEXPAND, 5 );
-	
-	panelListCtrl->SetSizer( sizerListCtrl );
-	panelListCtrl->Layout();
-	sizerListCtrl->Fit( panelListCtrl );
-	m_splitterVert->SplitVertically( panelFolderBrowser, panelListCtrl, 0 );
-	sizerTop->Add( m_splitterVert, 1, wxEXPAND, 5 );
-	
-	m_panelTop->SetSizer( sizerTop );
-	m_panelTop->Layout();
-	sizerTop->Fit( m_panelTop );
-	panelBottom = new wxPanel( m_splitterHoriz, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	sizerBottom = new wxBoxSizer( wxVERTICAL );
-	
-	m_log = new wxTextCtrl( panelBottom, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY|wxTE_RICH2|wxSUNKEN_BORDER );
-	sizerBottom->Add( m_log, 1, wxEXPAND, 5 );
-	
-	panelBottom->SetSizer( sizerBottom );
-	panelBottom->Layout();
-	sizerBottom->Fit( panelBottom );
-	m_splitterHoriz->SplitHorizontally( m_panelTop, panelBottom, -1 );
-	sizerRoot->Add( m_splitterHoriz, 1, wxEXPAND, 5 );
-	
-	this->SetSizer( sizerRoot );
-	this->Layout();
-	m_statusBar = this->CreateStatusBar( 1, wxST_SIZEGRIP, wxID_ANY );
-	
-	// Connect Events
-	this->Connect( wxEVT_ACTIVATE, wxActivateEventHandler( MainFrameBase::OnActivate ) );
-	this->Connect( wxEVT_SIZE, wxSizeEventHandler( MainFrameBase::OnSize ) );
-	m_folderBrowser->Connect( wxEVT_SET_FOCUS, wxFocusEventHandler( MainFrameBase::OnFolderBrowserSetFocus ), NULL, this );
-	m_listCtrl->Connect( wxEVT_SET_FOCUS, wxFocusEventHandler( MainFrameBase::OnListCtrlSetFocus ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    wxBoxSizer* sizerRoot;
+    sizerRoot = new wxBoxSizer( wxVERTICAL );
+    
+    m_splitterHoriz = new SplitterWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE );
+    m_splitterHoriz->SetSashGravity( 1 );
+    m_splitterHoriz->Connect( wxEVT_IDLE, wxIdleEventHandler( MainFrameBase::m_splitterHorizOnIdle ), NULL, this );
+    m_panelTop = new wxPanel( m_splitterHoriz, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* sizerTop;
+    sizerTop = new wxBoxSizer( wxVERTICAL );
+    
+    m_splitterVert = new SplitterWindow( m_panelTop, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE );
+    m_splitterVert->Connect( wxEVT_IDLE, wxIdleEventHandler( MainFrameBase::m_splitterVertOnIdle ), NULL, this );
+    panelFolderBrowser = new wxPanel( m_splitterVert, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    sizerFolderBrowser = new wxBoxSizer( wxVERTICAL );
+    
+    m_folderBrowser = new FolderBrowser( panelFolderBrowser, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE );
+    sizerFolderBrowser->Add( m_folderBrowser, 1, wxEXPAND, 5 );
+    
+    panelFolderBrowser->SetSizer( sizerFolderBrowser );
+    panelFolderBrowser->Layout();
+    sizerFolderBrowser->Fit( panelFolderBrowser );
+    panelListCtrl = new wxPanel( m_splitterVert, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    sizerListCtrl = new wxBoxSizer( wxVERTICAL );
+    
+    m_listCtrl = new FileListCtrl( panelListCtrl, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_REPORT );
+    sizerListCtrl->Add( m_listCtrl, 1, wxEXPAND, 5 );
+    
+    panelListCtrl->SetSizer( sizerListCtrl );
+    panelListCtrl->Layout();
+    sizerListCtrl->Fit( panelListCtrl );
+    m_splitterVert->SplitVertically( panelFolderBrowser, panelListCtrl, 0 );
+    sizerTop->Add( m_splitterVert, 1, wxEXPAND, 5 );
+    
+    m_panelTop->SetSizer( sizerTop );
+    m_panelTop->Layout();
+    sizerTop->Fit( m_panelTop );
+    panelBottom = new wxPanel( m_splitterHoriz, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    sizerBottom = new wxBoxSizer( wxVERTICAL );
+    
+    m_log = new wxTextCtrl( panelBottom, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY|wxTE_RICH2|wxSUNKEN_BORDER );
+    sizerBottom->Add( m_log, 1, wxEXPAND, 5 );
+    
+    panelBottom->SetSizer( sizerBottom );
+    panelBottom->Layout();
+    sizerBottom->Fit( panelBottom );
+    m_splitterHoriz->SplitHorizontally( m_panelTop, panelBottom, -1 );
+    sizerRoot->Add( m_splitterHoriz, 1, wxEXPAND, 5 );
+    
+    this->SetSizer( sizerRoot );
+    this->Layout();
+    m_statusBar = this->CreateStatusBar( 1, wxST_SIZEGRIP, wxID_ANY );
+    
+    // Connect Events
+    this->Connect( wxEVT_ACTIVATE, wxActivateEventHandler( MainFrameBase::OnActivate ) );
+    this->Connect( wxEVT_SIZE, wxSizeEventHandler( MainFrameBase::OnSize ) );
+    m_folderBrowser->Connect( wxEVT_SET_FOCUS, wxFocusEventHandler( MainFrameBase::OnFolderBrowserSetFocus ), NULL, this );
+    m_listCtrl->Connect( wxEVT_SET_FOCUS, wxFocusEventHandler( MainFrameBase::OnListCtrlSetFocus ), NULL, this );
 }
 
 MainFrameBase::~MainFrameBase()
 {
-	// Disconnect Events
-	this->Disconnect( wxEVT_ACTIVATE, wxActivateEventHandler( MainFrameBase::OnActivate ) );
-	this->Disconnect( wxEVT_SIZE, wxSizeEventHandler( MainFrameBase::OnSize ) );
-	m_folderBrowser->Disconnect( wxEVT_SET_FOCUS, wxFocusEventHandler( MainFrameBase::OnFolderBrowserSetFocus ), NULL, this );
-	m_listCtrl->Disconnect( wxEVT_SET_FOCUS, wxFocusEventHandler( MainFrameBase::OnListCtrlSetFocus ), NULL, this );
+    // Disconnect Events
+    this->Disconnect( wxEVT_ACTIVATE, wxActivateEventHandler( MainFrameBase::OnActivate ) );
+    this->Disconnect( wxEVT_SIZE, wxSizeEventHandler( MainFrameBase::OnSize ) );
+    m_folderBrowser->Disconnect( wxEVT_SET_FOCUS, wxFocusEventHandler( MainFrameBase::OnFolderBrowserSetFocus ), NULL, this );
+    m_listCtrl->Disconnect( wxEVT_SET_FOCUS, wxFocusEventHandler( MainFrameBase::OnListCtrlSetFocus ), NULL, this );
 }
 
 MergeDlgBase::MergeDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	wxStaticBoxSizer* sizer1;
-	sizer1 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("First working copy or URL") ), wxHORIZONTAL );
-	
-	wxFlexGridSizer* fgSizer1;
-	fgSizer1 = new wxFlexGridSizer( 2, 2, 0, 5 );
-	fgSizer1->AddGrowableCol( 0 );
-	fgSizer1->SetFlexibleDirection( wxBOTH );
-	fgSizer1->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
-	
-	fgSizer1->Add( 0, 0, 1, wxEXPAND, 5 );
-	
-	m_staticRevision1 = new wxStaticText( this, wxID_ANY, _("&Revision"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticRevision1->Wrap( -1 );
-	fgSizer1->Add( m_staticRevision1, 0, 0, 5 );
-	
-	m_comboUrl1 = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, wxCB_DROPDOWN ); 
-	fgSizer1->Add( m_comboUrl1, 1, wxEXPAND, 5 );
-	
-	m_textRevision1 = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	fgSizer1->Add( m_textRevision1, 0, wxALIGN_CENTER_VERTICAL|wxEXPAND, 5 );
-	
-	sizer1->Add( fgSizer1, 1, wxEXPAND, 5 );
-	
-	m_mainSizer->Add( sizer1, 0, wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* sizer2;
-	sizer2 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("First working copy or URL") ), wxHORIZONTAL );
-	
-	wxFlexGridSizer* fgSizer2;
-	fgSizer2 = new wxFlexGridSizer( 2, 2, 0, 5 );
-	fgSizer2->AddGrowableCol( 0 );
-	fgSizer2->SetFlexibleDirection( wxBOTH );
-	fgSizer2->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
-	
-	fgSizer2->Add( 0, 0, 1, wxEXPAND, 5 );
-	
-	m_staticRevision2 = new wxStaticText( this, wxID_ANY, _("&Revision"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticRevision2->Wrap( -1 );
-	fgSizer2->Add( m_staticRevision2, 0, 0, 5 );
-	
-	m_comboUrl2 = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, wxCB_DROPDOWN ); 
-	fgSizer2->Add( m_comboUrl2, 1, wxEXPAND, 5 );
-	
-	m_textRevision2 = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	fgSizer2->Add( m_textRevision2, 0, wxALIGN_CENTER_VERTICAL|wxEXPAND, 5 );
-	
-	sizer2->Add( fgSizer2, 1, wxEXPAND, 5 );
-	
-	m_mainSizer->Add( sizer2, 0, wxEXPAND, 5 );
-	
-	wxStaticBoxSizer* destSizer;
-	destSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Destination Directory") ), wxHORIZONTAL );
-	
-	m_comboDest = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 205,-1 ), 0, NULL, 0 ); 
-	destSizer->Add( m_comboDest, 1, wxEXPAND, 5 );
-	
-	m_buttonBrowse = new wxButton( this, wxID_ANY, _("..."), wxDefaultPosition, wxSize( 20,-1 ), 0 );
-	destSizer->Add( m_buttonBrowse, 0, wxLEFT, 5 );
-	
-	m_mainSizer->Add( destSizer, 0, wxEXPAND, 5 );
-	
-	wxBoxSizer* optionSizer;
-	optionSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
-	optionSizer->Add( m_checkRecursive, 0, 0, 5 );
-	
-	m_checkForce = new wxCheckBox( this, wxID_ANY, _("Force"), wxDefaultPosition, wxDefaultSize, 0 );
-	optionSizer->Add( m_checkForce, 0, 0, 5 );
-	
-	m_mainSizer->Add( optionSizer, 1, wxALIGN_CENTER|wxBOTTOM|wxTOP, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	
-	// Connect Events
-	m_comboUrl1->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
-	m_textRevision1->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
-	m_comboUrl2->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
-	m_textRevision2->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
-	m_comboDest->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
-	m_buttonBrowse->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( MergeDlgBase::OnBrowse ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    wxStaticBoxSizer* sizer1;
+    sizer1 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("First working copy or URL") ), wxHORIZONTAL );
+    
+    wxFlexGridSizer* fgSizer1;
+    fgSizer1 = new wxFlexGridSizer( 2, 2, 0, 5 );
+    fgSizer1->AddGrowableCol( 0 );
+    fgSizer1->SetFlexibleDirection( wxBOTH );
+    fgSizer1->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    
+    
+    fgSizer1->Add( 0, 0, 1, wxEXPAND, 5 );
+    
+    m_staticRevision1 = new wxStaticText( this, wxID_ANY, _("&Revision"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticRevision1->Wrap( -1 );
+    fgSizer1->Add( m_staticRevision1, 0, 0, 5 );
+    
+    m_comboUrl1 = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, wxCB_DROPDOWN ); 
+    fgSizer1->Add( m_comboUrl1, 1, wxEXPAND, 5 );
+    
+    m_textRevision1 = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    fgSizer1->Add( m_textRevision1, 0, wxALIGN_CENTER_VERTICAL|wxEXPAND, 5 );
+    
+    sizer1->Add( fgSizer1, 1, wxEXPAND, 5 );
+    
+    m_mainSizer->Add( sizer1, 0, wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* sizer2;
+    sizer2 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("First working copy or URL") ), wxHORIZONTAL );
+    
+    wxFlexGridSizer* fgSizer2;
+    fgSizer2 = new wxFlexGridSizer( 2, 2, 0, 5 );
+    fgSizer2->AddGrowableCol( 0 );
+    fgSizer2->SetFlexibleDirection( wxBOTH );
+    fgSizer2->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    
+    
+    fgSizer2->Add( 0, 0, 1, wxEXPAND, 5 );
+    
+    m_staticRevision2 = new wxStaticText( this, wxID_ANY, _("&Revision"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticRevision2->Wrap( -1 );
+    fgSizer2->Add( m_staticRevision2, 0, 0, 5 );
+    
+    m_comboUrl2 = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, wxCB_DROPDOWN ); 
+    fgSizer2->Add( m_comboUrl2, 1, wxEXPAND, 5 );
+    
+    m_textRevision2 = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    fgSizer2->Add( m_textRevision2, 0, wxALIGN_CENTER_VERTICAL|wxEXPAND, 5 );
+    
+    sizer2->Add( fgSizer2, 1, wxEXPAND, 5 );
+    
+    m_mainSizer->Add( sizer2, 0, wxEXPAND, 5 );
+    
+    wxStaticBoxSizer* destSizer;
+    destSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Destination Directory") ), wxHORIZONTAL );
+    
+    m_comboDest = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 205,-1 ), 0, NULL, 0 ); 
+    destSizer->Add( m_comboDest, 1, wxEXPAND, 5 );
+    
+    m_buttonBrowse = new wxButton( this, wxID_ANY, _("..."), wxDefaultPosition, wxSize( 20,-1 ), 0 );
+    destSizer->Add( m_buttonBrowse, 0, wxLEFT, 5 );
+    
+    m_mainSizer->Add( destSizer, 0, wxEXPAND, 5 );
+    
+    wxBoxSizer* optionSizer;
+    optionSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
+    optionSizer->Add( m_checkRecursive, 0, 0, 5 );
+    
+    m_checkForce = new wxCheckBox( this, wxID_ANY, _("Force"), wxDefaultPosition, wxDefaultSize, 0 );
+    optionSizer->Add( m_checkForce, 0, 0, 5 );
+    
+    m_mainSizer->Add( optionSizer, 1, wxALIGN_CENTER|wxBOTTOM|wxTOP, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    
+    // Connect Events
+    m_comboUrl1->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
+    m_textRevision1->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
+    m_comboUrl2->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
+    m_textRevision2->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
+    m_comboDest->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
+    m_buttonBrowse->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( MergeDlgBase::OnBrowse ), NULL, this );
 }
 
 MergeDlgBase::~MergeDlgBase()
 {
-	// Disconnect Events
-	m_comboUrl1->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
-	m_textRevision1->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
-	m_comboUrl2->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
-	m_textRevision2->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
-	m_comboDest->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
-	m_buttonBrowse->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( MergeDlgBase::OnBrowse ), NULL, this );
+    // Disconnect Events
+    m_comboUrl1->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
+    m_textRevision1->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
+    m_comboUrl2->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
+    m_textRevision2->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
+    m_comboDest->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( MergeDlgBase::OnText ), NULL, this );
+    m_buttonBrowse->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( MergeDlgBase::OnBrowse ), NULL, this );
 }
 
 PreferencesDlgBase::PreferencesDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	wxBoxSizer* mainSizer;
-	mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_notebookMain = new wxNotebook( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
-	m_panelGeneral = new wxPanel( m_notebookMain, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* bSizer3;
-	bSizer3 = new wxBoxSizer( wxVERTICAL );
-	
-	m_checkPurgeTempFiles = new wxCheckBox( m_panelGeneral, wxID_ANY, _("Purge temporary files on program exit"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer3->Add( m_checkPurgeTempFiles, 0, wxALL, 5 );
-	
-	m_checkUseLastCommitMessage = new wxCheckBox( m_panelGeneral, wxID_ANY, _("Commit log message: default to most recent"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer3->Add( m_checkUseLastCommitMessage, 0, wxALL, 5 );
-	
-	m_checkResetFlatMode = new wxCheckBox( m_panelGeneral, wxID_ANY, _("Reset Flat Mode on every program start"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer3->Add( m_checkResetFlatMode, 0, wxALL, 5 );
-	
-	m_panelGeneral->SetSizer( bSizer3 );
-	m_panelGeneral->Layout();
-	bSizer3->Fit( m_panelGeneral );
-	m_notebookMain->AddPage( m_panelGeneral, _("General"), false );
-	m_panelPrograms = new wxPanel( m_notebookMain, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* bSizer4;
-	bSizer4 = new wxBoxSizer( wxVERTICAL );
-	
-	m_notebook2 = new wxNotebook( m_panelPrograms, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
-	m_panelEditor = new wxPanel( m_notebook2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* sizerPanelEditor;
-	sizerPanelEditor = new wxBoxSizer( wxVERTICAL );
-	
-	wxBoxSizer* sizerEditor;
-	sizerEditor = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_textEditor = new wxTextCtrl( m_panelEditor, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	sizerEditor->Add( m_textEditor, 1, wxALL, 5 );
-	
-	m_buttonEditor = new wxButton( m_panelEditor, wxID_ANY, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerEditor->Add( m_buttonEditor, 0, wxALL, 5 );
-	
-	sizerPanelEditor->Add( sizerEditor, 0, wxEXPAND, 5 );
-	
-	wxStaticText* m_staticEditorArgs;
-	m_staticEditorArgs = new wxStaticText( m_panelEditor, wxID_ANY, _("Program arguments (%1=selected file):"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticEditorArgs->Wrap( -1 );
-	sizerPanelEditor->Add( m_staticEditorArgs, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
-	
-	m_textEditorArgs = new wxTextCtrl( m_panelEditor, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	sizerPanelEditor->Add( m_textEditorArgs, 0, wxALL|wxEXPAND, 5 );
-	
-	m_checkEditorAlways = new wxCheckBox( m_panelEditor, wxID_ANY, _("Use always"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerPanelEditor->Add( m_checkEditorAlways, 0, wxALL, 5 );
-	
-	m_panelEditor->SetSizer( sizerPanelEditor );
-	m_panelEditor->Layout();
-	sizerPanelEditor->Fit( m_panelEditor );
-	m_notebook2->AddPage( m_panelEditor, _("Standard Editor"), true );
-	m_panelExplorer = new wxPanel( m_notebook2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* sizerPanelExplorer;
-	sizerPanelExplorer = new wxBoxSizer( wxVERTICAL );
-	
-	wxBoxSizer* sizerExplorer;
-	sizerExplorer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_textExplorer = new wxTextCtrl( m_panelExplorer, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	sizerExplorer->Add( m_textExplorer, 1, wxALL, 5 );
-	
-	m_buttonExplorer = new wxButton( m_panelExplorer, wxID_ANY, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerExplorer->Add( m_buttonExplorer, 0, wxALL, 5 );
-	
-	sizerPanelExplorer->Add( sizerExplorer, 0, wxEXPAND, 0 );
-	
-	wxStaticText* m_staticExplorerArgs;
-	m_staticExplorerArgs = new wxStaticText( m_panelExplorer, wxID_ANY, _("Program arguments (%1=selected directory):"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticExplorerArgs->Wrap( -1 );
-	sizerPanelExplorer->Add( m_staticExplorerArgs, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
-	
-	m_textExplorerArgs = new wxTextCtrl( m_panelExplorer, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	sizerPanelExplorer->Add( m_textExplorerArgs, 0, wxALL|wxEXPAND, 5 );
-	
-	m_checkExplorerAlways = new wxCheckBox( m_panelExplorer, wxID_ANY, _("Use always"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerPanelExplorer->Add( m_checkExplorerAlways, 0, wxALL, 5 );
-	
-	m_panelExplorer->SetSizer( sizerPanelExplorer );
-	m_panelExplorer->Layout();
-	sizerPanelExplorer->Fit( m_panelExplorer );
-	m_notebook2->AddPage( m_panelExplorer, _("Standard Explorer"), false );
-	m_panelDiffTool = new wxPanel( m_notebook2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* sizerPanelDiffTool;
-	sizerPanelDiffTool = new wxBoxSizer( wxVERTICAL );
-	
-	wxBoxSizer* sizerDiffTool;
-	sizerDiffTool = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_textDiffTool = new wxTextCtrl( m_panelDiffTool, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	sizerDiffTool->Add( m_textDiffTool, 1, wxALL, 5 );
-	
-	m_buttonDiffTool = new wxButton( m_panelDiffTool, wxID_ANY, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerDiffTool->Add( m_buttonDiffTool, 0, wxALL, 5 );
-	
-	sizerPanelDiffTool->Add( sizerDiffTool, 0, wxEXPAND, 5 );
-	
-	wxStaticText* m_staticDiffToolArgs;
-	m_staticDiffToolArgs = new wxStaticText( m_panelDiffTool, wxID_ANY, _("Program arguments (%1=file1, %2=file2):"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticDiffToolArgs->Wrap( -1 );
-	sizerPanelDiffTool->Add( m_staticDiffToolArgs, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
-	
-	m_textDiffToolArgs = new wxTextCtrl( m_panelDiffTool, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	sizerPanelDiffTool->Add( m_textDiffToolArgs, 0, wxALL|wxEXPAND, 5 );
-	
-	m_panelDiffTool->SetSizer( sizerPanelDiffTool );
-	m_panelDiffTool->Layout();
-	sizerPanelDiffTool->Fit( m_panelDiffTool );
-	m_notebook2->AddPage( m_panelDiffTool, _("Diff Tool"), false );
-	m_panelMergeTool = new wxPanel( m_notebook2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* sizerPanelMergeTool;
-	sizerPanelMergeTool = new wxBoxSizer( wxVERTICAL );
-	
-	wxBoxSizer* sizerMergeTool;
-	sizerMergeTool = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_textMergeTool = new wxTextCtrl( m_panelMergeTool, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	sizerMergeTool->Add( m_textMergeTool, 1, wxALL, 5 );
-	
-	m_buttonMergeTool = new wxButton( m_panelMergeTool, wxID_ANY, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerMergeTool->Add( m_buttonMergeTool, 0, wxALL, 5 );
-	
-	sizerPanelMergeTool->Add( sizerMergeTool, 0, wxEXPAND, 5 );
-	
-	m_staticMergeToolArgs = new wxStaticText( m_panelMergeTool, wxID_ANY, _("Program arguments (%1=base, %2=theirs %3=mine %4=result):"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticMergeToolArgs->Wrap( -1 );
-	sizerPanelMergeTool->Add( m_staticMergeToolArgs, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
-	
-	m_textMergeToolArgs = new wxTextCtrl( m_panelMergeTool, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	sizerPanelMergeTool->Add( m_textMergeToolArgs, 0, wxALL|wxEXPAND, 5 );
-	
-	m_panelMergeTool->SetSizer( sizerPanelMergeTool );
-	m_panelMergeTool->Layout();
-	sizerPanelMergeTool->Fit( m_panelMergeTool );
-	m_notebook2->AddPage( m_panelMergeTool, _("Merge Tool"), false );
-	
-	bSizer4->Add( m_notebook2, 1, wxEXPAND | wxALL, 5 );
-	
-	m_panelPrograms->SetSizer( bSizer4 );
-	m_panelPrograms->Layout();
-	bSizer4->Fit( m_panelPrograms );
-	m_notebookMain->AddPage( m_panelPrograms, _("Programs"), false );
-	m_panelAuth = new wxPanel( m_notebookMain, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-	wxBoxSizer* sizerAuth;
-	sizerAuth = new wxBoxSizer( wxVERTICAL );
-	
-	m_checkAuthPerBookmark = new wxCheckBox( m_panelAuth, wxID_ANY, _("Different login for each bookmark in the bookmarks list"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerAuth->Add( m_checkAuthPerBookmark, 0, wxALL, 5 );
-	
-	m_checkUseAuthCache = new wxCheckBox( m_panelAuth, wxID_ANY, _("Store authentication credentials on hard disk"), wxDefaultPosition, wxDefaultSize, 0 );
-	sizerAuth->Add( m_checkUseAuthCache, 0, wxALL, 5 );
-	
-	m_panelAuth->SetSizer( sizerAuth );
-	m_panelAuth->Layout();
-	sizerAuth->Fit( m_panelAuth );
-	m_notebookMain->AddPage( m_panelAuth, _("Authentication"), false );
-	
-	mainSizer->Add( m_notebookMain, 1, wxEXPAND | wxALL, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER, 0 );
-	
-	this->SetSizer( mainSizer );
-	this->Layout();
-	mainSizer->Fit( this );
-	
-	// Connect Events
-	m_buttonEditor->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonEditorClick ), NULL, this );
-	m_buttonExplorer->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonExplorerClick ), NULL, this );
-	m_buttonDiffTool->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonDiffToolClick ), NULL, this );
-	m_buttonMergeTool->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonMergeToolClick ), NULL, this );
-	m_buttonOK->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnOK ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    wxBoxSizer* mainSizer;
+    mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_notebookMain = new wxNotebook( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
+    m_panelGeneral = new wxPanel( m_notebookMain, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* bSizer3;
+    bSizer3 = new wxBoxSizer( wxVERTICAL );
+    
+    m_checkPurgeTempFiles = new wxCheckBox( m_panelGeneral, wxID_ANY, _("Purge temporary files on program exit"), wxDefaultPosition, wxDefaultSize, 0 );
+    bSizer3->Add( m_checkPurgeTempFiles, 0, wxALL, 5 );
+    
+    m_checkUseLastCommitMessage = new wxCheckBox( m_panelGeneral, wxID_ANY, _("Commit log message: default to most recent"), wxDefaultPosition, wxDefaultSize, 0 );
+    bSizer3->Add( m_checkUseLastCommitMessage, 0, wxALL, 5 );
+    
+    m_checkResetFlatMode = new wxCheckBox( m_panelGeneral, wxID_ANY, _("Reset Flat Mode on every program start"), wxDefaultPosition, wxDefaultSize, 0 );
+    bSizer3->Add( m_checkResetFlatMode, 0, wxALL, 5 );
+    
+    m_panelGeneral->SetSizer( bSizer3 );
+    m_panelGeneral->Layout();
+    bSizer3->Fit( m_panelGeneral );
+    m_notebookMain->AddPage( m_panelGeneral, _("General"), false );
+    m_panelPrograms = new wxPanel( m_notebookMain, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* bSizer4;
+    bSizer4 = new wxBoxSizer( wxVERTICAL );
+    
+    m_notebook2 = new wxNotebook( m_panelPrograms, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
+    m_panelEditor = new wxPanel( m_notebook2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* sizerPanelEditor;
+    sizerPanelEditor = new wxBoxSizer( wxVERTICAL );
+    
+    wxBoxSizer* sizerEditor;
+    sizerEditor = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_textEditor = new wxTextCtrl( m_panelEditor, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    sizerEditor->Add( m_textEditor, 1, wxALL, 5 );
+    
+    m_buttonEditor = new wxButton( m_panelEditor, wxID_ANY, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerEditor->Add( m_buttonEditor, 0, wxALL, 5 );
+    
+    sizerPanelEditor->Add( sizerEditor, 0, wxEXPAND, 5 );
+    
+    wxStaticText* m_staticEditorArgs;
+    m_staticEditorArgs = new wxStaticText( m_panelEditor, wxID_ANY, _("Program arguments (%1=selected file):"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticEditorArgs->Wrap( -1 );
+    sizerPanelEditor->Add( m_staticEditorArgs, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
+    
+    m_textEditorArgs = new wxTextCtrl( m_panelEditor, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    sizerPanelEditor->Add( m_textEditorArgs, 0, wxALL|wxEXPAND, 5 );
+    
+    m_checkEditorAlways = new wxCheckBox( m_panelEditor, wxID_ANY, _("Use always"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerPanelEditor->Add( m_checkEditorAlways, 0, wxALL, 5 );
+    
+    m_panelEditor->SetSizer( sizerPanelEditor );
+    m_panelEditor->Layout();
+    sizerPanelEditor->Fit( m_panelEditor );
+    m_notebook2->AddPage( m_panelEditor, _("Standard Editor"), true );
+    m_panelExplorer = new wxPanel( m_notebook2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* sizerPanelExplorer;
+    sizerPanelExplorer = new wxBoxSizer( wxVERTICAL );
+    
+    wxBoxSizer* sizerExplorer;
+    sizerExplorer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_textExplorer = new wxTextCtrl( m_panelExplorer, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    sizerExplorer->Add( m_textExplorer, 1, wxALL, 5 );
+    
+    m_buttonExplorer = new wxButton( m_panelExplorer, wxID_ANY, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerExplorer->Add( m_buttonExplorer, 0, wxALL, 5 );
+    
+    sizerPanelExplorer->Add( sizerExplorer, 0, wxEXPAND, 0 );
+    
+    wxStaticText* m_staticExplorerArgs;
+    m_staticExplorerArgs = new wxStaticText( m_panelExplorer, wxID_ANY, _("Program arguments (%1=selected directory):"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticExplorerArgs->Wrap( -1 );
+    sizerPanelExplorer->Add( m_staticExplorerArgs, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
+    
+    m_textExplorerArgs = new wxTextCtrl( m_panelExplorer, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    sizerPanelExplorer->Add( m_textExplorerArgs, 0, wxALL|wxEXPAND, 5 );
+    
+    m_checkExplorerAlways = new wxCheckBox( m_panelExplorer, wxID_ANY, _("Use always"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerPanelExplorer->Add( m_checkExplorerAlways, 0, wxALL, 5 );
+    
+    m_panelExplorer->SetSizer( sizerPanelExplorer );
+    m_panelExplorer->Layout();
+    sizerPanelExplorer->Fit( m_panelExplorer );
+    m_notebook2->AddPage( m_panelExplorer, _("Standard Explorer"), false );
+    m_panelDiffTool = new wxPanel( m_notebook2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* sizerPanelDiffTool;
+    sizerPanelDiffTool = new wxBoxSizer( wxVERTICAL );
+    
+    wxBoxSizer* sizerDiffTool;
+    sizerDiffTool = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_textDiffTool = new wxTextCtrl( m_panelDiffTool, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    sizerDiffTool->Add( m_textDiffTool, 1, wxALL, 5 );
+    
+    m_buttonDiffTool = new wxButton( m_panelDiffTool, wxID_ANY, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerDiffTool->Add( m_buttonDiffTool, 0, wxALL, 5 );
+    
+    sizerPanelDiffTool->Add( sizerDiffTool, 0, wxEXPAND, 5 );
+    
+    wxStaticText* m_staticDiffToolArgs;
+    m_staticDiffToolArgs = new wxStaticText( m_panelDiffTool, wxID_ANY, _("Program arguments (%1=file1, %2=file2):"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticDiffToolArgs->Wrap( -1 );
+    sizerPanelDiffTool->Add( m_staticDiffToolArgs, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
+    
+    m_textDiffToolArgs = new wxTextCtrl( m_panelDiffTool, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    sizerPanelDiffTool->Add( m_textDiffToolArgs, 0, wxALL|wxEXPAND, 5 );
+    
+    m_panelDiffTool->SetSizer( sizerPanelDiffTool );
+    m_panelDiffTool->Layout();
+    sizerPanelDiffTool->Fit( m_panelDiffTool );
+    m_notebook2->AddPage( m_panelDiffTool, _("Diff Tool"), false );
+    m_panelMergeTool = new wxPanel( m_notebook2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* sizerPanelMergeTool;
+    sizerPanelMergeTool = new wxBoxSizer( wxVERTICAL );
+    
+    wxBoxSizer* sizerMergeTool;
+    sizerMergeTool = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_textMergeTool = new wxTextCtrl( m_panelMergeTool, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    sizerMergeTool->Add( m_textMergeTool, 1, wxALL, 5 );
+    
+    m_buttonMergeTool = new wxButton( m_panelMergeTool, wxID_ANY, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerMergeTool->Add( m_buttonMergeTool, 0, wxALL, 5 );
+    
+    sizerPanelMergeTool->Add( sizerMergeTool, 0, wxEXPAND, 5 );
+    
+    m_staticMergeToolArgs = new wxStaticText( m_panelMergeTool, wxID_ANY, _("Program arguments (%1=base, %2=theirs %3=mine %4=result):"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticMergeToolArgs->Wrap( -1 );
+    sizerPanelMergeTool->Add( m_staticMergeToolArgs, 0, wxLEFT|wxRIGHT|wxTOP, 5 );
+    
+    m_textMergeToolArgs = new wxTextCtrl( m_panelMergeTool, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    sizerPanelMergeTool->Add( m_textMergeToolArgs, 0, wxALL|wxEXPAND, 5 );
+    
+    m_panelMergeTool->SetSizer( sizerPanelMergeTool );
+    m_panelMergeTool->Layout();
+    sizerPanelMergeTool->Fit( m_panelMergeTool );
+    m_notebook2->AddPage( m_panelMergeTool, _("Merge Tool"), false );
+    
+    bSizer4->Add( m_notebook2, 1, wxEXPAND | wxALL, 5 );
+    
+    m_panelPrograms->SetSizer( bSizer4 );
+    m_panelPrograms->Layout();
+    bSizer4->Fit( m_panelPrograms );
+    m_notebookMain->AddPage( m_panelPrograms, _("Programs"), false );
+    m_panelAuth = new wxPanel( m_notebookMain, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+    wxBoxSizer* sizerAuth;
+    sizerAuth = new wxBoxSizer( wxVERTICAL );
+    
+    m_checkAuthPerBookmark = new wxCheckBox( m_panelAuth, wxID_ANY, _("Different login for each bookmark in the bookmarks list"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerAuth->Add( m_checkAuthPerBookmark, 0, wxALL, 5 );
+    
+    m_checkUseAuthCache = new wxCheckBox( m_panelAuth, wxID_ANY, _("Store authentication credentials on hard disk"), wxDefaultPosition, wxDefaultSize, 0 );
+    sizerAuth->Add( m_checkUseAuthCache, 0, wxALL, 5 );
+    
+    m_panelAuth->SetSizer( sizerAuth );
+    m_panelAuth->Layout();
+    sizerAuth->Fit( m_panelAuth );
+    m_notebookMain->AddPage( m_panelAuth, _("Authentication"), false );
+    
+    mainSizer->Add( m_notebookMain, 1, wxEXPAND | wxALL, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER, 0 );
+    
+    this->SetSizer( mainSizer );
+    this->Layout();
+    mainSizer->Fit( this );
+    
+    // Connect Events
+    m_buttonEditor->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonEditorClick ), NULL, this );
+    m_buttonExplorer->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonExplorerClick ), NULL, this );
+    m_buttonDiffTool->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonDiffToolClick ), NULL, this );
+    m_buttonMergeTool->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonMergeToolClick ), NULL, this );
+    m_buttonOK->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnOK ), NULL, this );
 }
 
 PreferencesDlgBase::~PreferencesDlgBase()
 {
-	// Disconnect Events
-	m_buttonEditor->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonEditorClick ), NULL, this );
-	m_buttonExplorer->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonExplorerClick ), NULL, this );
-	m_buttonDiffTool->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonDiffToolClick ), NULL, this );
-	m_buttonMergeTool->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonMergeToolClick ), NULL, this );
-	m_buttonOK->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnOK ), NULL, this );
+    // Disconnect Events
+    m_buttonEditor->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonEditorClick ), NULL, this );
+    m_buttonExplorer->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonExplorerClick ), NULL, this );
+    m_buttonDiffTool->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonDiffToolClick ), NULL, this );
+    m_buttonMergeTool->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnButtonMergeToolClick ), NULL, this );
+    m_buttonOK->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PreferencesDlgBase::OnOK ), NULL, this );
 }
 
 ReportDlgBase::ReportDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_text = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 500,200 ), wxTE_MULTILINE|wxTE_READONLY|wxTE_RICH );
-	m_mainSizer->Add( m_text, 1, wxALL|wxEXPAND, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_text = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 500,200 ), wxTE_MULTILINE|wxTE_READONLY|wxTE_RICH );
+    m_mainSizer->Add( m_text, 1, wxALL|wxEXPAND, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
 }
 
 ReportDlgBase::~ReportDlgBase()
@@ -1755,32 +1760,32 @@ ReportDlgBase::~ReportDlgBase()
 
 RevertDlgBase::RevertDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticQuestion = new wxStaticText( this, wxID_ANY, _("Do you want to revert local changes?"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticQuestion->Wrap( -1 );
-	m_mainSizer->Add( m_staticQuestion, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
-	
-	m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_mainSizer->Add( m_checkRecursive, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	m_mainSizer->Fit( this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_staticQuestion = new wxStaticText( this, wxID_ANY, _("Do you want to revert local changes?"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticQuestion->Wrap( -1 );
+    m_mainSizer->Add( m_staticQuestion, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    
+    m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_mainSizer->Add( m_checkRecursive, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    m_mainSizer->Fit( this );
 }
 
 RevertDlgBase::~RevertDlgBase()
@@ -1789,96 +1794,96 @@ RevertDlgBase::~RevertDlgBase()
 
 SwitchDlgBase::SwitchDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_urlSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("URL") ), wxVERTICAL );
-	
-	m_comboUrl = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, wxCB_DROPDOWN ); 
-	m_urlSizer->Add( m_comboUrl, 1, wxALL|wxEXPAND, 5 );
-	
-	m_mainSizer->Add( m_urlSizer, 0, wxEXPAND, 5 );
-	
-	m_revisionSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision") ), wxHORIZONTAL );
-	
-	m_textRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	m_revisionSizer->Add( m_textRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5 );
-	
-	m_checkUseLatest = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_checkUseLatest->SetValue(true); 
-	m_revisionSizer->Add( m_checkUseLatest, 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 5 );
-	
-	m_mainSizer->Add( m_revisionSizer, 0, wxEXPAND, 5 );
-	
-	wxBoxSizer* optionSizer;
-	optionSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
-	optionSizer->Add( m_checkRecursive, 0, 0, 5 );
-	
-	m_checkRelocate = new wxCheckBox( this, wxID_ANY, _("Relocate"), wxDefaultPosition, wxDefaultSize, 0 );
-	optionSizer->Add( m_checkRelocate, 0, 0, 5 );
-	
-	m_mainSizer->Add( optionSizer, 1, wxALIGN_CENTER|wxBOTTOM|wxTOP, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	m_mainSizer->Fit( this );
-	
-	// Connect Events
-	m_comboUrl->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( SwitchDlgBase::OnText ), NULL, this );
-	m_textRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( SwitchDlgBase::OnText ), NULL, this );
-	m_checkUseLatest->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SwitchDlgBase::OnUseLatest ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_urlSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("URL") ), wxVERTICAL );
+    
+    m_comboUrl = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, wxCB_DROPDOWN ); 
+    m_urlSizer->Add( m_comboUrl, 1, wxALL|wxEXPAND, 5 );
+    
+    m_mainSizer->Add( m_urlSizer, 0, wxEXPAND, 5 );
+    
+    m_revisionSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision") ), wxHORIZONTAL );
+    
+    m_textRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    m_revisionSizer->Add( m_textRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5 );
+    
+    m_checkUseLatest = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_checkUseLatest->SetValue(true); 
+    m_revisionSizer->Add( m_checkUseLatest, 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 5 );
+    
+    m_mainSizer->Add( m_revisionSizer, 0, wxEXPAND, 5 );
+    
+    wxBoxSizer* optionSizer;
+    optionSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
+    optionSizer->Add( m_checkRecursive, 0, 0, 5 );
+    
+    m_checkRelocate = new wxCheckBox( this, wxID_ANY, _("Relocate"), wxDefaultPosition, wxDefaultSize, 0 );
+    optionSizer->Add( m_checkRelocate, 0, 0, 5 );
+    
+    m_mainSizer->Add( optionSizer, 1, wxALIGN_CENTER|wxBOTTOM|wxTOP, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    m_mainSizer->Fit( this );
+    
+    // Connect Events
+    m_comboUrl->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( SwitchDlgBase::OnText ), NULL, this );
+    m_textRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( SwitchDlgBase::OnText ), NULL, this );
+    m_checkUseLatest->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SwitchDlgBase::OnUseLatest ), NULL, this );
 }
 
 SwitchDlgBase::~SwitchDlgBase()
 {
-	// Disconnect Events
-	m_comboUrl->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( SwitchDlgBase::OnText ), NULL, this );
-	m_textRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( SwitchDlgBase::OnText ), NULL, this );
-	m_checkUseLatest->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SwitchDlgBase::OnUseLatest ), NULL, this );
+    // Disconnect Events
+    m_comboUrl->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( SwitchDlgBase::OnText ), NULL, this );
+    m_textRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( SwitchDlgBase::OnText ), NULL, this );
+    m_checkUseLatest->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( SwitchDlgBase::OnUseLatest ), NULL, this );
 }
 
 UnlockDlgBase::UnlockDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticQuestion = new wxStaticText( this, wxID_ANY, _("Do you want to unlock the selected files/directories?"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticQuestion->Wrap( -1 );
-	m_mainSizer->Add( m_staticQuestion, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
-	
-	m_checkForce = new wxCheckBox( this, wxID_ANY, _("Force unlocking even if you are not the lock owner"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_mainSizer->Add( m_checkForce, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_staticQuestion = new wxStaticText( this, wxID_ANY, _("Do you want to unlock the selected files/directories?"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticQuestion->Wrap( -1 );
+    m_mainSizer->Add( m_staticQuestion, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    
+    m_checkForce = new wxCheckBox( this, wxID_ANY, _("Force unlocking even if you are not the lock owner"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_mainSizer->Add( m_checkForce, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER_HORIZONTAL, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
 }
 
 UnlockDlgBase::~UnlockDlgBase()
@@ -1887,66 +1892,66 @@ UnlockDlgBase::~UnlockDlgBase()
 
 UpdateDlgBase::UpdateDlgBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	m_mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_urlSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("URL") ), wxVERTICAL );
-	
-	m_comboUrl = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, wxCB_DROPDOWN ); 
-	m_urlSizer->Add( m_comboUrl, 1, wxALL|wxEXPAND, 5 );
-	
-	m_mainSizer->Add( m_urlSizer, 0, wxEXPAND, 5 );
-	
-	m_revisionSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision") ), wxHORIZONTAL );
-	
-	m_textRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	m_revisionSizer->Add( m_textRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5 );
-	
-	m_checkUseLatest = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_checkUseLatest->SetValue(true); 
-	m_revisionSizer->Add( m_checkUseLatest, 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 5 );
-	
-	m_mainSizer->Add( m_revisionSizer, 0, wxEXPAND, 5 );
-	
-	wxBoxSizer* optionSizer;
-	optionSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
-	optionSizer->Add( m_checkRecursive, 0, 0, 5 );
-	
-	m_checkIgnoreExternals = new wxCheckBox( this, wxID_ANY, _("Ignore Externals"), wxDefaultPosition, wxDefaultSize, 0 );
-	optionSizer->Add( m_checkIgnoreExternals, 0, 0, 5 );
-	
-	m_mainSizer->Add( optionSizer, 1, wxALIGN_CENTER|wxBOTTOM|wxTOP, 5 );
-	
-	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_buttonOK->SetDefault(); 
-	buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
-	
-	m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
-	
-	m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, 5 );
-	
-	this->SetSizer( m_mainSizer );
-	this->Layout();
-	
-	// Connect Events
-	m_comboUrl->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
-	m_comboUrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
-	m_textRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
-	m_checkUseLatest->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( UpdateDlgBase::OnUseLatest ), NULL, this );
+    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    
+    m_mainSizer = new wxBoxSizer( wxVERTICAL );
+    
+    m_urlSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("URL") ), wxVERTICAL );
+    
+    m_comboUrl = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 235,-1 ), 0, NULL, wxCB_DROPDOWN ); 
+    m_urlSizer->Add( m_comboUrl, 1, wxALL|wxEXPAND, 5 );
+    
+    m_mainSizer->Add( m_urlSizer, 0, wxEXPAND, 5 );
+    
+    m_revisionSizer = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Revision") ), wxHORIZONTAL );
+    
+    m_textRevision = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    m_revisionSizer->Add( m_textRevision, 1, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5 );
+    
+    m_checkUseLatest = new wxCheckBox( this, wxID_ANY, _("Use latest"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_checkUseLatest->SetValue(true); 
+    m_revisionSizer->Add( m_checkUseLatest, 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 5 );
+    
+    m_mainSizer->Add( m_revisionSizer, 0, wxEXPAND, 5 );
+    
+    wxBoxSizer* optionSizer;
+    optionSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_checkRecursive = new wxCheckBox( this, wxID_ANY, _("Recursive"), wxDefaultPosition, wxDefaultSize, 0 );
+    optionSizer->Add( m_checkRecursive, 0, 0, 5 );
+    
+    m_checkIgnoreExternals = new wxCheckBox( this, wxID_ANY, _("Ignore Externals"), wxDefaultPosition, wxDefaultSize, 0 );
+    optionSizer->Add( m_checkIgnoreExternals, 0, 0, 5 );
+    
+    m_mainSizer->Add( optionSizer, 1, wxALIGN_CENTER|wxBOTTOM|wxTOP, 5 );
+    
+    wxBoxSizer* buttonSizer;
+    buttonSizer = new wxBoxSizer( wxHORIZONTAL );
+    
+    m_buttonOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonOK->SetDefault(); 
+    buttonSizer->Add( m_buttonOK, 0, wxALL, 10 );
+    
+    m_buttonCancel = new wxButton( this, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    buttonSizer->Add( m_buttonCancel, 0, wxALL, 10 );
+    
+    m_mainSizer->Add( buttonSizer, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, 5 );
+    
+    this->SetSizer( m_mainSizer );
+    this->Layout();
+    
+    // Connect Events
+    m_comboUrl->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
+    m_comboUrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
+    m_textRevision->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
+    m_checkUseLatest->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( UpdateDlgBase::OnUseLatest ), NULL, this );
 }
 
 UpdateDlgBase::~UpdateDlgBase()
 {
-	// Disconnect Events
-	m_comboUrl->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
-	m_comboUrl->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
-	m_textRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
-	m_checkUseLatest->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( UpdateDlgBase::OnUseLatest ), NULL, this );
+    // Disconnect Events
+    m_comboUrl->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
+    m_comboUrl->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
+    m_textRevision->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( UpdateDlgBase::OnText ), NULL, this );
+    m_checkUseLatest->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( UpdateDlgBase::OnUseLatest ), NULL, this );
 }

--- a/libsvncpp/include/svncpp/client.hpp
+++ b/libsvncpp/include/svncpp/client.hpp
@@ -122,7 +122,7 @@ namespace svn
       date = info->date;
       author = info->author;
       if (0 != info->post_commit_err)
-	postCommitErr = info->post_commit_err;
+    postCommitErr = info->post_commit_err;
     }
   };
 
@@ -549,6 +549,31 @@ namespace svn
     log(const char * path,
         const Revision & revisionStart,
         const Revision & revisionEnd,
+        bool discoverChangedPaths = false,
+        bool strictNodeHistory = true) throw(ClientException);
+
+    /**
+     * Retrieve log information for the given path
+     * Loads the log messages result set. The first
+     * entry  is the youngest revision.
+     * Can limit the number of log entries returned.
+     *
+     * You can use the constants Revision::START and
+     * Revision::HEAD
+     *
+     * @param path
+     * @param revisionStart
+     * @param revisionEnd
+     * @param limit
+     * @param discoverChangedPaths
+     * @param strictNodeHistory
+     * @return a vector with log entries
+     */
+    const LogEntries *
+    log(const char * path,
+        const Revision & revisionStart,
+        const Revision & revisionEnd,
+        const int limit,
         bool discoverChangedPaths = false,
         bool strictNodeHistory = true) throw(ClientException);
 

--- a/libsvncpp/src/client_status.cpp
+++ b/libsvncpp/src/client_status.cpp
@@ -24,6 +24,8 @@
 // Stdlib (for strcmp)
 #include "string.h"
 
+#include <algorithm>
+
 // Subversion api
 #include "svn_client.h"
 #include "svn_sorts.h"
@@ -339,8 +341,6 @@ public:
     }
   }
 
-
-
   const LogEntries *
   Client::log(const char * path, const Revision & revisionStart,
               const Revision & revisionEnd, bool discoverChangedPaths,
@@ -351,6 +351,37 @@ public:
     LogEntries * entries = new LogEntries();
     svn_error_t *error;
     int limit = 0;
+
+    error = svn_client_log2(
+              target.array(pool),
+              revisionStart.revision(),
+              revisionEnd.revision(),
+              limit,
+              discoverChangedPaths ? 1 : 0,
+              strictNodeHistory ? 1 : 0,
+              logReceiver,
+              entries,
+              *m_context, // client ctx
+              pool);
+
+    if (error != NULL)
+    {
+      delete entries;
+      throw ClientException(error);
+    }
+
+    return entries;
+  }
+
+  const LogEntries *
+  Client::log(const char * path, const Revision & revisionStart,
+              const Revision & revisionEnd, const int limit, bool discoverChangedPaths,
+              bool strictNodeHistory) throw(ClientException)
+  {
+    Pool pool;
+    Targets target(path);
+    LogEntries * entries = new LogEntries();
+    svn_error_t *error;
 
     error = svn_client_log2(
               target.array(pool),


### PR DESCRIPTION
Supplied fix will fetch the log history in pages. Added a "more" button to the Dialog, below the revisions list, so the User can request the next page of log entries. I have set the fetch size to 30.

I added a new function to the libsvncpp which is an overload of "log" function (includes an extra parameter for the log fetch limit).  Hopefully this wont cause issues in the versioning and compatability of this library.