### PR TITLE
Issue 24 : Log dialog does not have sortable columns in the affectedf…

### DIFF
--- a/librapidsvn/include/log_aff_list.hpp
+++ b/librapidsvn/include/log_aff_list.hpp
@@ -45,9 +45,10 @@ public:
       wxListView* Parent;
       long Column;
       bool Ascending;
+      long SortIterations;
 
       ColSortInfo(wxListView* parent, long column, bool ascending)
-          : Parent(parent), Column(column), Ascending(ascending)
+          : Parent(parent), Column(column), Ascending(ascending), SortIterations(0)
       {
       }
   };


### PR DESCRIPTION
…iles listview.

Found some issues in my code for Issue 24. Fixes are :
1) right-mouse click menu on Affected Files (bottom listview) now not working due to Issue 24 changes.
2) slow response when browsing log history with large commits (number of affected files > 1000)
3) prevent non-applicable right-mouse menu items on Affected Files (bottom listview), such as Diff item when file has Added or Deleted Status.