### PR TITLE
Fix item number underrun on empty log list, when changing view flags.

### DIFF
--- a/librapidsvn/src/log_list.cpp
+++ b/librapidsvn/src/log_list.cpp
@@ -143,9 +143,12 @@ void LogList::SetItemFilter(LogItemType type, bool enabled)
     }
     // set list control item count and autoscroll, if desired
     SetItemCount(displayedItems.size());
-    RefreshItems(0, displayedItems.size()-1);
-    if (autoscroll)
-      EnsureVisible(displayedItems.size()-1);
+    if (displayedItems.size() > 0)
+    {
+      RefreshItems(0, displayedItems.size()-1);
+      if (autoscroll)
+        EnsureVisible(displayedItems.size()-1);
+    }
   }
 }
 


### PR DESCRIPTION
The easies way to reproduce the issue, was for me to click on the filter buttons left to the log list, when the program was fresh started (thus the loglist was empty).